### PR TITLE
Api Correction Part 1: User struct

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1360,7 +1360,7 @@ defmodule Nostrum.Api do
   end
 
   @doc """
-  Gets a user by its `user_id`.
+  Gets a user by its `t:Nostrum.Struct.User.id/0`.
 
   If the request is successful, this function returns `{:ok, user}`, where 
   `user` is a `Nostrum.Struct.User`. Otherwise, returns `{:error, reason}`.
@@ -1435,7 +1435,7 @@ defmodule Nostrum.Api do
   @spec modify_current_user!(keyword | map) :: no_return | User.t
   def modify_current_user!(params) do
     modify_current_user(params)
-    |> bangify()
+    |> bangify
   end
 
   @doc """
@@ -1852,7 +1852,7 @@ defmodule Nostrum.Api do
   defp handle_request_with_decode({:ok, body}, type) do 
     convert =  
       body 
-      |> Poison.decode!()
+      |> Poison.decode!
       |> Util.cast(type)
  
     {:ok, convert}

--- a/lib/nostrum/cache/me.ex
+++ b/lib/nostrum/cache/me.ex
@@ -16,7 +16,7 @@ defmodule Nostrum.Cache.Me do
     # Returns {:error, reason} if this fails, acting as a simple check for
     # correct tokens
     with {:ok, user} <- Api.get_current_user(),
-    do: {:ok, %{user | id: String.to_integer(user.id)}}
+    do: {:ok, %{user | id: user.id}}
   end
 
   @doc """

--- a/lib/nostrum/struct/message/attachment.ex
+++ b/lib/nostrum/struct/message/attachment.ex
@@ -49,7 +49,11 @@ defmodule Nostrum.Struct.Message.Attachment do
 
   @doc false
   def to_struct(map) do
-    struct(__MODULE__, Util.safe_atom_map(map))
-    |> Map.update(:id, nil, &Snowflake.cast!/1)
+    new = 
+      map 
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end) 
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/message/attachment.ex
+++ b/lib/nostrum/struct/message/attachment.ex
@@ -3,8 +3,21 @@ defmodule Nostrum.Struct.Message.Attachment do
   Struct representing a Discord message attachment.
   """
 
+  alias Nostrum.Struct.Snowflake
+  alias Nostrum.Util
+
+  defstruct [
+    :id,
+    :filename,
+    :size,
+    :url,
+    :proxy_url,
+    :height,
+    :width
+  ]
+
   @typedoc "Attachment id"
-  @type id :: integer
+  @type id :: Snowflake.t
 
   @typedoc "Name of attached file"
   @type filename :: String.t
@@ -34,19 +47,9 @@ defmodule Nostrum.Struct.Message.Attachment do
     width: width
   }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :id,
-    :filename,
-    :size,
-    :url,
-    :proxy_url,
-    :height,
-    :width
-  ]
-
   @doc false
   def to_struct(map) do
-    struct(__MODULE__, map)
+    struct(__MODULE__, Util.safe_atom_map(map))
+    |> Map.update(:id, nil, &Snowflake.cast!/1)
   end
 end

--- a/lib/nostrum/struct/snowflake.ex
+++ b/lib/nostrum/struct/snowflake.ex
@@ -1,0 +1,62 @@
+defmodule Nostrum.Struct.Snowflake do
+  @moduledoc """
+  Functions that work on Snowflakes.
+
+  Snowflakes are 64-bit unsigned integers used to represent discord 
+  object ids. In JSON, they are typically represented as strings due 
+  to some languages not being able to represent such a large number.
+  
+  Nostrum represents snowflakes as integers since Elixir allows us 
+  to represent large integers.
+  """
+
+  @type external_snowflake :: String.t
+
+  @type t :: integer
+
+  @doc """
+  Returns `true` if `term` is a snowflake; otherwise returns `false`
+  """
+  defmacro is_snowflake(term) do
+    quote do
+      is_integer(unquote(term))
+    end
+  end
+
+  @doc """
+  Attempts to convert a term into a snowflake.
+  """
+  @spec cast(term) :: {:ok, t | nil} | :error
+  def cast(value)
+  def cast(nil), do: {:ok, nil}
+  def cast(value) when is_integer(value), do: {:ok, value}
+
+  def cast(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {snowflake, _} -> {:ok, snowflake}
+      _ -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  @doc """
+  Same as `cast/1`, except it raises an `ArgumentException` on failure.
+  """
+  @spec cast!(term) :: t | nil | no_return
+  def cast!(value) do
+    case cast(value) do
+      {:ok, res} -> res
+      :error -> raise ArgumentError, "Could not convert to a snowflake"
+    end
+  end
+
+  @doc """
+  Convert a snowflake into its external representation.
+  """
+  @spec dump(t) :: external_snowflake
+  def dump(snowflake) when is_snowflake(snowflake), do: to_string(snowflake)
+  def dump(_), do: raise ArgumentError, "Was not given a snowflake"
+
+  
+end

--- a/lib/nostrum/struct/snowflake.ex
+++ b/lib/nostrum/struct/snowflake.ex
@@ -1,17 +1,22 @@
 defmodule Nostrum.Struct.Snowflake do
   @moduledoc """
   Functions that work on Snowflakes.
-
-  Snowflakes are 64-bit unsigned integers used to represent discord 
-  object ids. In JSON, they are typically represented as strings due 
-  to some languages not being able to represent such a large number.
-  
-  Nostrum represents snowflakes as integers since Elixir allows us 
-  to represent large integers.
   """
 
+  @typedoc """
+  The type that represents snowflakes in JSON.
+
+  In JSON, Snowflakes are typically represented as strings due 
+  to some languages not being able to represent such a large number.
+  """
   @type external_snowflake :: String.t
 
+  @typedoc """
+  The snowflake type.
+
+  Snowflakes are 64-bit unsigned integers used to represent discord 
+  object ids.
+  """
   @type t :: integer
 
   @doc """

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -63,7 +63,11 @@ defmodule Nostrum.Struct.User do
 
   @doc false
   def to_struct(map) do
-    struct(__MODULE__, Util.safe_atom_map(map))
-    |> Map.update(:id, nil, &Snowflake.cast!/1)
+    new = 
+      map 
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end) 
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -7,8 +7,22 @@ defmodule Nostrum.Struct.User do
   A `member` has everything that a `user` has, but also additional information on a per guild basis. This includes things like a `nickname` and a list of `roles`.
   """
 
+  alias Nostrum.Struct.Snowflake
+  alias Nostrum.Util
+
+  defstruct [
+    :id,
+    :username,
+    :discriminator,
+    :avatar,
+    :bot,
+    :mfa_enabled,
+    :verified,
+    :email,
+  ]
+
   @typedoc "The user's id"
-  @type id :: integer
+  @type id :: Snowflake.t
 
   @typedoc "The user's username"
   @type username :: String.t
@@ -17,19 +31,19 @@ defmodule Nostrum.Struct.User do
   @type discriminator :: String.t
 
   @typedoc "User's avatar hash"
-  @type avatar :: String.t
+  @type avatar :: String.t | nil
 
   @typedoc "Whether the user is a bot"
-  @type bot :: boolean
+  @type bot :: boolean | nil
 
   @typedoc "Whether the user has two factor enabled"
-  @type mfa_enabled :: boolean
+  @type mfa_enabled :: boolean | nil
 
   @typedoc "Whether the email on the account has been verified"
-  @type verified :: boolean
+  @type verified :: boolean | nil
 
   @typedoc "The user's email"
-  @type email :: String.t
+  @type email :: String.t | nil
 
   @type t :: %__MODULE__{
     id: id,
@@ -42,27 +56,14 @@ defmodule Nostrum.Struct.User do
     email: email,
   }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :id,
-    :username,
-    :discriminator,
-    :avatar,
-    :bot,
-    :mfa_enabled,
-    :verified,
-    :email,
-  ]
-
   @doc false
   def p_encode do
     %__MODULE__{}
   end
 
   @doc false
-  # TODO: Necessary?
-  def to_struct(%{__struct__: _} = map), do: map
   def to_struct(map) do
-    struct(__MODULE__, map)
+    struct(__MODULE__, Util.safe_atom_map(map))
+    |> Map.update(:id, nil, &Snowflake.cast!/1)
   end
 end

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -204,7 +204,7 @@ defmodule Nostrum.Util do
       String.to_atom(token)
   end
 
-   # Generic casting function
+  # Generic casting function
   @doc false
   @spec cast(term, module | {:list, term} | {:struct, term} | {:index, term, [atom]}) :: term
   def cast(value, type)

--- a/test/nostrum/struct/snowflake_test.exs
+++ b/test/nostrum/struct/snowflake_test.exs
@@ -1,0 +1,78 @@
+defmodule Nostrum.Struct.SnowflakeTest do
+  use ExUnit.Case
+
+  alias Nostrum.Struct.Snowflake
+
+  require Nostrum.Struct.Snowflake
+
+  test "cast/1: if string is given, then return snowflake" do
+    given = "4384931048190393"
+    expected = {:ok, 4384931048190393}
+
+    observed = Snowflake.cast(given)
+
+    assert ^expected = observed
+  end
+
+  test "cast/1: if integer is given, then return snowflake" do
+    given = 4384931048190393
+    expected = {:ok, 4384931048190393}
+
+    observed = Snowflake.cast(given)
+
+    assert ^expected = observed
+  end
+
+  test "cast/1: if nil is given, then return nil" do
+    given = nil
+    expected = {:ok, nil}
+
+    observed = Snowflake.cast(given)
+
+    assert ^expected = observed
+  end
+
+  test "cast/1: if non-convertible is given, then return :error" do
+    given = true
+    expected = :error
+
+    observed = Snowflake.cast(given)
+
+    assert ^expected = observed
+  end
+
+  test "dump/1: if snowflake is given, then return snowflake as string" do
+    given = 4314103984319043
+    expected = "4314103984319043"
+
+    observed = Snowflake.dump(given)
+
+    assert ^expected = observed
+  end
+
+  test "dump/1: if non-snowflake is given, then raise exception" do
+    given = :not_snowflake
+
+    assert_raise(ArgumentError, fn ->
+      Snowflake.dump(given)
+    end)
+  end
+
+  test "is_snowflake/1: if snowflake is given, return true" do
+    given = 4314831498137
+    expected = true
+
+    observed = Snowflake.is_snowflake(given)
+
+    assert expected === observed
+  end
+  
+  test "is_snowflake/1: if snowflake is given, return false" do
+    given = "4314831498137"
+    expected = false
+
+    observed = Snowflake.is_snowflake(given)
+
+    assert expected === observed
+  end
+end


### PR DESCRIPTION
This is part one of the the bigger Api correction PR that I'm starting to break apart.

This PR accomplishes the following:

* Ensures the User struct snowflakes are decoded as integers instead of strings
* Fixes User-related functions typespecs, docs, and return values in Api module. Example: certain functions not returning a User struct where specified.
* Adds "bangified" functions for User-related Api calls.