### PR TITLE
always make GuildRegistry hold Guild structs strictly

### DIFF
--- a/lib/nostrum/cache/guild/guild_server.ex
+++ b/lib/nostrum/cache/guild/guild_server.ex
@@ -339,20 +339,21 @@ defmodule Nostrum.Cache.Guild.GuildServer do
     {:reply, tf.(state), state}
   end
 
-  def handle_call({:update, guild}, _from, state) do
+  def handle_call({:update, guild}, _from, %Guild{} = state) do
+    guild = guild |> Guild.to_struct()
     {:reply, {state, guild}, guild}
   end
 
-  def handle_call({:delete}, _from, state) do
+  def handle_call({:delete}, _from, %Guild{} = state) do
     {:stop, :normal, state, %{}}
   end
 
-  def handle_call({:create, :member, guild_id, member}, _from, state) do
-    new_members = [member | state.members]
+  def handle_call({:create, :member, guild_id, member}, _from, %Guild{} = state) do
+    new_members = [member |> Guild.Member.to_struct() | state.members]
     {:reply, {guild_id, member}, %{state | members: new_members}}
   end
 
-  def handle_call({:update, :member, guild_id, new_partial_member}, _from, state) do
+  def handle_call({:update, :member, guild_id, new_partial_member}, _from, %Guild{} = state) do
     member_index = Enum.find_index(state.members, fn member ->
       member.user.id == new_partial_member.user.id
     end)
@@ -361,12 +362,12 @@ defmodule Nostrum.Cache.Guild.GuildServer do
         {:ok, old_member} -> old_member
         :error -> %{user: %{}, roles: []}
       end
-    new_member = Map.merge(old_member, new_partial_member)
+    new_member = Map.merge(old_member, new_partial_member) |> Guild.Member.to_struct()
     new_members = List.replace_at(state.members, member_index, new_member)
     {:reply, {guild_id, old_member, new_member}, %{state | members: new_members}}
   end
 
-  def handle_call({:delete, :member, guild_id, user}, _from, state) do
+  def handle_call({:delete, :member, guild_id, user}, _from, %Guild{} = state) do
     member_index = Enum.find_index(state.members, fn member -> member.user.id == user.id end)
     deleted_member =
       case Enum.fetch(state.members, member_index || length(state.members) + 1) do
@@ -377,12 +378,12 @@ defmodule Nostrum.Cache.Guild.GuildServer do
     {:reply, {guild_id, deleted_member}, %{state | members: members}}
   end
 
-  def handle_call({:create, :channel, channel}, _from, state) do
-    new_channels = [channel | state.channels]
+  def handle_call({:create, :channel, channel}, _from, %Guild{} = state) do
+    new_channels = [channel |> Guild.Channel.to_struct() | state.channels]
     {:reply, channel, %{state | channels: new_channels}}
   end
 
-  def handle_call({:update, :channel, channel}, _from, state) do
+  def handle_call({:update, :channel, channel}, _from, %Guild{} = state) do
     channel_index = Enum.find_index(state.channels, fn g_channel -> g_channel.id == channel.id end)
     old_channel =
       case Enum.fetch(state.channels, channel_index || length(state.channels) + 1) do
@@ -391,12 +392,12 @@ defmodule Nostrum.Cache.Guild.GuildServer do
       end
     channels = List.update_at(state.channels, channel_index,
       fn _ ->
-        channel
+        channel |> Guild.Channel.to_struct()
       end)
     {:reply, {old_channel, channel}, %{state | channels: channels}}
   end
 
-  def handle_call({:delete, :channel, channel_id}, _from, state) do
+  def handle_call({:delete, :channel, channel_id}, _from, %Guild{} = state) do
     channel_index = Enum.find_index(state.channels, fn g_channel -> g_channel.id == channel_id end)
     old_channel =
       case Enum.fetch(state.channels, channel_index || length(state.channels) + 1) do
@@ -407,12 +408,12 @@ defmodule Nostrum.Cache.Guild.GuildServer do
     {:reply, old_channel, %{state | channels: channels}}
   end
 
-  def handle_call({:create, :role, guild_id, role}, _from, state) do
-    new_roles = [role | state.roles]
+  def handle_call({:create, :role, guild_id, role}, _from, %Guild{} = state) do
+    new_roles = [role |> Guild.Role.to_struct() | state.roles]
     {:reply, {guild_id, role}, %{state | roles: new_roles}}
   end
 
-  def handle_call({:update, :role, guild_id, role}, _from, state) do
+  def handle_call({:update, :role, guild_id, role}, _from, %Guild{} = state) do
     role_index = Enum.find_index(state.roles, fn g_role -> g_role.id == role.id end)
     old_role =
       case Enum.fetch(state.roles, role_index || length(state.roles) + 1) do
@@ -421,12 +422,12 @@ defmodule Nostrum.Cache.Guild.GuildServer do
       end
     roles = List.update_at(state.roles, role_index,
       fn _ ->
-        role
+        role |> Guild.Role.to_struct()
       end)
     {:reply, {guild_id, old_role, role}, %{state | roles: roles}}
   end
 
-  def handle_call({:delete, :role, guild_id, role_id}, _from, state) do
+  def handle_call({:delete, :role, guild_id, role_id}, _from, %Guild{} = state) do
     role_index = Enum.find_index(state.roles, fn g_role -> g_role.id == role_id end)
     old_role =
       case Enum.fetch(state.roles, role_index || length(state.roles) + 1) do
@@ -437,7 +438,7 @@ defmodule Nostrum.Cache.Guild.GuildServer do
     {:reply, {guild_id, old_role}, %{state | roles: roles}}
   end
 
-  def handle_call({:update, :emoji, guild_id, emojis}, _from, state) do
+  def handle_call({:update, :emoji, guild_id, emojis}, _from, %Guild{} = state) do
     old_emojis = state.emojis
     {:reply, {guild_id, old_emojis, emojis}, %{state | emojis: emojis}}
   end

--- a/lib/nostrum/struct/dm_channel.ex
+++ b/lib/nostrum/struct/dm_channel.ex
@@ -36,7 +36,7 @@ defmodule Nostrum.Struct.DMChannel do
   @doc false
   def to_struct(map) do
     new = map
-    |> Map.update(:recipients, %{}, &Util.list_to_struct_list(&1, User))
+    |> Map.update(:recipients, [], &Util.list_to_struct_list(&1, User))
     struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -95,7 +95,7 @@ defmodule Nostrum.Struct.Embed do
     |> Map.update(:video, %{}, &Video.to_struct(&1))
     |> Map.update(:provider, %{}, &Provider.to_struct(&1))
     |> Map.update(:author, %{}, &Author.to_struct(&1))
-    |> Map.update(:fields, %{}, &Util.list_to_struct_list(&1, Field))
+    |> Map.update(:fields, [], &Util.list_to_struct_list(&1, Field))
     struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -147,10 +147,10 @@ defmodule Nostrum.Struct.Guild do
   def to_struct(%{unavailable: true} = map), do: UnavailableGuild.to_struct(map)
   def to_struct(map) do
     new = map
-    |> Map.update(:emojis, %{}, &Util.list_to_struct_list(&1, Emoji))
-    |> Map.update(:roles, %{}, &Util.list_to_struct_list(&1, Role))
-    |> Map.update(:members, %{}, &Util.list_to_struct_list(&1, Member))
-    |> Map.update(:channels, %{}, &Util.list_to_struct_list(&1, Channel))
+    |> Map.update(:emojis, [], &Util.list_to_struct_list(&1, Emoji))
+    |> Map.update(:roles, [], &Util.list_to_struct_list(&1, Role))
+    |> Map.update(:members, [], &Util.list_to_struct_list(&1, Member))
+    |> Map.update(:channels, [], &Util.list_to_struct_list(&1, Channel))
     struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/guild/channel.ex
+++ b/lib/nostrum/struct/guild/channel.ex
@@ -72,7 +72,7 @@ defmodule Nostrum.Struct.Guild.Channel do
   @doc false
   def to_struct(map) do
     new = map
-    |> Map.update(:permission_overwrites, %{}, &Util.list_to_struct_list(&1, Overwrite))
+    |> Map.update(:permission_overwrites, [], &Util.list_to_struct_list(&1, Overwrite))
     struct(__MODULE__, new)
   end
 

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -104,10 +104,10 @@ defmodule Nostrum.Struct.Message do
   def to_struct(map) do
     new = map
     |> Map.update(:author, %{}, &User.to_struct(&1))
-    |> Map.update(:attachments, %{}, &Util.list_to_struct_list(&1, Attachment))
-    |> Map.update(:mentions, %{}, &Util.list_to_struct_list(&1, User))
-    |> Map.update(:mention_roles, %{}, &Util.list_to_struct_list(&1, Role))
-    |> Map.update(:embeds, %{}, &Util.list_to_struct_list(&1, Embed))
+    |> Map.update(:attachments, [], &Util.list_to_struct_list(&1, Attachment))
+    |> Map.update(:mentions, [], &Util.list_to_struct_list(&1, User))
+    |> Map.update(:mention_roles, [], &Util.list_to_struct_list(&1, Role))
+    |> Map.update(:embeds, [], &Util.list_to_struct_list(&1, Embed))
     struct(__MODULE__, new)
   end
 end


### PR DESCRIPTION
## Why
Some functions, for example `Nostrum.Cache.Guild.GuildServer.get/1` is documented to return a `%Guild{}` struct, but sometimes it did not. This was because `get/1` relies on `transform/1`, which relies on getting values from the Registry.
The Registry initially holds a `Nostrum.Struct.Guild` struct, by passing that struct to `GuildRegister.create_guild_process/2`, but after that almost all `handle_call`s updated the `state` with a simple map.
This becomes a problem such as: Dot-notations will raise an error when it was supposed to return a `nil` (if it was a struct). Since `GUILD_UPDATE` renewals the whole `state`, the entire thing becomes a map, and it breaks eg. `Nostrum.Cache.Guild.GuildServer.get/1`'s type document.

## What
- `handle_call`s' `state`s are restricted to `%Nostrum.Guild{}`s
- always do `to_struct/1` on updating and creating new elements
    - vals which supposed to be lists but having empty maps as default values inside `to_struct/1`, now have lists as default value

### concerns
- should the default empty maps in `to_struct/1` should be an empty struct?