### PR TITLE
Implement new statuses

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -99,12 +99,12 @@ defmodule Nostrum.Api do
     - `pid` - Pid of the shard.
     - `status` - Status of the bot.
     - `game` - The 'playing' text of the bot. Empty will clear.
-    - `type` - The type of status to show.
-    - `streaming` - URL of twitch.tv stream
+    - `type` - The type of status to show. 0 (Playing) | 1 (Streaming) | 2 (Listening) | 3 (Watching)
+    - `stream` - URL of twitch.tv stream
   """
-  @spec update_status(pid, status, String.t) :: :ok
+  @spec update_shard_status(pid, status, String.t, integer, String.t) :: :ok
   def update_shard_status(pid, status, game, type \\ 0, stream \\ nil) do
-    Session.update_status(pid, to_string(status), {game, stream}, type)
+    Session.update_status(pid, to_string(status), game, stream, type)
     :ok
   end
 
@@ -113,9 +113,9 @@ defmodule Nostrum.Api do
 
   See `update_shard_status/4` for usage.
   """
-  @spec update_status(status, String.t) :: :ok
+  @spec update_status(status, String.t, integer, String.t) :: :ok
   def update_status(status, game, type \\ 0, stream \\ nil) do
-    Supervisor.update_status(status, {game, stream}, type)
+    Supervisor.update_status(status, game, stream, type)
     :ok
   end
 

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -99,22 +99,23 @@ defmodule Nostrum.Api do
     - `pid` - Pid of the shard.
     - `status` - Status of the bot.
     - `game` - The 'playing' text of the bot. Empty will clear.
+    - `type` - The type of status to show.
     - `streaming` - URL of twitch.tv stream
   """
   @spec update_status(pid, status, String.t) :: :ok
-  def update_shard_status(pid, status, game, stream \\ nil) do
-    Session.update_status(pid, to_string(status), game, stream)
+  def update_shard_status(pid, status, game, type \\ 0, stream \\ nil) do
+    Session.update_status(pid, to_string(status), {game, stream}, type)
     :ok
   end
 
   @doc """
   Updates the status of the bot for all shards.
 
-  See `update_shard_status/3` for usage.
+  See `update_shard_status/4` for usage.
   """
   @spec update_status(status, String.t) :: :ok
-  def update_status(status, game, stream \\ nil) do
-    Supervisor.update_status(status, game, stream)
+  def update_status(status, game, type \\ 0, stream \\ nil) do
+    Supervisor.update_status(status, {game, stream}, type)
     :ok
   end
 

--- a/lib/nostrum/shard/payload.ex
+++ b/lib/nostrum/shard/payload.ex
@@ -41,28 +41,14 @@ defmodule Nostrum.Shard.Payload do
   end
 
   @doc false
-  # No stream
-  def status_update_payload(idle_since, game, status, afk, nil) do
+  def status_update_payload(idle_since, {game, stream}, status, afk, type) do
     %{
       "since" => idle_since,
       "afk" => afk,
       "status" => status,
       "game" => %{
         "name" => game,
-        "type" => 0
-      }
-    } |> build_payload("STATUS_UPDATE")
-  end
-
-  @doc false
-  def status_update_payload(idle_since, game, status, afk, stream) do
-    %{
-      "since" => idle_since,
-      "afk" => afk,
-      "status" => status,
-      "game" => %{
-        "name" => game,
-        "type" => 1,
+        "type" => type,
         "url" => stream
       }
     } |> build_payload("STATUS_UPDATE")

--- a/lib/nostrum/shard/payload.ex
+++ b/lib/nostrum/shard/payload.ex
@@ -41,7 +41,7 @@ defmodule Nostrum.Shard.Payload do
   end
 
   @doc false
-  def status_update_payload(idle_since, {game, stream}, status, afk, type) do
+  def status_update_payload(idle_since, game, stream, status, afk, type) do
     %{
       "since" => idle_since,
       "afk" => afk,

--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -28,7 +28,7 @@ defmodule Nostrum.Shard.Session do
 
   @gateway_qs '/?compress=zlib-stream&encoding=etf&v=6'
 
-  def update_status(pid, status, {game, stream}, type) do
+  def update_status(pid, status, game, stream, type) do
     {idle_since, afk} =
       case status do
         "idle" ->
@@ -36,7 +36,7 @@ defmodule Nostrum.Shard.Session do
         _ ->
           {0, false}
       end
-    payload = Payload.status_update_payload(idle_since, {game, stream}, status, afk, type)
+    payload = Payload.status_update_payload(idle_since, game, stream, status, afk, type)
     send(pid, {:status_update, payload})
   end
 

--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -28,7 +28,7 @@ defmodule Nostrum.Shard.Session do
 
   @gateway_qs '/?compress=zlib-stream&encoding=etf&v=6'
 
-  def update_status(pid, status, game, stream) do
+  def update_status(pid, status, {game, stream}, type) do
     {idle_since, afk} =
       case status do
         "idle" ->
@@ -36,7 +36,7 @@ defmodule Nostrum.Shard.Session do
         _ ->
           {0, false}
       end
-    payload = Payload.status_update_payload(idle_since, game, status, afk, stream)
+    payload = Payload.status_update_payload(idle_since, {game, stream}, status, afk, type)
     send(pid, {:status_update, payload})
   end
 

--- a/lib/nostrum/shard/supervisor.ex
+++ b/lib/nostrum/shard/supervisor.ex
@@ -21,13 +21,13 @@ defmodule Nostrum.Shard.Supervisor do
     Supervisor.start_link(__MODULE__, [url: url, token: token, num_shards: num_shards], name: ShardSupervisor)
   end
 
-  def update_status(status, {game, stream}, type) do
+  def update_status(status, game, stream, type) do
     ShardSupervisor
     |> Supervisor.which_children
     |> Enum.filter(fn {_id, _pid, _type, [modules]} -> modules == Nostrum.Shard end)
     |> Enum.map(fn {_id, pid, _type, _modules} -> Supervisor.which_children(pid) end)
     |> List.flatten
-    |> Enum.map(fn {_id, pid, _type, _modules} -> Session.update_status(pid, status, {game, stream}, type) end)
+    |> Enum.map(fn {_id, pid, _type, _modules} -> Session.update_status(pid, status, game, stream, type) end)
   end
 
   @doc false

--- a/lib/nostrum/shard/supervisor.ex
+++ b/lib/nostrum/shard/supervisor.ex
@@ -21,13 +21,13 @@ defmodule Nostrum.Shard.Supervisor do
     Supervisor.start_link(__MODULE__, [url: url, token: token, num_shards: num_shards], name: ShardSupervisor)
   end
 
-  def update_status(status, game, stream) do
+  def update_status(status, {game, stream}, type) do
     ShardSupervisor
     |> Supervisor.which_children
     |> Enum.filter(fn {_id, _pid, _type, [modules]} -> modules == Nostrum.Shard end)
     |> Enum.map(fn {_id, pid, _type, _modules} -> Supervisor.which_children(pid) end)
     |> List.flatten
-    |> Enum.map(fn {_id, pid, _type, _modules} -> Session.update_status(pid, status, game, stream) end)
+    |> Enum.map(fn {_id, pid, _type, _modules} -> Session.update_status(pid, status, {game, stream}, type) end)
   end
 
   @doc false


### PR DESCRIPTION
Modify the update_status methods to allow a `type` parameter. 
This is to allow users to use the new type statuses that have been implemented (Listening & Watching).

It also works out for future updates to the presence api so long as they just add in a new type, whatever that may be.