### PR TITLE
Correction for a doc example.

### DIFF
--- a/lib/nostrum/cache/user_cache.ex
+++ b/lib/nostrum/cache/user_cache.ex
@@ -38,7 +38,7 @@ defmodule Nostrum.Cache.UserCache do
 
   **Example**
   ```elixir
-  case Nostrum.Cache.User.get(id: 1111222233334444) do
+  case Nostrum.Cache.UserCache.get(id: 1111222233334444) do
     {:ok, user} ->
       "We found " <> user.username
     {:error, _reason} ->


### PR DESCRIPTION
`Nostrum.Cache.UserCache.get/1` instead of undefined `Nostrum.Cache.User.get/1`.