### PR TITLE
Fix typespec for Nostrum.Api.create_message/3

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -54,7 +54,7 @@ defmodule Nostrum.Api do
   """
   @type message_content :: String.t |
                            [content: String.t, embed: Embed.t] |
-                           [content: String.t, file: String.t]
+                           [file_name: String.t, file: String.t]
 
   @typedoc """
   Represents a failed response from the API.


### PR DESCRIPTION
# Why
Typespec is incorrect for `create_message/3`

# What
Changed key from "content" to "file_name" in type `message_content`