### PR TITLE
Cleanup for Embeds and its components

### DIFF
--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -16,12 +16,11 @@ defmodule Nostrum.Struct.Embed do
     |> put_url("https://google.com/")
     |> put_timestamp("2016-05-05T21:04:13.203Z")
     |> put_color(431_948)
-    |> add_field("Field 1", "Test")
-    |> add_field("Field 2", "More test", true)
+    |> put_field("Field 1", "Test")
+    |> put_field("Field 2", "More test", true)
   ```
 
-  Alternatively, it is possible to build `Nostrum.Struct.Embed`s using standard map syntax.
-  However, we recommend sticking to the aforementioned builder functions.
+  Alternatively, `Nostrum.Struct.Embed`s can be built using standard map syntax.
 
   ```Elixir
   embed = %Nostrum.Struct.Embed{
@@ -243,10 +242,10 @@ defmodule Nostrum.Struct.Embed do
   @doc ~S"""
   Adds a `Nostrum.Struct.Embed.Field` under `:fields` in `embed`.
   """
-  @spec add_field(t, Field.name(), Field.value(), Field.inline()) :: t
-  def add_field(embed, name, value, inline \\ nil)
+  @spec put_field(t, Field.name(), Field.value(), Field.inline()) :: t
+  def put_field(embed, name, value, inline \\ nil)
 
-  def add_field(%__MODULE__{fields: fields} = embed, name, value, inline) when is_list(fields) do
+  def put_field(%__MODULE__{fields: fields} = embed, name, value, inline) when is_list(fields) do
     field = %Field{
       name: name,
       value: value,
@@ -256,8 +255,8 @@ defmodule Nostrum.Struct.Embed do
     %__MODULE__{embed | fields: fields ++ [field]}
   end
 
-  def add_field(embed, name, value, inline) do
-    add_field(%__MODULE__{embed | fields: []}, name, value, inline)
+  def put_field(embed, name, value, inline) do
+    put_field(%__MODULE__{embed | fields: []}, name, value, inline)
   end
 
   # TODO: Jump down the rabbit hole

--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -87,6 +87,144 @@ defmodule Nostrum.Struct.Embed do
           fields: fields
         }
 
+  @doc ~S"""
+  Puts the given `value` under `:title` in `embed`.
+  """
+  @spec put_title(t, title) :: t
+  def put_title(%__MODULE__{} = embed, value) do
+    %__MODULE__{embed | title: value}
+  end
+
+  @doc false
+  @spec put_type(t, type) :: t
+  def put_type(%__MODULE__{} = embed, value) do
+    %__MODULE__{embed | type: value}
+  end
+
+  @doc ~S"""
+  Puts the given `value` under `:description` in `embed`.
+  """
+  @spec put_description(t, description) :: t
+  def put_description(%__MODULE__{} = embed, value) do
+    %__MODULE__{embed | description: value}
+  end
+
+  @doc ~S"""
+  Puts the given `value` under `:url` in `embed`.
+  """
+  @spec put_url(t, url) :: t
+  def put_url(%__MODULE__{} = embed, value) do
+    %__MODULE__{embed | url: value}
+  end
+
+  @doc ~S"""
+  Puts the given `value` under `:timestamp` in `embed`.
+  """
+  @spec put_timestamp(t, timestamp) :: t
+  def put_timestamp(%__MODULE__{} = embed, value) do
+    %__MODULE__{embed | timestamp: value}
+  end
+
+  @doc ~S"""
+  Puts the given `value` under `:color` in `embed`.
+  """
+  @spec put_color(t, color) :: t
+  def put_color(%__MODULE__{} = embed, value) do
+    %__MODULE__{embed | color: value}
+  end
+
+  @doc ~S"""
+  Puts a `Nostrum.Struct.Embed.Footer` under `:footer` in `embed`.
+  """
+  @spec put_footer(t, Footer.text(), Footer.icon_url()) :: t
+  def put_footer(%__MODULE__{} = embed, text, icon_url) do
+    footer = %Footer{
+      text: text,
+      icon_url: icon_url
+    }
+
+    %__MODULE__{embed | footer: footer}
+  end
+
+  @doc ~S"""
+  Puts a `Nostrum.Struct.Embed.Image` under `:image` in `embed`.
+  """
+  @spec put_image(t, Image.url()) :: t
+  def put_image(%__MODULE__{} = embed, url) do
+    image = %Image{
+      url: url
+    }
+
+    %__MODULE__{embed | image: image}
+  end
+
+  @doc ~S"""
+  Puts a `Nostrum.Struct.Embed.Thumbnail` under `:thumbnail` in `embed`.
+  """
+  @spec put_thumbnail(t, Thumbnail.url()) :: t
+  def put_thumbnail(%__MODULE__{} = embed, url) do
+    thumbnail = %Thumbnail{
+      url: url
+    }
+
+    %__MODULE__{embed | thumbnail: thumbnail}
+  end
+
+  @doc false
+  @spec put_video(t, Video.url()) :: t
+  def put_video(%__MODULE__{} = embed, url) do
+    video = %Video{
+      url: url
+    }
+
+    %__MODULE__{embed | video: video}
+  end
+
+  @doc false
+  @spec put_provider(t, Provider.name(), Provider.url()) :: t
+  def put_provider(%__MODULE__{} = embed, name, url) do
+    provider = %Provider{
+      name: name,
+      url: url
+    }
+
+    %__MODULE__{embed | provider: provider}
+  end
+
+  @doc ~S"""
+  Puts a `Nostrum.Struct.Embed.Author` under `:author` in `embed`.
+  """
+  @spec put_author(t, Author.name(), Author.url(), Author.icon_url()) :: t
+  def put_author(%__MODULE__{} = embed, name, url, icon_url) do
+    author = %Author{
+      name: name,
+      url: url,
+      icon_url: icon_url
+    }
+
+    %__MODULE__{embed | author: author}
+  end
+
+  @doc ~S"""
+  Adds a `Nostrum.Struct.Embed.Field` under `:fields` in `embed`.
+  """
+  @spec add_field(t, Field.name(), Field.value(), Field.inline()) :: t
+  def add_field(embed, name, value, inline \\ nil)
+
+  def add_field(%__MODULE__{fields: fields} = embed, name, value, inline) when is_list(fields) do
+    field = %Field{
+      name: name,
+      value: value,
+      inline: inline
+    }
+
+    %__MODULE__{embed | fields: fields ++ [field]}
+  end
+
+  def add_field(embed, name, value, inline) do
+    add_field(%__MODULE__{embed | fields: []}, name, value, inline)
+  end
+
   # TODO: Jump down the rabbit hole
   def p_encode do
     %__MODULE__{}

--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -261,6 +261,7 @@ defmodule Nostrum.Struct.Embed do
   end
 
   # TODO: Jump down the rabbit hole
+  @doc false
   def p_encode do
     %__MODULE__{}
   end

--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -4,7 +4,7 @@ defmodule Nostrum.Struct.Embed do
 
   ## Building Embeds
 
-  `Nostrum.Struct.Embed`s can be built using this module's "builder functions":
+  `Nostrum.Struct.Embed`s can be built using this module's builder functions:
 
   ```Elixir
   import Nostrum.Struct.Embed
@@ -21,7 +21,7 @@ defmodule Nostrum.Struct.Embed do
   ```
 
   Alternatively, it is possible to build `Nostrum.Struct.Embed`s using standard map syntax.
-  However, we recommend sticking to the aforementioned "builder functions".
+  However, we recommend sticking to the aforementioned builder functions.
 
   ```Elixir
   embed = %Nostrum.Struct.Embed{

--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -6,44 +6,70 @@ defmodule Nostrum.Struct.Embed do
   alias Nostrum.Struct.Embed.{Author, Field, Footer, Image, Provider, Thumbnail, Video}
   alias Nostrum.Util
 
+  defstruct [
+    :title,
+    :type,
+    :description,
+    :url,
+    :timestamp,
+    :color,
+    :footer,
+    :image,
+    :thumbnail,
+    :video,
+    :provider,
+    :author,
+    :fields
+  ]
+
+  defimpl Poison.Encoder do
+    def encode(embed, options) do
+      embed
+      |> Map.from_struct()
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Map.new()
+      |> Poison.Encoder.encode(options)
+    end
+  end
+
   @typedoc "Title of the embed"
-  @type title :: String.t()
+  @type title :: String.t() | nil
 
   @typedoc "Type of the embed"
-  @type type :: String.t()
+  @type type :: String.t() | nil
 
   @typedoc "Description of the embed"
-  @type description :: String.t()
+  @type description :: String.t() | nil
 
   @typedoc "Url of the embed"
-  @type url :: String.t()
+  @type url :: String.t() | nil
 
   @typedoc "Timestamp of embed content"
-  @type timestamp :: String.t()
+  @type timestamp :: String.t() | nil
 
   @typedoc "Color code of the embed"
-  @type color :: Integer.t()
+  @type color :: Integer.t() | nil
 
   @typedoc "Footer information"
-  @type footer :: Footer.t()
+  @type footer :: Footer.t() | nil
 
   @typedoc "Image information"
-  @type image :: Image.t()
+  @type image :: Image.t() | nil
 
   @typedoc "Thumbnail information"
-  @type thumbnail :: Thumbnail.t()
+  @type thumbnail :: Thumbnail.t() | nil
 
   @typedoc "Video information"
-  @type video :: Video.t()
+  @type video :: Video.t() | nil
 
   @typedoc "Provider information"
-  @type provider :: Provider.t()
+  @type provider :: Provider.t() | nil
 
   @typedoc "Author information"
-  @type author :: Author.t()
+  @type author :: Author.t() | nil
 
   @typedoc "Fields information"
-  @type fields :: [Field.t()]
+  @type fields :: [Field.t()] | nil
 
   @type t :: %__MODULE__{
           title: title,
@@ -61,23 +87,6 @@ defmodule Nostrum.Struct.Embed do
           fields: fields
         }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :title,
-    :type,
-    :description,
-    :url,
-    :timestamp,
-    :color,
-    :footer,
-    :image,
-    :thumbnail,
-    :video,
-    :provider,
-    :author,
-    :fields
-  ]
-
   # TODO: Jump down the rabbit hole
   def p_encode do
     %__MODULE__{}
@@ -87,13 +96,14 @@ defmodule Nostrum.Struct.Embed do
   def to_struct(map) do
     new =
       map
-      |> Map.update(:footer, %{}, &Footer.to_struct(&1))
-      |> Map.update(:image, %{}, &Image.to_struct(&1))
-      |> Map.update(:thumbnail, %{}, &Thumbnail.to_struct(&1))
-      |> Map.update(:video, %{}, &Video.to_struct(&1))
-      |> Map.update(:provider, %{}, &Provider.to_struct(&1))
-      |> Map.update(:author, %{}, &Author.to_struct(&1))
-      |> Map.update(:fields, %{}, &Util.list_to_struct_list(&1, Field))
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:footer, nil, &Util.cast(&1, {:struct, Footer}))
+      |> Map.update(:image, nil, &Util.cast(&1, {:struct, Image}))
+      |> Map.update(:thumbnail, nil, &Util.cast(&1, {:struct, Thumbnail}))
+      |> Map.update(:video, nil, &Util.cast(&1, {:struct, Video}))
+      |> Map.update(:provider, nil, &Util.cast(&1, {:struct, Provider}))
+      |> Map.update(:author, nil, &Util.cast(&1, {:struct, Author}))
+      |> Map.update(:fields, nil, &Util.cast(&1, {:list, {:struct, Field}}))
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -1,6 +1,41 @@
 defmodule Nostrum.Struct.Embed do
-  @moduledoc """
-  Struct representing a Discord embed.
+  @moduledoc ~S"""
+  Functions that work on Discord embeds.
+
+  ## Building Embeds
+
+  `Nostrum.Struct.Embed`s can be built using this module's "builder functions":
+
+  ```Elixir
+  import Nostrum.Struct.Embed
+
+  embed =
+    %Nostrum.Struct.Embed{}
+    |> put_title("craig")
+    |> put_description("nostrum")
+    |> put_url("https://google.com/")
+    |> put_timestamp("2016-05-05T21:04:13.203Z")
+    |> put_color(431_948)
+    |> add_field("Field 1", "Test")
+    |> add_field("Field 2", "More test", true)
+  ```
+
+  Alternatively, it is possible to build `Nostrum.Struct.Embed`s using standard map syntax.
+  However, we recommend sticking to the aforementioned "builder functions".
+
+  ```Elixir
+  embed = %Nostrum.Struct.Embed{
+    title: "craig",
+    description: "nostrum",
+    url: "https://google.com/",
+    timestamp: "2016-05-05T21:04:13.203Z",
+    color: 431_948,
+    fields: [
+      %Nostrum.Struct.Embed.Field{name: "Field 1", value: "Test"},
+      %Nostrum.Struct.Embed.Field{name: "Field 2", value: "More test", inline: true}
+    ]
+  }
+  ```
   """
 
   alias Nostrum.Struct.Embed.{Author, Field, Footer, Image, Provider, Thumbnail, Video}

--- a/lib/nostrum/struct/embed/author.ex
+++ b/lib/nostrum/struct/embed/author.ex
@@ -3,17 +3,36 @@ defmodule Nostrum.Struct.Embed.Author do
   Struct representing a Discord embed author.
   """
 
+  alias Nostrum.Util
+
+  defstruct [
+    :name,
+    :url,
+    :icon_url,
+    :proxy_icon_url
+  ]
+
+  defimpl Poison.Encoder do
+    def encode(author, options) do
+      author
+      |> Map.from_struct()
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Map.new()
+      |> Poison.Encoder.encode(options)
+    end
+  end
+
   @typedoc "Name of the author"
-  @type name :: String.t()
+  @type name :: String.t() | nil
 
   @typedoc "URL of the author"
-  @type url :: String.t()
+  @type url :: String.t() | nil
 
   @typedoc "URL of the author icon"
-  @type icon_url :: String.t()
+  @type icon_url :: String.t() | nil
 
   @typedoc "Proxied URL of author icon"
-  @type proxy_icon_url :: String.t()
+  @type proxy_icon_url :: String.t() | nil
 
   @type t :: %__MODULE__{
           name: name,
@@ -22,15 +41,10 @@ defmodule Nostrum.Struct.Embed.Author do
           proxy_icon_url: proxy_icon_url
         }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :name,
-    :url,
-    :icon_url,
-    :proxy_icon_url
-  ]
-
+  @doc false
   def to_struct(map) do
-    struct(__MODULE__, map)
+    new = Map.new(map, fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/embed/field.ex
+++ b/lib/nostrum/struct/embed/field.ex
@@ -3,6 +3,24 @@ defmodule Nostrum.Struct.Embed.Field do
   Struct representing a Discord embed field.
   """
 
+  alias Nostrum.Util
+
+  defstruct [
+    :name,
+    :value,
+    :inline
+  ]
+
+  defimpl Poison.Encoder do
+    def encode(field, options) do
+      field
+      |> Map.from_struct()
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Map.new()
+      |> Poison.Encoder.encode(options)
+    end
+  end
+
   @typedoc "Name of the field"
   @type name :: String.t()
 
@@ -10,7 +28,7 @@ defmodule Nostrum.Struct.Embed.Field do
   @type value :: String.t()
 
   @typedoc "Whether the field should display as inline"
-  @type inline :: boolean
+  @type inline :: boolean | nil
 
   @type t :: %__MODULE__{
           name: name,
@@ -18,14 +36,10 @@ defmodule Nostrum.Struct.Embed.Field do
           inline: inline
         }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :name,
-    :value,
-    :inline
-  ]
-
+  @doc false
   def to_struct(map) do
-    struct(__MODULE__, map)
+    new = Map.new(map, fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/embed/footer.ex
+++ b/lib/nostrum/struct/embed/footer.ex
@@ -3,14 +3,32 @@ defmodule Nostrum.Struct.Embed.Footer do
   Struct representing a Discord embed footer.
   """
 
+  alias Nostrum.Util
+
+  defstruct [
+    :text,
+    :icon_url,
+    :proxy_icon_url
+  ]
+
+  defimpl Poison.Encoder do
+    def encode(footer, options) do
+      footer
+      |> Map.from_struct()
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Map.new()
+      |> Poison.Encoder.encode(options)
+    end
+  end
+
   @typedoc "Footer text"
   @type text :: String.t()
 
   @typedoc "URL of footer icon"
-  @type icon_url :: String.t()
+  @type icon_url :: String.t() | nil
 
   @typedoc "Proxied URL of footer icon"
-  @type proxy_icon_url :: String.t()
+  @type proxy_icon_url :: String.t() | nil
 
   @type t :: %__MODULE__{
           text: text,
@@ -18,14 +36,10 @@ defmodule Nostrum.Struct.Embed.Footer do
           proxy_icon_url: proxy_icon_url
         }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :text,
-    :icon_url,
-    :proxy_icon_url
-  ]
-
+  @doc false
   def to_struct(map) do
-    struct(__MODULE__, map)
+    new = Map.new(map, fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/embed/image.ex
+++ b/lib/nostrum/struct/embed/image.ex
@@ -3,17 +3,36 @@ defmodule Nostrum.Struct.Embed.Image do
   Struct representing a Discord embed image.
   """
 
+  alias Nostrum.Util
+
+  defstruct [
+    :url,
+    :proxy_url,
+    :height,
+    :width
+  ]
+
+  defimpl Poison.Encoder do
+    def encode(image, options) do
+      image
+      |> Map.from_struct()
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Map.new()
+      |> Poison.Encoder.encode(options)
+    end
+  end
+
   @typedoc "Image text"
-  @type url :: String.t()
+  @type url :: String.t() | nil
 
   @typedoc "URL of image icon"
-  @type proxy_url :: String.t()
+  @type proxy_url :: String.t() | nil
 
   @typedoc "Height of the image"
-  @type height :: integer
+  @type height :: integer | nil
 
   @typedoc "Width of the image"
-  @type width :: integer
+  @type width :: integer | nil
 
   @type t :: %__MODULE__{
           url: url,
@@ -22,15 +41,10 @@ defmodule Nostrum.Struct.Embed.Image do
           width: width
         }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :url,
-    :proxy_url,
-    :height,
-    :width
-  ]
-
+  @doc false
   def to_struct(map) do
-    struct(__MODULE__, map)
+    new = Map.new(map, fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/embed/provider.ex
+++ b/lib/nostrum/struct/embed/provider.ex
@@ -3,24 +3,38 @@ defmodule Nostrum.Struct.Embed.Provider do
   Struct representing a Discord embed provider.
   """
 
+  alias Nostrum.Util
+
+  defstruct [
+    :name,
+    :url
+  ]
+
+  defimpl Poison.Encoder do
+    def encode(provider, options) do
+      provider
+      |> Map.from_struct()
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Map.new()
+      |> Poison.Encoder.encode(options)
+    end
+  end
+
   @typedoc "Name of the provider"
-  @type name :: String.t()
+  @type name :: String.t() | nil
 
   @typedoc "URL of provider"
-  @type url :: String.t()
+  @type url :: String.t() | nil
 
   @type t :: %__MODULE__{
           name: name,
           url: url
         }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :name,
-    :url
-  ]
-
+  @doc false
   def to_struct(map) do
-    struct(__MODULE__, map)
+    new = Map.new(map, fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/embed/thumbnail.ex
+++ b/lib/nostrum/struct/embed/thumbnail.ex
@@ -3,17 +3,36 @@ defmodule Nostrum.Struct.Embed.Thumbnail do
   Struct representing a Discord embed thumbnail.
   """
 
+  alias Nostrum.Util
+
+  defstruct [
+    :url,
+    :proxy_url,
+    :height,
+    :width
+  ]
+
+  defimpl Poison.Encoder do
+    def encode(thumbnail, options) do
+      thumbnail
+      |> Map.from_struct()
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Map.new()
+      |> Poison.Encoder.encode(options)
+    end
+  end
+
   @typedoc "Source URL of the thumbnail"
-  @type url :: String.t()
+  @type url :: String.t() | nil
 
   @typedoc "URL of thumbnail icon"
-  @type proxy_url :: String.t()
+  @type proxy_url :: String.t() | nil
 
   @typedoc "Height of the thumbnail"
-  @type height :: integer
+  @type height :: integer | nil
 
   @typedoc "Width of the thumbnail"
-  @type width :: integer
+  @type width :: integer | nil
 
   @type t :: %__MODULE__{
           url: url,
@@ -22,15 +41,10 @@ defmodule Nostrum.Struct.Embed.Thumbnail do
           width: width
         }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :url,
-    :proxy_url,
-    :height,
-    :width
-  ]
-
+  @doc false
   def to_struct(map) do
-    struct(__MODULE__, map)
+    new = Map.new(map, fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/embed/video.ex
+++ b/lib/nostrum/struct/embed/video.ex
@@ -3,14 +3,32 @@ defmodule Nostrum.Struct.Embed.Video do
   Struct representing a Discord embed video.
   """
 
+  alias Nostrum.Util
+
+  defstruct [
+    :url,
+    :height,
+    :width
+  ]
+
+  defimpl Poison.Encoder do
+    def encode(video, options) do
+      video
+      |> Map.from_struct()
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Map.new()
+      |> Poison.Encoder.encode(options)
+    end
+  end
+
   @typedoc "Source URL of the video"
-  @type url :: String.t()
+  @type url :: String.t() | nil
 
   @typedoc "Height of the video"
-  @type height :: integer
+  @type height :: integer | nil
 
   @typedoc "Width of the video"
-  @type width :: integer
+  @type width :: integer | nil
 
   @type t :: %__MODULE__{
           url: url,
@@ -18,14 +36,10 @@ defmodule Nostrum.Struct.Embed.Video do
           width: width
         }
 
-  @derive [Poison.Encoder]
-  defstruct [
-    :url,
-    :height,
-    :width
-  ]
-
+  @doc false
   def to_struct(map) do
-    struct(__MODULE__, map)
+    new = Map.new(map, fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+
+    struct(__MODULE__, new)
   end
 end

--- a/test/nostrum/struct/embed_test.exs
+++ b/test/nostrum/struct/embed_test.exs
@@ -1,0 +1,38 @@
+defmodule Nostrum.Struct.EmbedTest do
+  use ExUnit.Case
+
+  alias Nostrum.Struct.Embed
+  alias Nostrum.Struct.Embed.Field
+
+  require Nostrum.Struct.Embed
+
+  describe "embed builder functions" do
+    test "if given embed info, then they modify the embed correctly" do
+      import Nostrum.Struct.Embed
+
+      expected = %Embed{
+        title: "craig",
+        description: "nostrum",
+        url: "https://google.com/",
+        timestamp: "2016-05-05T21:04:13.203Z",
+        color: 431_948,
+        fields: [
+          %Field{name: "Field 1", value: "Test"},
+          %Field{name: "Field 2", value: "More test", inline: true}
+        ]
+      }
+
+      observed =
+        %Embed{}
+        |> put_title("craig")
+        |> put_description("nostrum")
+        |> put_url("https://google.com/")
+        |> put_timestamp("2016-05-05T21:04:13.203Z")
+        |> put_color(431_948)
+        |> add_field("Field 1", "Test")
+        |> add_field("Field 2", "More test", true)
+
+      assert expected === observed
+    end
+  end
+end

--- a/test/nostrum/struct/embed_test.exs
+++ b/test/nostrum/struct/embed_test.exs
@@ -29,8 +29,8 @@ defmodule Nostrum.Struct.EmbedTest do
         |> put_url("https://google.com/")
         |> put_timestamp("2016-05-05T21:04:13.203Z")
         |> put_color(431_948)
-        |> add_field("Field 1", "Test")
-        |> add_field("Field 2", "More test", true)
+        |> put_field("Field 1", "Test")
+        |> put_field("Field 2", "More test", true)
 
       assert expected === observed
     end


### PR DESCRIPTION
This PR makes the following changes:

1. Updates the typespecs for Embed fields and its components.
2. Updates the `to_struct/1` functions for each Embed and its components.
3. Implements the Poison.Encoder protocol for each Embed and its components.
