### PR TITLE
Api Correction Part 2: Emojis

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -285,28 +285,32 @@ defmodule Nostrum.Api do
   ## Examples
 
   ```Elixir
+  # Using a Nostrum.Struct.Emoji.
+  emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
+  Nostrum.Api.create_reaction(123123123123, 321321321321, emoji)
+
   # Using a base 16 emoji string.
   Nostrum.Api.create_reaction(123123123123, 321321321321, "\xF0\x9F\x98\x81")
 
   # Using a URI encoded emoji string.
   Nostrum.Api.create_reaction(123123123123, 321321321321, URI.encode("\u2b50"))
-
-  # Using a Nostrum.Struct.Emoji.
-  emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
-  Nostrum.Api.create_reaction(123123123123, 321321321321, Nostrum.Struct.Emoji.to_api_name(emoji))
   ```
 
   For other emoji string examples, see `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
   """
-  @spec create_reaction(Channel.id, Message.id, Emoji.emoji_api_name) :: error | {:ok}
-  def create_reaction(channel_id, message_id, emoji) do
-    request(:put, Constants.channel_reaction_me(channel_id, message_id, emoji))
+  @spec create_reaction(Channel.id, Message.id, Emoji.t | Emoji.emoji_api_name) :: error | {:ok}
+  def create_reaction(channel_id, message_id, emoji)
+  def create_reaction(channel_id, message_id, %Emoji{} = emoji), 
+    do: create_reaction(channel_id, message_id, Emoji.get_api_name(emoji))
+
+  def create_reaction(channel_id, message_id, emoji_api_name) do
+    request(:put, Constants.channel_reaction_me(channel_id, message_id, emoji_api_name))
   end
 
   @doc """
   Same as `create_reaction/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec create_reaction!(Channel.id, Message.id, Emoji.emoji_api_name) :: no_return | {:ok}
+  @spec create_reaction!(Channel.id, Message.id, Emoji.t | Emoji.emoji_api_name) :: no_return | {:ok}
   def create_reaction!(channel_id, message_id, emoji) do
     create_reaction(channel_id, message_id, emoji)
     |> bangify
@@ -318,19 +322,21 @@ defmodule Nostrum.Api do
   If the request was successful, this function returns `{:ok}`. Otherwise, 
   this function returns `{:error, reason}`.
 
-  ## Examples
-
   See `create_reaction/3` for similar examples.
   """
-  @spec delete_own_reaction(Channel.id, Message.id, Emoji.emoji_api_name) :: error | {:ok}
-  def delete_own_reaction(channel_id, message_id, emoji) do
-    request(:delete, Constants.channel_reaction_me(channel_id, message_id, emoji))
+  @spec delete_own_reaction(Channel.id, Message.id, Emoji.t | Emoji.emoji_api_name) :: error | {:ok}
+  def delete_own_reaction(channel_id, message_id, emoji)
+  def delete_own_reaction(channel_id, message_id, %Emoji{} = emoji), 
+    do: delete_own_reaction(channel_id, message_id, Emoji.get_api_name(emoji))
+  
+  def delete_own_reaction(channel_id, message_id, emoji_api_name) do
+    request(:delete, Constants.channel_reaction_me(channel_id, message_id, emoji_api_name))
   end
 
   @doc ~S"""
   Same as `delete_own_reaction/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec delete_own_reaction!(Channel.id, Message.id, Emoji.emoji_api_name) :: no_return | {:ok}
+  @spec delete_own_reaction!(Channel.id, Message.id, Emoji.t | Emoji.emoji_api_name) :: no_return | {:ok}
   def delete_own_reaction!(channel_id, message_id, emoji) do
     delete_own_reaction(channel_id, message_id, emoji)
     |> bangify
@@ -342,19 +348,21 @@ defmodule Nostrum.Api do
   If the request was successful, this function returns `{:ok}`. Otherwise, 
   this function returns `{:error, reason}`.
 
-  ## Examples
-
   See `create_reaction/3` for similar examples.
   """
-  @spec delete_user_reaction(Channel.id, Message.id, Emoji.emoji_api_name, User.id) :: error | {:ok}
-  def delete_user_reaction(channel_id, message_id, emoji, user_id) do
-    request(:delete, Constants.channel_reaction(channel_id, message_id, emoji, user_id))
+  @spec delete_user_reaction(Channel.id, Message.id, Emoji.t | Emoji.emoji_api_name, User.id) :: error | {:ok}
+  def delete_user_reaction(channel_id, message_id, emoji, user_id)
+  def delete_user_reaction(channel_id, message_id, %Emoji{} = emoji, user_id), 
+    do: delete_user_reaction(channel_id, message_id, Emoji.get_api_name(emoji), user_id)
+
+  def delete_user_reaction(channel_id, message_id, emoji_api_name, user_id) do
+    request(:delete, Constants.channel_reaction(channel_id, message_id, emoji_api_name, user_id))
   end
 
   @doc ~S"""
   Same as `delete_user_reaction/4`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec delete_user_reaction!(Channel.id, Message.id, Emoji.emoji_api_name, User.id) :: no_return | {:ok}
+  @spec delete_user_reaction!(Channel.id, Message.id, Emoji.t | Emoji.emoji_api_name, User.id) :: no_return | {:ok}
   def delete_user_reaction!(channel_id, message_id, emoji, user_id) do
     delete_user_reaction(channel_id, message_id, emoji, user_id)
     |> bangify
@@ -367,20 +375,22 @@ defmodule Nostrum.Api do
   `users` is a list of `Nostrum.Struct.User`. Otherwise, this function 
   returns `{:error, reason}`.
 
-  ## Examples
-
   See `create_reaction/3` for similar examples.
   """
-  @spec get_reactions(Channel.id, Message.id, Emoji.emoji_api_name) :: error | {:ok, [User.t]}
-  def get_reactions(channel_id, message_id, emoji) do
-    request(:get, Constants.channel_reactions_get(channel_id, message_id, emoji))
+  @spec get_reactions(Channel.id, Message.id, Emoji.t | Emoji.emoji_api_name) :: error | {:ok, [User.t]}
+  def get_reactions(channel_id, message_id, emoji)
+  def get_reactions(channel_id, message_id, %Emoji{} = emoji), 
+    do: get_reactions(channel_id, message_id, Emoji.get_api_name(emoji))
+  
+  def get_reactions(channel_id, message_id, emoji_api_name) do
+    request(:get, Constants.channel_reactions_get(channel_id, message_id, emoji_api_name))
     |> handle_request_with_decode({:list, {:struct, User}})
   end
 
   @doc """
   Same as `get_reactions/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec get_reactions!(Channel.id, Message.id, Emoji.emoji_api_name) :: no_return | [User.t]
+  @spec get_reactions!(Channel.id, Message.id, Emoji.t | Emoji.emoji_api_name) :: no_return | [User.t]
   def get_reactions!(channel_id, message_id, emoji) do
     get_reactions(channel_id, message_id, emoji)
     |> bangify

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -346,17 +346,17 @@ defmodule Nostrum.Api do
 
   See `create_reaction/3` for similar examples.
   """
-  @spec delete_reaction(Channel.id, Message.id, Emoji.emoji_api_name, User.id) :: error | {:ok}
-  def delete_reaction(channel_id, message_id, emoji, user_id) do
+  @spec delete_user_reaction(Channel.id, Message.id, Emoji.emoji_api_name, User.id) :: error | {:ok}
+  def delete_user_reaction(channel_id, message_id, emoji, user_id) do
     request(:delete, Constants.channel_reaction(channel_id, message_id, emoji, user_id))
   end
 
   @doc ~S"""
-  Same as `delete_reaction/4`, but raises `Nostrum.Error.ApiError` in case of failure.
+  Same as `delete_user_reaction/4`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec delete_reaction!(Channel.id, Message.id, Emoji.emoji_api_name, User.id) :: no_return | {:ok}
-  def delete_reaction!(channel_id, message_id, emoji, user_id) do
-    delete_reaction(channel_id, message_id, emoji, user_id)
+  @spec delete_user_reaction!(Channel.id, Message.id, Emoji.emoji_api_name, User.id) :: no_return | {:ok}
+  def delete_user_reaction!(channel_id, message_id, emoji, user_id) do
+    delete_user_reaction(channel_id, message_id, emoji, user_id)
     |> bangify
   end
 

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -279,22 +279,26 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Creates a reaction for a message.
 
-  Parameter `emoji` can be any of the following:
-
-    * A `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
-    * A base 16 unicode emoji string.
-    * A URI encoded string.
-
   If the request was successful, this function returns `{:ok}`. Otherwise, 
   this function returns `{:error, reason}`.
 
   ## Examples
 
-      Nostrum.Api.create_reaction(123123123123, 321321321321, "\xF0\x9F\x98\x81")
+  ```Elixir
+  # Using a base 16 emoji string.
+  Nostrum.Api.create_reaction(123123123123, 321321321321, "\xF0\x9F\x98\x81")
 
-      Nostrum.Api.create_reaction(123123123123, 321321321321, URI.encode("\u2b50"))
+  # Using a URI encoded emoji string.
+  Nostrum.Api.create_reaction(123123123123, 321321321321, URI.encode("\u2b50"))
+
+  # Using a Nostrum.Struct.Emoji.
+  emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
+  Nostrum.Api.create_reaction(123123123123, 321321321321, Nostrum.Struct.Emoji.to_api_name(emoji))
+  ```
+
+  For other emoji string examples, see `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
   """
-  @spec create_reaction(Channel.id, Message.id, String.t | Emoji.emoji_api_name) :: error | {:ok}
+  @spec create_reaction(Channel.id, Message.id, Emoji.emoji_api_name) :: error | {:ok}
   def create_reaction(channel_id, message_id, emoji) do
     request(:put, Constants.channel_reaction_me(channel_id, message_id, emoji))
   end
@@ -302,7 +306,7 @@ defmodule Nostrum.Api do
   @doc """
   Same as `create_reaction/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec create_reaction!(Channel.id, Message.id, String.t | Emoji.emoji_api_name) :: no_return | {:ok}
+  @spec create_reaction!(Channel.id, Message.id, Emoji.emoji_api_name) :: no_return | {:ok}
   def create_reaction!(channel_id, message_id, emoji) do
     create_reaction(channel_id, message_id, emoji)
     |> bangify
@@ -311,23 +315,14 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Deletes a reaction made by the user.
 
-  Parameter `emoji` can be any of the following:
-
-    * A `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
-    * A base 16 unicode emoji string.
-    * A URI encoded string.
-
   If the request was successful, this function returns `{:ok}`. Otherwise, 
   this function returns `{:error, reason}`.
 
   ## Examples
 
-      Nostrum.Api.delete_own_reaction(123123123123, 321321321321, "\xF0\x9F\x98\x81")
-      
-      Nostrum.Api.delete_own_reaction(123123123123, 321321321321, URI.encode("\u2b50"))
-      
+  See `create_reaction/3` for similar examples.
   """
-  @spec delete_own_reaction(Channel.id, Message.id, String.t | Emoji.emoji_api_name) :: error | {:ok}
+  @spec delete_own_reaction(Channel.id, Message.id, Emoji.emoji_api_name) :: error | {:ok}
   def delete_own_reaction(channel_id, message_id, emoji) do
     request(:delete, Constants.channel_reaction_me(channel_id, message_id, emoji))
   end
@@ -335,32 +330,23 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Same as `delete_own_reaction/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec delete_own_reaction!(Channel.id, Message.id, String.t | Emoji.emoji_api_name) :: no_return | {:ok}
+  @spec delete_own_reaction!(Channel.id, Message.id, Emoji.emoji_api_name) :: no_return | {:ok}
   def delete_own_reaction!(channel_id, message_id, emoji) do
     delete_own_reaction(channel_id, message_id, emoji)
-    |> bangify()
+    |> bangify
   end
 
   @doc ~S"""
   Deletes another user's reaction from a message
-
-  Parameter `emoji` can be any of the following:
-
-    * A `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
-    * A base 16 unicode emoji string.
-    * A URI encoded string.
 
   If the request was successful, this function returns `{:ok}`. Otherwise, 
   this function returns `{:error, reason}`.
 
   ## Examples
 
-      Nostrum.Api.delete_reaction(351194183568195585, 417954134373957633, "\xF0\x9F\x98\x81", 177888205536886784)
-      
-      Nostrum.Api.delete_reaction(351194183568195585, 417954134373957633, URI.encode("\u2b50"), 177888205536886784)
-      
+  See `create_reaction/3` for similar examples.
   """
-  @spec delete_reaction(Channel.id, Message.id, String.t | Emoji.emoji_api_name, User.id) :: error | {:ok}
+  @spec delete_reaction(Channel.id, Message.id, Emoji.emoji_api_name, User.id) :: error | {:ok}
   def delete_reaction(channel_id, message_id, emoji, user_id) do
     request(:delete, Constants.channel_reaction(channel_id, message_id, emoji, user_id))
   end
@@ -368,7 +354,7 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Same as `delete_reaction/4`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec delete_reaction!(Channel.id, Message.id, String.t | Emoji.emoji_api_name, User.id) :: no_return | {:ok}
+  @spec delete_reaction!(Channel.id, Message.id, Emoji.emoji_api_name, User.id) :: no_return | {:ok}
   def delete_reaction!(channel_id, message_id, emoji, user_id) do
     delete_reaction(channel_id, message_id, emoji, user_id)
     |> bangify
@@ -380,8 +366,12 @@ defmodule Nostrum.Api do
   If the request was successful, this function returns `{:ok, users}`, where 
   `users` is a list of `Nostrum.Struct.User`. Otherwise, this function 
   returns `{:error, reason}`.
+
+  ## Examples
+
+  See `create_reaction/3` for similar examples.
   """
-  @spec get_reactions(Channel.id, Message.id, String.t | Emoji.emoji_api_name) :: error | {:ok, [User.t]}
+  @spec get_reactions(Channel.id, Message.id, Emoji.emoji_api_name) :: error | {:ok, [User.t]}
   def get_reactions(channel_id, message_id, emoji) do
     request(:get, Constants.channel_reactions_get(channel_id, message_id, emoji))
     |> handle_request_with_decode({:list, {:struct, User}})
@@ -390,7 +380,7 @@ defmodule Nostrum.Api do
   @doc """
   Same as `get_reactions/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec get_reactions!(Channel.id, Message.id, String.t | Emoji.emoji_api_name) :: no_return | [User.t]
+  @spec get_reactions!(Channel.id, Message.id, Emoji.emoji_api_name) :: no_return | [User.t]
   def get_reactions!(channel_id, message_id, emoji) do
     get_reactions(channel_id, message_id, emoji)
     |> bangify
@@ -1470,8 +1460,9 @@ defmodule Nostrum.Api do
  
   ## Examples 
 
-      iex> Nostrum.Api.modify_current_user(avatar: "data:image/jpeg;base64,YXl5IGJieSB1IGx1a2luIDQgc3VtIGZ1az8=") 
-      {:ok, %Nostrum.Struct.User{}}
+  ```Elixir
+  Nostrum.Api.modify_current_user(avatar: "data:image/jpeg;base64,YXl5IGJieSB1IGx1a2luIDQgc3VtIGZ1az8=") 
+  ```
   """
   @spec modify_current_user(keyword | map) :: error | {:ok, User.t}
   def modify_current_user(params)

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -101,7 +101,7 @@ defmodule Nostrum.Api do
   @typedoc """
   Represents optional parameters for Api functions.
 
-  Each function has documentation regarding what parameters it 
+  Each function has documentation regarding what parameters it
   supports or needs.
   """
   @type options :: keyword | map
@@ -292,10 +292,10 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Creates a reaction for a message.
 
-  This endpoint requires the `VIEW_CHANNEL` and `READ_MESSAGE_HISTORY` 
-  permissions. Additionally, if nobody else has reacted to the message with 
-  the `emoji`, this endpoint requires the `ADD_REACTIONS` permission. It 
-  fires the `MESSAGE_REACTION_ADD` event.
+  This endpoint requires the `VIEW_CHANNEL` and `READ_MESSAGE_HISTORY`
+  permissions. Additionally, if nobody else has reacted to the message with
+  the `emoji`, this endpoint requires the `ADD_REACTIONS` permission. It
+  fires a `t:Nostrum.Consumer.message_reaction_add/0` event.
 
   If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
@@ -309,15 +309,13 @@ defmodule Nostrum.Api do
   # Using a base 16 emoji string.
   Nostrum.Api.create_reaction(123123123123, 321321321321, "\xF0\x9F\x98\x81")
 
-  # Using a URI encoded emoji string.
-  Nostrum.Api.create_reaction(123123123123, 321321321321, URI.encode("\u2b50"))
   ```
 
   For other emoji string examples, see `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
   """
   @spec create_reaction(Channel.id, Message.id, emoji) :: error | {:ok}
   def create_reaction(channel_id, message_id, emoji)
-  def create_reaction(channel_id, message_id, %Emoji{} = emoji), 
+  def create_reaction(channel_id, message_id, %Emoji{} = emoji),
     do: create_reaction(channel_id, message_id, Emoji.get_api_name(emoji))
 
   def create_reaction(channel_id, message_id, emoji_api_name) do
@@ -336,8 +334,8 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Deletes a reaction the current user has made for the message.
 
-  This endpoint requires the `VIEW_CHANNEL` and `READ_MESSAGE_HISTORY` 
-  permissions. This endpoint fires the `MESSAGE_REACTION_REMOVE` event.
+  This endpoint requires the `VIEW_CHANNEL` and `READ_MESSAGE_HISTORY`
+  permissions. It fires a `t:Nostrum.Consumer.message_reaction_remove/0` event.
 
   If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
@@ -345,9 +343,9 @@ defmodule Nostrum.Api do
   """
   @spec delete_own_reaction(Channel.id, Message.id, emoji) :: error | {:ok}
   def delete_own_reaction(channel_id, message_id, emoji)
-  def delete_own_reaction(channel_id, message_id, %Emoji{} = emoji), 
+  def delete_own_reaction(channel_id, message_id, %Emoji{} = emoji),
     do: delete_own_reaction(channel_id, message_id, Emoji.get_api_name(emoji))
-  
+
   def delete_own_reaction(channel_id, message_id, emoji_api_name) do
     request(:delete, Constants.channel_reaction_me(channel_id, message_id, emoji_api_name))
   end
@@ -364,16 +362,16 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Deletes another user's reaction from a message.
 
-  This endpoint requires the `VIEW_CHANNEL`, `READ_MESSAGE_HISTORY`, and 
-  `MANAGE_MESSAGES` permissions. It fires the `MESSAGE_REACTION_REMOVE` event.
-  
+  This endpoint requires the `VIEW_CHANNEL`, `READ_MESSAGE_HISTORY`, and
+  `MANAGE_MESSAGES` permissions. It fires a `t:Nostrum.Consumer.message_reaction_remove/0` event.
+
   If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
   See `create_reaction/3` for similar examples.
   """
   @spec delete_user_reaction(Channel.id, Message.id, emoji, User.id) :: error | {:ok}
   def delete_user_reaction(channel_id, message_id, emoji, user_id)
-  def delete_user_reaction(channel_id, message_id, %Emoji{} = emoji, user_id), 
+  def delete_user_reaction(channel_id, message_id, %Emoji{} = emoji, user_id),
     do: delete_user_reaction(channel_id, message_id, Emoji.get_api_name(emoji), user_id)
 
   def delete_user_reaction(channel_id, message_id, emoji_api_name, user_id) do
@@ -400,9 +398,9 @@ defmodule Nostrum.Api do
   """
   @spec get_reactions(Channel.id, Message.id, emoji) :: error | {:ok, [User.t]}
   def get_reactions(channel_id, message_id, emoji)
-  def get_reactions(channel_id, message_id, %Emoji{} = emoji), 
+  def get_reactions(channel_id, message_id, %Emoji{} = emoji),
     do: get_reactions(channel_id, message_id, Emoji.get_api_name(emoji))
-  
+
   def get_reactions(channel_id, message_id, emoji_api_name) do
     request(:get, Constants.channel_reactions_get(channel_id, message_id, emoji_api_name))
     |> handle_request_with_decode({:list, {:struct, User}})
@@ -420,8 +418,8 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Deletes all reactions from a message.
 
-  This endpoint requires the `VIEW_CHANNEL`, `READ_MESSAGE_HISTORY`, and 
-  `MANAGE_MESSAGES` permissions. It fires the `MESSAGE_REACTION_REMOVE_ALL` event.
+  This endpoint requires the `VIEW_CHANNEL`, `READ_MESSAGE_HISTORY`, and
+  `MANAGE_MESSAGES` permissions. It fires a `t:Nostrum.Consumer.message_reaction_remove_all/0` event.
 
   If successful, returns `{:ok}`. Otherwise, return `t:Nostrum.Api.error/0`.
   """
@@ -908,8 +906,8 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Creates a new emoji for the given guild.
 
-  This endpoint requires the `MANAGE_EMOJIS` permission. It fires a 
-  `GUILD_EMOJIS_UPDATE` event.
+  This endpoint requires the `MANAGE_EMOJIS` permission. It fires a
+  `t:Nostrum.Consumer.guild_emojis_update/0` event.
 
   If successful, returns `{:ok, emoji}`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
@@ -932,7 +930,7 @@ defmodule Nostrum.Api do
   """
   @spec create_guild_emoji(Guild.id, options) :: error | {:ok, Emoji.t}
   def create_guild_emoji(guild_id, options)
-  def create_guild_emoji(guild_id, options) when is_list(options), 
+  def create_guild_emoji(guild_id, options) when is_list(options),
     do: create_guild_emoji(guild_id, Map.new(options))
 
   def create_guild_emoji(guild_id, %{} = options) do
@@ -952,8 +950,8 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Modify the given emoji.
 
-  This endpoint requires the `MANAGE_EMOJIS` permission. It fires a 
-  `GUILD_EMOJIS_UPDATE` event.
+  This endpoint requires the `MANAGE_EMOJIS` permission. It fires a
+  `t:Nostrum.Consumer.guild_emojis_update/0` event.
 
   If successful, returns `{:ok, emoji}`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
@@ -970,7 +968,7 @@ defmodule Nostrum.Api do
   """
   @spec modify_guild_emoji(Guild.id, Emoji.id, options) :: error | {:ok, Emoji.t}
   def modify_guild_emoji(guild_id, emoji_id, options \\ %{})
-  def modify_guild_emoji(guild_id, emoji_id, options) when is_list(options), 
+  def modify_guild_emoji(guild_id, emoji_id, options) when is_list(options),
     do: modify_guild_emoji(guild_id, emoji_id, Map.new(options))
 
   def modify_guild_emoji(guild_id, emoji_id, %{} = options) do
@@ -990,13 +988,13 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Deletes the given emoji.
 
-  This endpoint requires the `MANAGE_EMOJIS` permission. It fires a 
-  `GUILD_EMOJIS_UPDATE` event.
+  This endpoint requires the `MANAGE_EMOJIS` permission. It fires a
+  `t:Nostrum.Consumer.guild_emojis_update/0` event.
 
   If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
   """
   @spec delete_guild_emoji(Guild.id, Emoji.id) :: error | {:ok}
-  def delete_guild_emoji(guild_id, emoji_id), 
+  def delete_guild_emoji(guild_id, emoji_id),
     do: request(:delete, Constants.guild_emoji(guild_id, emoji_id))
 
   @doc ~S"""
@@ -1592,7 +1590,7 @@ defmodule Nostrum.Api do
   @doc """
   Gets a user by its `t:Nostrum.Struct.User.id/0`.
 
-  If the request is successful, this function returns `{:ok, user}`, where 
+  If the request is successful, this function returns `{:ok, user}`, where
   `user` is a `Nostrum.Struct.User`. Otherwise, returns `{:error, reason}`.
   """
   @spec get_user(User.id) :: error | {:ok, User.t}
@@ -1613,11 +1611,11 @@ defmodule Nostrum.Api do
   @doc """
   Gets info on the current user.
 
-  If nostrum's caching is enabled, it is recommended to use `Nostrum.Cache.Me.get/0` 
-  instead of this function. This is because sending out an API request is much slower 
+  If nostrum's caching is enabled, it is recommended to use `Nostrum.Cache.Me.get/0`
+  instead of this function. This is because sending out an API request is much slower
   than pulling from our cache.
 
-  If the request is successful, this function returns `{:ok, user}`, where 
+  If the request is successful, this function returns `{:ok, user}`, where
   `user` is nostrum's `Nostrum.Struct.User`. Otherwise, returns `{:error, reason}`.
   """
   @spec get_current_user() :: error | {:ok, User.t}
@@ -1638,20 +1636,20 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Changes the username or avatar of the current user.
 
-  ## Options 
- 
+  ## Options
+
     * `:username` (string) - new username
     * `:avatar` (string) - the user's avatar as [avatar data](https://discordapp.com/developers/docs/resources/user#avatar-data)
- 
-  ## Examples 
+
+  ## Examples
 
   ```Elixir
-  Nostrum.Api.modify_current_user(avatar: "data:image/jpeg;base64,YXl5IGJieSB1IGx1a2luIDQgc3VtIGZ1az8=") 
+  Nostrum.Api.modify_current_user(avatar: "data:image/jpeg;base64,YXl5IGJieSB1IGx1a2luIDQgc3VtIGZ1az8=")
   ```
   """
   @spec modify_current_user(keyword | map) :: error | {:ok, User.t}
   def modify_current_user(options)
-  def modify_current_user(options) when is_list(options), 
+  def modify_current_user(options) when is_list(options),
     do: modify_current_user(Map.new(options))
 
   def modify_current_user(%{} = options) do
@@ -2076,15 +2074,15 @@ defmodule Nostrum.Api do
     Application.get_env(:nostrum, :token)
   end
 
-  defp handle_request_with_decode(response, type) 
-  defp handle_request_with_decode({:error, _} = error, _type), do: error 
- 
-  defp handle_request_with_decode({:ok, body}, type) do 
-    convert =  
-      body 
+  defp handle_request_with_decode(response, type)
+  defp handle_request_with_decode({:error, _} = error, _type), do: error
+
+  defp handle_request_with_decode({:ok, body}, type) do
+    convert =
+      body
       |> Poison.decode!
       |> Util.cast(type)
- 
+
     {:ok, convert}
   end
 end

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -831,6 +831,153 @@ defmodule Nostrum.Api do
     |> bangify
   end
 
+  @doc ~S"""
+  Gets a list of emojis for a given guild.
+
+  If the request is successful, this function returns `{:ok, emojis}`, where 
+  `emojis` is a list of `Nostrum.Struct.Emoji`. Otherwise, returns `{:error, reason}`.
+  """
+  @spec list_guild_emojis(Guild.id) :: error | {:ok, [Emoji.t]}
+  def list_guild_emojis(guild_id) do
+    request(:get, Constants.guild_emojis(guild_id))
+    |> handle_request_with_decode({:list, {:struct, Emoji}})
+  end
+
+  @doc ~S"""
+  Same as `list_guild_emojis/1`, but raises `Nostrum.Error.ApiError` in case of failure.
+  """
+  @spec list_guild_emojis!(Guild.id) :: no_return | [Emoji.t]
+  def list_guild_emojis!(guild_id) do
+    list_guild_emojis(guild_id)
+    |> bangify
+  end
+
+  @doc ~S"""
+  Gets an emoji for the given guild and emoji ids.
+
+  If the request is successful, this function returns `{:ok, emoji}`, where 
+  `emoji` is a `Nostrum.Struct.Emoji`. Otherwise, returns `{:error, reason}`.
+  """
+  @spec get_guild_emoji(Guild.id, Emoji.id) :: error | {:ok, Emoji.t}
+  def get_guild_emoji(guild_id, emoji_id) do
+    request(:get, Constants.guild_emoji(guild_id, emoji_id))
+    |> handle_request_with_decode({:struct, Emoji})
+  end
+
+  @doc ~S"""
+  Same as `get_guild_emoji/2`, but raises `Nostrum.Error.ApiError` in case of failure.
+  """
+  @spec get_guild_emoji!(Guild.id, Emoji.id) :: no_return | Emoji.t
+  def get_guild_emoji!(guild_id, emoji_id) do
+    get_guild_emoji(guild_id, emoji_id)
+    |> bangify
+  end
+
+  @doc ~S"""
+  Creates a new emoji for the given guild.
+
+  ## Request Params
+ 
+  The following params are required: 
+ 
+    * `:name` (string) - name of the emoji
+    * `:image` (base64 data URI) - the 128x128 emoji image. Maximum size of 256kb
+  
+  The following params are optional:
+
+    * `:roles` (list of `t:Nostrum.Struct.Snowflake.t/0`) - roles for which this emoji will be whitelisted
+
+  ## Return Values
+
+  If the request is successful, this function returns `{:ok, emoji}`, where 
+  `emoji` is a `Nostrum.Struct.Emoji`. Otherwise, returns `{:error, reason}`.
+
+  ## Examples
+
+  ```Elixir
+  image = "data:image/png;base64,YXl5IGJieSB1IGx1a2luIDQgc3VtIGZ1az8="
+
+  Nostrum.Api.create_guild_emoji(43189401384091, name: "nostrum", image: image, roles: [])
+  ```
+  """
+  @spec create_guild_emoji(Guild.id, keyword | map) :: error | {:ok, Emoji.t}
+  def create_guild_emoji(guild_id, params)
+  def create_guild_emoji(guild_id, params) when is_list(params), 
+    do: create_guild_emoji(guild_id, Map.new(params))
+
+  def create_guild_emoji(guild_id, %{} = params) do
+    request(:post, Constants.guild_emojis(guild_id), params)
+    |> handle_request_with_decode({:struct, Emoji})
+  end
+
+  @doc ~S"""
+  Same as `create_guild_emoji/2`, but raises `Nostrum.Error.ApiError` in case of failure.
+  """
+  @spec create_guild_emoji!(Guild.id, keyword | map) :: no_return | Emoji.t
+  def create_guild_emoji!(guild_id, params) do
+    create_guild_emoji(guild_id, params)
+    |> bangify
+  end
+
+  @doc ~S"""
+  Modify the given emoji.
+
+  ## Request Params
+
+  The following params are optional:
+
+    * `:name` (string) - name of the emoji
+    * `:roles` (list of `t:Nostrum.Struct.Snowflake.t/0`) - roles to which this emoji will be whitelisted
+
+  ## Return Values
+
+  If the request is successful, this function returns `{:ok, emoji}`, where 
+  `emoji` is a `Nostrum.Struct.Emoji`. Otherwise, returns `{:error, reason}`.
+
+  ## Examples
+
+  ```Elixir
+  Nostrum.Api.modify_guild_emoji(43189401384091, 4314301984301, name: "elixir", roles: [])
+  ```
+  """
+  @spec modify_guild_emoji(Guild.id, Emoji.id, keyword | map) :: error | {:ok, Emoji.t}
+  def modify_guild_emoji(guild_id, emoji_id, params \\ %{})
+  def modify_guild_emoji(guild_id, emoji_id, params) when is_list(params), 
+    do: modify_guild_emoji(guild_id, emoji_id, Map.new(params))
+
+  def modify_guild_emoji(guild_id, emoji_id, %{} = params) do
+    request(:patch, Constants.guild_emoji(guild_id, emoji_id), params)
+    |> handle_request_with_decode({:struct, Emoji})
+  end
+
+  @doc ~S"""
+  Same as `modify_guild_emoji/3`, but raises `Nostrum.Error.ApiError` in case of failure.
+  """
+  @spec modify_guild_emoji!(Guild.id, Emoji.id, keyword | map) :: no_return | Emoji.t
+  def modify_guild_emoji!(guild_id, emoji_id, params) do
+    modify_guild_emoji(guild_id, emoji_id, params)
+    |> bangify
+  end
+
+  @doc ~S"""
+  Deletes the given emoji.
+
+  If the request is successful, this function returns `{:ok}`. 
+  Otherwise, returns `{:error, reason}`.
+  """
+  @spec delete_guild_emoji(Guild.id, Emoji.id) :: error | {:ok}
+  def delete_guild_emoji(guild_id, emoji_id), 
+    do: request(:delete, Constants.guild_emoji(guild_id, emoji_id))
+
+  @doc ~S"""
+  Same as `delete_guild_emoji/2`, but raises `Nostrum.Error.ApiError` in case of failure.
+  """
+  @spec delete_guild_emoji!(Guild.id, Emoji.id) :: no_return | {:ok}
+  def delete_guild_emoji!(guild_id, emoji_id) do
+    delete_guild_emoji(guild_id, emoji_id)
+    |> bangify
+  end
+
   @doc """
   Gets a guild using the REST api
 

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -876,16 +876,14 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Creates a new emoji for the given guild.
 
-  ## Request Params
- 
-  The following params are required: 
+  ## Options 
  
     * `:name` (string) - name of the emoji
     * `:image` (base64 data URI) - the 128x128 emoji image. Maximum size of 256kb
-  
-  The following params are optional:
-
     * `:roles` (list of `t:Nostrum.Struct.Snowflake.t/0`) - roles for which this emoji will be whitelisted
+    (default: [])
+
+  `:name` and `:image` are always required.
 
   ## Return Values
 
@@ -901,12 +899,12 @@ defmodule Nostrum.Api do
   ```
   """
   @spec create_guild_emoji(Guild.id, keyword | map) :: error | {:ok, Emoji.t}
-  def create_guild_emoji(guild_id, params)
-  def create_guild_emoji(guild_id, params) when is_list(params), 
-    do: create_guild_emoji(guild_id, Map.new(params))
+  def create_guild_emoji(guild_id, options)
+  def create_guild_emoji(guild_id, options) when is_list(options), 
+    do: create_guild_emoji(guild_id, Map.new(options))
 
-  def create_guild_emoji(guild_id, %{} = params) do
-    request(:post, Constants.guild_emojis(guild_id), params)
+  def create_guild_emoji(guild_id, %{} = options) do
+    request(:post, Constants.guild_emojis(guild_id), options)
     |> handle_request_with_decode({:struct, Emoji})
   end
 
@@ -922,9 +920,7 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Modify the given emoji.
 
-  ## Request Params
-
-  The following params are optional:
+  ## Options
 
     * `:name` (string) - name of the emoji
     * `:roles` (list of `t:Nostrum.Struct.Snowflake.t/0`) - roles to which this emoji will be whitelisted
@@ -941,12 +937,12 @@ defmodule Nostrum.Api do
   ```
   """
   @spec modify_guild_emoji(Guild.id, Emoji.id, keyword | map) :: error | {:ok, Emoji.t}
-  def modify_guild_emoji(guild_id, emoji_id, params \\ %{})
-  def modify_guild_emoji(guild_id, emoji_id, params) when is_list(params), 
-    do: modify_guild_emoji(guild_id, emoji_id, Map.new(params))
+  def modify_guild_emoji(guild_id, emoji_id, options \\ %{})
+  def modify_guild_emoji(guild_id, emoji_id, options) when is_list(options), 
+    do: modify_guild_emoji(guild_id, emoji_id, Map.new(options))
 
-  def modify_guild_emoji(guild_id, emoji_id, %{} = params) do
-    request(:patch, Constants.guild_emoji(guild_id, emoji_id), params)
+  def modify_guild_emoji(guild_id, emoji_id, %{} = options) do
+    request(:patch, Constants.guild_emoji(guild_id, emoji_id), options)
     |> handle_request_with_decode({:struct, Emoji})
   end
 
@@ -954,8 +950,8 @@ defmodule Nostrum.Api do
   Same as `modify_guild_emoji/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @spec modify_guild_emoji!(Guild.id, Emoji.id, keyword | map) :: no_return | Emoji.t
-  def modify_guild_emoji!(guild_id, emoji_id, params) do
-    modify_guild_emoji(guild_id, emoji_id, params)
+  def modify_guild_emoji!(guild_id, emoji_id, options) do
+    modify_guild_emoji(guild_id, emoji_id, options)
     |> bangify
   end
 
@@ -1608,9 +1604,7 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Changes the username or avatar of the current user.
 
-  ## Params 
- 
-  The following params are optional: 
+  ## Options 
  
     * `:username` (string) - new username
     * `:avatar` (string) - the user's avatar as [avatar data](https://discordapp.com/developers/docs/resources/user#avatar-data)
@@ -1622,11 +1616,12 @@ defmodule Nostrum.Api do
   ```
   """
   @spec modify_current_user(keyword | map) :: error | {:ok, User.t}
-  def modify_current_user(params)
-  def modify_current_user(params) when is_list(params), do: modify_current_user(Map.new(params))
+  def modify_current_user(options)
+  def modify_current_user(options) when is_list(options), 
+    do: modify_current_user(Map.new(options))
 
-  def modify_current_user(%{} = params) do
-    request(:patch, Constants.me, params)
+  def modify_current_user(%{} = options) do
+    request(:patch, Constants.me, options)
     |> handle_request_with_decode({:struct, User})
   end
 
@@ -1634,8 +1629,8 @@ defmodule Nostrum.Api do
   Same as `modify_current_user/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @spec modify_current_user!(keyword | map) :: no_return | User.t
-  def modify_current_user!(params) do
-    modify_current_user(params)
+  def modify_current_user!(options) do
+    modify_current_user(options)
     |> bangify
   end
 

--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -147,6 +147,8 @@ defmodule Nostrum.Api.Ratelimiter do
         {:error, %{status_code: nil, message: reason}}
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, body}
+      {:ok, %HTTPoison.Response{status_code: 201, body: body}} ->
+        {:ok, body}
       {:ok, %HTTPoison.Response{status_code: 204}} ->
         {:ok}
       {:ok, %HTTPoison.Response{status_code: status_code, body: body}} ->

--- a/lib/nostrum/constants.ex
+++ b/lib/nostrum/constants.ex
@@ -37,6 +37,8 @@ defmodule Nostrum.Constants do
   def guild_integration(guild_id, integration_id),                do: "/guilds/#{guild_id}/integrations/#{integration_id}"
   def guild_integration_sync(guild_id, integration_id),           do: "/guilds/#{guild_id}/integrations/#{integration_id}/sync"
   def guild_embed(guild_id),                                      do: "/guilds/#{guild_id}/embed"
+  def guild_emojis(guild_id),                                     do: "/guilds/#{guild_id}/emojis"
+  def guild_emoji(guild_id, emoji_id),                            do: "/guilds/#{guild_id}/emojis/#{emoji_id}"
 
   def webhooks_guild(guild_id),                                   do: "/guilds/#{guild_id}/webhooks"
   def webhooks_channel(channel_id),                               do: "/channels/#{channel_id}/webhooks"

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -1,6 +1,23 @@
 defmodule Nostrum.Struct.Emoji do
-  @moduledoc """
+  @moduledoc ~S"""
   Struct representing a Discord emoji.
+
+  ## Using Emojis in Messages
+
+  A `Nostrum.Struct.Emoji` can be used in message content using the `String.Chars` 
+  protocol or `format_mention/1`. We highly recommend using the `String.Chars` protocol 
+  instead of the latter.
+
+  ```Elixir
+  emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
+
+  Nostrum.Api.create_message!(189098431762321, "#{emoji}")
+  Nostrum.Api.create_message!(189098431762321, "#{Nostrum.Struct.Emoji.format_mention(emoji)}")
+  ```
+
+  ## Using Emojis in the Api
+
+  See `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
   """
 
   alias Nostrum.Struct.Snowflake
@@ -28,7 +45,7 @@ defmodule Nostrum.Struct.Emoji do
     * A base 16 unicode emoji string.
     * A URI encoded string.
 
-  We suggest library users to use the `to_api_name/1` function to get a 
+  We suggest library users to use the `get_api_name/1` function to get a 
   `Nostrum.Struct.Emoji`'s emoji api name.
 
   ## Examples
@@ -44,7 +61,7 @@ defmodule Nostrum.Struct.Emoji do
 
   # All Emojis
   emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
-  Nostrum.Struct.Emoji.to_api_name(emoji)
+  Nostrum.Struct.Emoji.get_api_name(emoji)
   "foxbot:43819043108"
   ```
 
@@ -83,24 +100,28 @@ defmodule Nostrum.Struct.Emoji do
   }
 
   @doc ~S"""
-  Formats an emoji struct into its respective markdown.
+  Formats an emoji struct into an emoji mention.
+
+  Because `Nostrum.Struct.Emoji` implements the `String.Chars` protocol, we 
+  recommend nostrum users to use `String.Chars` instead of this function.
+  See `Nostrum.Struct.Emoji` for more information.
 
   ## Examples
 
   ```Elixir
   emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
 
-  Nostrum.Struct.Emoji.format(emoji)
+  Nostrum.Struct.Emoji.format_mention(emoji)
   "<:foxbot:43819043108>"
 
-  Nostrum.Api.create_message!(4318940318049, "Sending some text with this emoji #{Nostrum.Struct.Emoji.format(emoji)}")
+  Nostrum.Api.create_message!(4318940318049, "Sending some text with this emoji #{Nostrum.Struct.Emoji.format_mention(emoji)}")
   ```
   """
-  @spec format(t) :: String.t
-  def format(emoji)
-  def format(%__MODULE__{id: nil, name: name}), do: name
-  def format(%__MODULE__{animated: true, id: id, name: name}), do: "<a:#{name}:#{id}>"
-  def format(%__MODULE__{id: id, name: name}), do: "<:#{name}:#{id}>"
+  @spec format_mention(t) :: String.t
+  def format_mention(emoji)
+  def format_mention(%__MODULE__{id: nil, name: name}), do: name
+  def format_mention(%__MODULE__{animated: true, id: id, name: name}), do: "<a:#{name}:#{id}>"
+  def format_mention(%__MODULE__{id: id, name: name}), do: "<:#{name}:#{id}>"
 
   @doc ~S"""
   Formats an emoji struct into its `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
@@ -110,17 +131,17 @@ defmodule Nostrum.Struct.Emoji do
   ```Elixir
   emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
 
-  api_name = Nostrum.Struct.Emoji.to_api_name(emoji)
+  api_name = Nostrum.Struct.Emoji.get_api_name(emoji)
   "foxbot:43819043108"
 
   Nostrum.Api.create_reaction(471635274857, 47361625345554, api_name)
   {:ok}
   ```
   """
-  @spec to_api_name(t) :: emoji_api_name
-  def to_api_name(emoji)
-  def to_api_name(%__MODULE__{id: nil, name: name}), do: name
-  def to_api_name(%__MODULE__{id: id, name: name}), do: "#{name}:#{id}"
+  @spec get_api_name(t) :: emoji_api_name
+  def get_api_name(emoji)
+  def get_api_name(%__MODULE__{id: nil, name: name}), do: name
+  def get_api_name(%__MODULE__{id: id, name: name}), do: "#{name}:#{id}"
 
   @doc false
   def p_encode do
@@ -137,5 +158,13 @@ defmodule Nostrum.Struct.Emoji do
       |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
 
     struct(__MODULE__, new)
+  end
+end
+
+defimpl String.Chars, for: Nostrum.Struct.Emoji do
+  alias Nostrum.Struct.Emoji
+
+  def to_string(emoji) do
+    Emoji.format_mention(emoji)
   end
 end

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -90,17 +90,17 @@ defmodule Nostrum.Struct.Emoji do
   ```Elixir
   emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
 
-  Nostrum.Struct.Emoji.to_markdown(emoji)
+  Nostrum.Struct.Emoji.format(emoji)
   "<:foxbot:43819043108>"
 
-  Nostrum.Api.create_message!(4318940318049, "Sending some text with this emoji #{Nostrum.Struct.Emoji.to_markdown(emoji)}")
+  Nostrum.Api.create_message!(4318940318049, "Sending some text with this emoji #{Nostrum.Struct.Emoji.format(emoji)}")
   ```
   """
-  @spec to_markdown(t) :: String.t
-  def to_markdown(emoji)
-  def to_markdown(%{id: nil, name: name}), do: name
-  def to_markdown(%{animated: true, id: id, name: name}), do: "<a:#{name}:#{id}>"
-  def to_markdown(%{id: id, name: name}), do: "<:#{name}:#{id}>"
+  @spec format(t) :: String.t
+  def format(emoji)
+  def format(%__MODULE__{id: nil, name: name}), do: name
+  def format(%__MODULE__{animated: true, id: id, name: name}), do: "<a:#{name}:#{id}>"
+  def format(%__MODULE__{id: id, name: name}), do: "<:#{name}:#{id}>"
 
   @doc ~S"""
   Formats an emoji struct into its `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
@@ -119,8 +119,8 @@ defmodule Nostrum.Struct.Emoji do
   """
   @spec to_api_name(t) :: emoji_api_name
   def to_api_name(emoji)
-  def to_api_name(%{id: nil, name: name}), do: name
-  def to_api_name(%{id: id, name: name}), do: "#{name}:#{id}"
+  def to_api_name(%__MODULE__{id: nil, name: name}), do: name
+  def to_api_name(%__MODULE__{id: id, name: name}), do: "#{name}:#{id}"
 
   @doc false
   def p_encode do

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -4,8 +4,8 @@ defmodule Nostrum.Struct.Emoji do
 
   ## Using Emojis in Messages
 
-  A `Nostrum.Struct.Emoji` can be used in message content using the `String.Chars` 
-  protocol or `format_mention/1`. We highly recommend using the `String.Chars` protocol 
+  A `Nostrum.Struct.Emoji` can be used in message content using the `String.Chars`
+  protocol or `format_mention/1`. We highly recommend using the `String.Chars` protocol
   instead of the latter.
 
   ```Elixir
@@ -41,15 +41,14 @@ defmodule Nostrum.Struct.Emoji do
   @typedoc ~S"""
   Emoji string to be used with the Discord API.
 
-  Some API endpoints take an `emoji`. If it is a custom emoji, it must be 
-  structured as `"id:name"`. If it is an unicode emoji, it can be structured 
-  as any of the following: 
+  Some API endpoints take an `emoji`. If it is a custom emoji, it must be
+  structured as `"id:name"`. If it is an unicode emoji, it can be structured
+  as any of the following:
 
     * `"name"`
     * A base 16 unicode emoji string.
-    * A URI encoded string.
 
-  We suggest library users to use the `get_api_name/1` function to get a 
+  We suggest library users to use the `get_api_name/1` function to get a
   `Nostrum.Struct.Emoji`'s emoji api name.
 
   ## Examples
@@ -61,7 +60,7 @@ defmodule Nostrum.Struct.Emoji do
   # Unicode Emojis
   "≡ƒæì"
   "\xF0\x9F\x98\x81"
-  URI.encode("\u2b50")
+  "\u2b50"
 
   # All Emojis
   emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
@@ -106,7 +105,7 @@ defmodule Nostrum.Struct.Emoji do
   @doc ~S"""
   Formats an emoji struct into an emoji mention.
 
-  Because `Nostrum.Struct.Emoji` implements the `String.Chars` protocol, we 
+  Because `Nostrum.Struct.Emoji` implements the `String.Chars` protocol, we
   recommend nostrum users to use `String.Chars` instead of this function.
   See `Nostrum.Struct.Emoji` for more information.
 

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -34,6 +34,10 @@ defmodule Nostrum.Struct.Emoji do
     :roles
   ]
 
+  defimpl String.Chars do
+    def to_string(emoji), do: @for.format_mention(emoji)
+  end
+
   @typedoc ~S"""
   Emoji string to be used with the Discord API.
 
@@ -158,13 +162,5 @@ defmodule Nostrum.Struct.Emoji do
       |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
 
     struct(__MODULE__, new)
-  end
-end
-
-defimpl String.Chars, for: Nostrum.Struct.Emoji do
-  alias Nostrum.Struct.Emoji
-
-  def to_string(emoji) do
-    Emoji.format_mention(emoji)
   end
 end

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -17,12 +17,37 @@ defmodule Nostrum.Struct.Emoji do
     :roles
   ]
 
-  @typedoc """
+  @typedoc ~S"""
   Emoji string to be used with the Discord API.
 
-  Some API endpoints take an `emoji`. This `emoji` string should be structured as `"id:name"`.
+  Some API endpoints take an `emoji`. If it is a custom emoji, it must be 
+  structured as `"id:name"`. If it is an unicode emoji, it can be structured 
+  as any of the following: 
 
-  Alternatively, the `to_api_name/1` function will convert a `Nostrum.Struct.Emoji` to this string.
+    * `"name"`
+    * A base 16 unicode emoji string.
+    * A URI encoded string.
+
+  We suggest library users to use the `to_api_name/1` function to get a 
+  `Nostrum.Struct.Emoji`'s emoji api name.
+
+  ## Examples
+
+  ```Elixir
+  # Custom Emojis
+  "nostrum:431890438091489"
+
+  # Unicode Emojis
+  "≡ƒæì"
+  "\xF0\x9F\x98\x81"
+  URI.encode("\u2b50")
+
+  # All Emojis
+  emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
+  Nostrum.Struct.Emoji.to_api_name(emoji)
+  "foxbot:43819043108"
+  ```
+
   """
   @type emoji_api_name :: String.t
 
@@ -38,7 +63,7 @@ defmodule Nostrum.Struct.Emoji do
   @typedoc "User that created this emoji"
   @type user :: User.t | nil
 
-  @typedoc "Whether this emoji must be wrapped in colons "
+  @typedoc "Whether this emoji must be wrapped in colons"
   @type require_colons :: boolean | nil
 
   @typedoc "Whether this emoji is managed"
@@ -59,22 +84,43 @@ defmodule Nostrum.Struct.Emoji do
 
   @doc """
   Formats an emoji struct into its respective markdown.
+
+  ## Examples
+
+  ```Elixir
+  emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
+
+  md = Nostrum.Struct.Emoji.to_markdown(emoji)
+  "<:foxbot:43819043108>"
+
+  Nostrum.Api.create_message!(4318940318049, "Sending some text with this emoji #{md}")
+  ```
   """
   @spec to_markdown(t) :: String.t
   def to_markdown(emoji)
-  def to_markdown(%__MODULE__{id: nil, name: name}), do: name
-  def to_markdown(%__MODULE__{animated: true, id: id, name: name}), do: "<a:#{name}:#{id}>"
-  def to_markdown(%__MODULE__{id: id, name: name}), do: "<:#{name}:#{id}>"
+  def to_markdown(%{id: nil, name: name}), do: name
+  def to_markdown(%{animated: true, id: id, name: name}), do: "<a:#{name}:#{id}>"
+  def to_markdown(%{id: id, name: name}), do: "<:#{name}:#{id}>"
 
   @doc """
-  Formats an emoji struct into its api name.
+  Formats an emoji struct into its `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
 
-  An emoji's api name is used to represent emojis in Discord API calls.
+  ## Examples
+
+  ```Elixir
+  emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
+
+  api_name = Nostrum.Struct.Emoji.to_api_name(emoji)
+  "foxbot:43819043108"
+
+  Nostrum.Api.create_reaction(471635274857, 47361625345554, api_name)
+  {:ok}
+  ```
   """
   @spec to_api_name(t) :: emoji_api_name
   def to_api_name(emoji)
-  def to_api_name(%__MODULE__{id: nil, name: name}), do: name
-  def to_api_name(%__MODULE__{id: id, name: name}), do: "#{name}:#{id}"
+  def to_api_name(%{id: nil, name: name}), do: name
+  def to_api_name(%{id: id, name: name}), do: "#{name}:#{id}"
 
   @doc false
   def p_encode do

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -82,7 +82,7 @@ defmodule Nostrum.Struct.Emoji do
     animated: animated
   }
 
-  @doc """
+  @doc ~S"""
   Formats an emoji struct into its respective markdown.
 
   ## Examples
@@ -90,10 +90,10 @@ defmodule Nostrum.Struct.Emoji do
   ```Elixir
   emoji = %Nostrum.Struct.Emoji{id: 43819043108, name: "foxbot"}
 
-  md = Nostrum.Struct.Emoji.to_markdown(emoji)
+  Nostrum.Struct.Emoji.to_markdown(emoji)
   "<:foxbot:43819043108>"
 
-  Nostrum.Api.create_message!(4318940318049, "Sending some text with this emoji #{md}")
+  Nostrum.Api.create_message!(4318940318049, "Sending some text with this emoji #{Nostrum.Struct.Emoji.to_markdown(emoji)}")
   ```
   """
   @spec to_markdown(t) :: String.t
@@ -102,7 +102,7 @@ defmodule Nostrum.Struct.Emoji do
   def to_markdown(%{animated: true, id: id, name: name}), do: "<a:#{name}:#{id}>"
   def to_markdown(%{id: id, name: name}), do: "<:#{name}:#{id}>"
 
-  @doc """
+  @doc ~S"""
   Formats an emoji struct into its `t:Nostrum.Struct.Emoji.emoji_api_name/0`.
 
   ## Examples
@@ -125,15 +125,6 @@ defmodule Nostrum.Struct.Emoji do
   @doc false
   def p_encode do
     %__MODULE__{}
-  end
-
-  @doc """
-  Formats a custom emoji for use in a Discord message.
-  """
-  @spec format_custom_emoji(String.t, String.t | integer) :: String.t
-  def format_custom_emoji(name, id) when is_binary(id), do: "<:" <> name <> ":" <> id <> ">"
-  def format_custom_emoji(name, id) do
-    "<:" <> name <> ":" <> to_string(id) <> ">"
   end
 
   @doc false

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -258,11 +258,11 @@ defmodule Nostrum.Util do
     ]
   end
 
-  @spec struct_get_in(map, [atom]) :: term 
-  defp struct_get_in(value, keys) 
-  defp struct_get_in(value, []), do: value 
- 
-  defp struct_get_in(value, [key | rest]) do 
-    struct_get_in(Map.fetch!(value, key), rest) 
+  @spec struct_get_in(map, [atom]) :: term
+  defp struct_get_in(value, keys)
+  defp struct_get_in(value, []), do: value
+
+  defp struct_get_in(value, [key | rest]) do
+    struct_get_in(Map.fetch!(value, key), rest)
   end
 end


### PR DESCRIPTION
This PR focuses on correcting the Api by cleaning up the pre-existing structs.

This PR does the following:

1. Cleans up the emoji struct by organizing it. Additionally, it adds more documentation to the Emoji module's elements.
2. Corrects specs in the Api module regarding Emojis.
3. Adds a couple of utility functions in the Emoji module for helping library users use Emojis with the Api.
4. Fixes the Emoji struct assembly process when reading outside data (converting snowflakes, other structs, etc.)

Notes:

1. I think `delete_reaction/4` in the Api does not have a matching name with the corresponding Discord Api endpoint (DELETE USER REACTION). This is a minor problem, but we could try renaming this function to match it with the endpoint name.
2. I added `to_api_name/1` and `to_markdown/1` in the Emoji module to help lib users use Emoji structs with the Api. I'm thinking of potentially renaming these to `get_api_name/1` and `format_markdown/1`. Up for discussion.
3. `format_custom_emoji/2` in the Emoji module does not seem to be useful from my perspective. Potential deprecation or removal?
4. I ended up renaming the `custom_emoji` type in favor of `emoji_api_name`. I think the latter is more representative of the type's purpose. It also lets us cover the api names of all emojis (not just custom ones).

TODO:

- Investigate URL encoding
- Reduce low-level binding of Emoji functions.
