### PR TITLE
Better HEARTBEAT and HEARTBEAT_ACK handling

### DIFF
--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -64,11 +64,14 @@ defmodule Nostrum.Shard do
     {:ok, state}
   end
 
-  def websocket_info({:heartbeat, interval}, _ws_req, state) do
-    now = Util.now()
-    :websocket_client.cast(self(), {:binary, Payload.heartbeat_payload(state.seq)})
-    Event.heartbeat(self(), interval)
-    {:ok, %{state | last_heartbeat: now}}
+  def websocket_info(:heartbeat, _ws_req, state) do
+    if state.heartbeat_ack do
+      :websocket_client.cast(self(), {:binary, Payload.heartbeat_payload(state.seq)})
+      {:ok, %{state | heartbeat_ack: false}}
+    else
+      Log.info "HEARTBEAT_ACK not received in time. Disconnecting..."
+      {:close, "", state}
+    end
   end
 
   def websocket_info(:identify, _ws_req, state) do
@@ -84,6 +87,9 @@ defmodule Nostrum.Shard do
   def ondisconnect(reason, state) do
     Logger.warn "WS DISCONNECTED BECAUSE: #{inspect reason}"
     Logger.debug "STATE ON CLOSE: #{inspect state}"
+
+    Task.shutdown(state.heartbeat_task)
+
     if state.reconnect_attempts > 3 do
       {:close, reason, state}
     else

--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -69,7 +69,7 @@ defmodule Nostrum.Shard do
       :websocket_client.cast(self(), {:binary, Payload.heartbeat_payload(state.seq)})
       {:ok, %{state | heartbeat_ack: false}}
     else
-      Log.info "HEARTBEAT_ACK not received in time. Disconnecting..."
+      Logger.info "HEARTBEAT_ACK not received in time. Disconnecting..."
       {:close, "", state}
     end
   end
@@ -88,10 +88,11 @@ defmodule Nostrum.Shard do
     Logger.warn "WS DISCONNECTED BECAUSE: #{inspect reason}"
     Logger.debug "STATE ON CLOSE: #{inspect state}"
 
-    if state.heartbeat_task do
-      Task.shutdown(state.heartbeat_task)
-      state = %{state | heartbeat_task: nil}
-    end
+    state =
+      if state.heartbeat_task do
+        Task.shutdown(state.heartbeat_task)
+        state = %{state | heartbeat_task: nil}
+      end
 
     if state.reconnect_attempts > 3 do
       {:close, reason, state}

--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -90,6 +90,7 @@ defmodule Nostrum.Shard do
 
     if state.heartbeat_task do
       Task.shutdown(state.heartbeat_task)
+      state = %{state | heartbeat_task: nil}
     end
 
     if state.reconnect_attempts > 3 do

--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -91,7 +91,7 @@ defmodule Nostrum.Shard do
     state =
       if state.heartbeat_task do
         Task.shutdown(state.heartbeat_task)
-        state = %{state | heartbeat_task: nil}
+        %{state | heartbeat_task: nil}
       end
 
     if state.reconnect_attempts > 3 do

--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -88,7 +88,9 @@ defmodule Nostrum.Shard do
     Logger.warn "WS DISCONNECTED BECAUSE: #{inspect reason}"
     Logger.debug "STATE ON CLOSE: #{inspect state}"
 
-    Task.shutdown(state.heartbeat_task)
+    if state.heartbeat_task do
+      Task.shutdown(state.heartbeat_task)
+    end
 
     if state.reconnect_attempts > 3 do
       {:close, reason, state}

--- a/lib/nostrum/shard/event.ex
+++ b/lib/nostrum/shard/event.ex
@@ -32,9 +32,6 @@ defmodule Nostrum.Shard.Event do
 
   def handle(:heartbeat_ack, _payload, state) do
     Logger.debug "HEARTBEAT_ACK"
-    heartbeat_intervals = state.heartbeat_intervals
-    |> List.delete_at(-1)
-    |> List.insert_at(0, Util.now() - state.last_heartbeat)
     %{state | heartbeat_ack: true}
   end
 

--- a/lib/nostrum/shard/event.ex
+++ b/lib/nostrum/shard/event.ex
@@ -44,7 +44,8 @@ defmodule Nostrum.Shard.Event do
       identify(self())
     end
 
-    heartbeat_task = Task.async(fn -> heartbeat(self(), payload.d.heartbeat_interval) end)
+    pid = self()
+    heartbeat_task = Task.async(fn -> heartbeat(pid, payload.d.heartbeat_interval) end)
 
     %{state | heartbeat_task: heartbeat_task}
   end
@@ -68,6 +69,7 @@ defmodule Nostrum.Shard.Event do
   def heartbeat(pid, interval) do
     Process.sleep(interval)
     send(pid, :heartbeat)
+    heartbeat(pid, interval)
   end
 
   def identify(pid) do

--- a/lib/nostrum/shard/payload.ex
+++ b/lib/nostrum/shard/payload.ex
@@ -19,7 +19,8 @@ defmodule Nostrum.Shard.Payload do
    * `last_heartbeat` - The time of the last heartbeat.
    * `shard_pid` - Pid of the shard containing this state.
    * `producer_pid` - Pid of the producer attached to this shard
-   * `heartbeat_intervals` - List of last ten heartbeat intervals, from hearbeat send to ack.
+   * `heartbeat_ack` - Wether we received a heartbeack_ack or no (initialized to true).
+   * `heartbeat_task` The Task struct of the heartbeat task.
   """
   @type state_map :: map
 

--- a/lib/nostrum/shard/payload.ex
+++ b/lib/nostrum/shard/payload.ex
@@ -30,10 +30,10 @@ defmodule Nostrum.Shard.Payload do
       seq: nil,
       session: nil,
       reconnect_attempts: 0,
-      last_heartbeat: 0,
       shard_pid: pid,
       producer_pid: nil,
-      heartbeat_intervals: Enum.map(1..10, fn _ -> 0 end)
+      heartbeat_ack: false,
+      heartbeat_task: nil
     }
   end
 

--- a/lib/nostrum/shard/payload.ex
+++ b/lib/nostrum/shard/payload.ex
@@ -32,7 +32,7 @@ defmodule Nostrum.Shard.Payload do
       reconnect_attempts: 0,
       shard_pid: pid,
       producer_pid: nil,
-      heartbeat_ack: false,
+      heartbeat_ack: true,
       heartbeat_task: nil
     }
   end


### PR DESCRIPTION
Heartbeat job is now in a task. And not receiving HEARTBEAT_ACK in time will disconnect the shard from the gateway. Also, after a disconnect the heartbeat task is now stopped.

This is barely tested but should work fine hopefully haha.