### PR TITLE
Fixed ChannelCache initial state.

### DIFF
--- a/lib/nostrum/cache/channel_cache.ex
+++ b/lib/nostrum/cache/channel_cache.ex
@@ -18,7 +18,7 @@ defmodule Nostrum.Cache.ChannelCache do
   end
 
   def init([]) do
-    {:ok, []}
+    {:ok, %{}}
   end
 
   @doc ~S"""


### PR DESCRIPTION
## Why

The ChannelCache GenServer was incorrectly starting with an empty list as an initial state instead of an empty map. This meant that DM channels could not be properly stored inside of ChannelCache's state.

## What

Changed the initial state of ChannelCache to `%{}` instead of an empty list `[]`
