### PR TITLE
Fix for `Nostrum.Api.get_guild_prune/2`.

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1706,8 +1706,8 @@ defmodule Nostrum.Api do
   Days is that number of days to count prune for.
   """
   @spec get_guild_prune(integer, integer) :: error | {:ok, %{pruned: integer}}
-  def get_guild_prune(guild_id, options) do
-    case request(:get, Constants.guild_prune(guild_id), options) do
+  def get_guild_prune(guild_id, days) do
+    case request(:get, Constants.guild_prune(guild_id), "", params: [days: days]) do
       {:ok, body} ->
         {:ok, Poison.decode!(body)}
 


### PR DESCRIPTION
Arguments passed to `Nostrum.Api.get_guild_prune/2` were improperly passed to `request` function, causing a malformed request and then failing on parsing the unexpected response content.

```elixir
iex(1)> Nostrum.Api.get_guild_prune(436595814903709706, 1)
** (exit) exited in: GenServer.call(Ratelimiter, {:queue, %{body: 1, headers: [{"content-type", "application/json"}], method: :get, options: [], route: "/guilds/436595814903709706/prune"}, nil}, :infinity)
    ** (EXIT) an exception was raised:
        ** (Poison.SyntaxError) Unexpected token at position 0: <
            (poison) lib/poison/parser.ex:57: Poison.Parser.parse!/2
            (poison) lib/poison.ex:83: Poison.decode!/2
            (nostrum) lib/nostrum/api/ratelimiter.ex:168: Nostrum.Api.Ratelimiter.format_response/1
            (nostrum) lib/nostrum/api/ratelimiter.ex:55: Nostrum.Api.Ratelimiter.handle_call/3
            (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
            (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
    (elixir) lib/gen_server.ex:834: GenServer.call/3
    (nostrum) lib/nostrum/api.ex:1710: Nostrum.Api.get_guild_prune/2
iex(1)>
23:09:51.654 [error] GenServer Ratelimiter terminating
** (Poison.SyntaxError) Unexpected token at position 0: <
    (poison) lib/poison/parser.ex:57: Poison.Parser.parse!/2
    (poison) lib/poison.ex:83: Poison.decode!/2
    (nostrum) lib/nostrum/api/ratelimiter.ex:168: Nostrum.Api.Ratelimiter.format_response/1
    (nostrum) lib/nostrum/api/ratelimiter.ex:55: Nostrum.Api.Ratelimiter.handle_call/3
    (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.342.0>): {:queue, %{body: 1, headers: [{"content-type", "application/json"}], method: :get, options: [], route: "/guilds/436595814903709706/prune"}, nil}
```

Behavior after changes:
```elixir
iex(1)> Nostrum.Api.get_guild_prune(90579372049723392, 1)
{:ok, %{"pruned" => 4}}
iex(2)> Nostrum.Api.get_guild_prune(90579372049723392, 10)
{:ok, %{"pruned" => 1}}
iex(3)> Nostrum.Api.get_guild_prune(90579372049723392, 30)
{:ok, %{"pruned" => 0}}
iex(4)> Nostrum.Api.get_guild_prune(90579372049723392, 50)
{:error,
 %{
   message: %{"days" => ["int value should be less than or equal to 30."]},
   status_code: 400
 }}
```