### PR TITLE
[WIP] Fix (some) Dialyzer warnings

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -113,7 +113,7 @@ defmodule Nostrum.Api do
     - `type` - The type of status to show. 0 (Playing) | 1 (Streaming) | 2 (Listening) | 3 (Watching)
     - `stream` - URL of twitch.tv stream
   """
-  @spec update_shard_status(pid, status, String.t(), integer, String.t()) :: :ok
+  @spec update_shard_status(pid, status, String.t(), integer, String.t() | nil) :: :ok
   def update_shard_status(pid, status, game, type \\ 0, stream \\ nil) do
     Session.update_status(pid, to_string(status), game, stream, type)
     :ok
@@ -124,7 +124,7 @@ defmodule Nostrum.Api do
 
   See `update_shard_status/4` for usage.
   """
-  @spec update_status(status, String.t(), integer, String.t()) :: :ok
+  @spec update_status(status, String.t(), integer, String.t() | nil) :: :ok
   def update_status(status, game, type \\ 0, stream \\ nil) do
     Supervisor.update_status(status, game, stream, type)
     :ok

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -819,10 +819,12 @@ defmodule Nostrum.Api do
   """
   @spec create_channel_invite(
           integer,
-          %{optional(:max_age) => integer,
-          optional(:max_uses) => integer,
-          optional(:temporary) => boolean,
-          optional(:unique) => boolean}
+          %{
+            optional(:max_age) => integer,
+            optional(:max_uses) => integer,
+            optional(:temporary) => boolean,
+            optional(:unique) => boolean
+          }
         ) :: error | {:ok, Nostrum.Struct.Invite.t()}
   def create_channel_invite(channel_id, options \\ %{}) do
     case request(:post, Constants.channel_invites(channel_id), options) do

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -819,10 +819,10 @@ defmodule Nostrum.Api do
   """
   @spec create_channel_invite(
           integer,
-          max_age: integer,
-          max_uses: integer,
-          temporary: boolean,
-          unique: boolean
+          %{optional(:max_age) => integer,
+          optional(:max_uses) => integer,
+          optional(:temporary) => boolean,
+          optional(:unique) => boolean}
         ) :: error | {:ok, Nostrum.Struct.Invite.t()}
   def create_channel_invite(channel_id, options \\ %{}) do
     case request(:post, Constants.channel_invites(channel_id), options) do

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -2500,7 +2500,7 @@ defmodule Nostrum.Api do
     GenServer.call(Ratelimiter, {:queue, request, nil}, :infinity)
   end
 
-  def request_multipart(method, route, body \\ "", options \\ []) do
+  def request_multipart(method, route, body, options \\ []) do
     request = %{
       method: method,
       route: route,

--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -39,7 +39,7 @@ defmodule Nostrum.Api.Ratelimiter do
   @doc """
   Empties all buckets, voiding any saved ratelimit values.
   """
-  @spec empty_buckets() :: :ok
+  @spec empty_buckets() :: true
   def empty_buckets do
     :ets.delete_all_objects(:ratelimit_buckets)
   end

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -21,7 +21,7 @@ defmodule Nostrum.Util do
   end
   ```
   """
-  @spec producers() :: list(pid)
+  @spec producers() :: Producer
   def producers do
     Producer
   end
@@ -148,7 +148,7 @@ defmodule Nostrum.Util do
   If by chance no gateway connection has been made, will fetch the url to use and store it
   for future use.
   """
-  @spec gateway() :: String.t()
+  @spec gateway() :: {String.t(), integer}
   def gateway do
     case :ets.lookup(:gateway_url, "url") do
       [] -> get_new_gateway_url()


### PR DESCRIPTION
I didn't fix these because I just have no idea what they mean or how to fix them:
```
:0: Unknown function 'Elixir.Mix':shell/0
:0: Unknown function 'Elixir.Mix.Error':exception/1
:0: Unknown function 'Elixir.Mix.Task':run/1
:0: Unknown type 'Elixir.Channel':t/0
:0: Unknown type 'Elixir.Guild':id/0
:0: Unknown type 'Elixir.Guild':t/0
:0: Unknown type 'Elixir.Integer':t/0
:0: Unknown type 'Elixir.Nostrum.Struct.Guild.Integration':t/0
:0: Unknown type 'Elixir.Nostrum.Struct.Message.Emoji':t/0
:0: Unknown type 'Elixir.Nostrum.Struct.User.Connection':t/0
:0: Unknown type 'Elixir.Nostrum.Struct.VoiceRegion':t/0
lib/mix/tasks/gh/docs.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available
lib/websockex.ex:4: The inferred return type of handle_ping/2 ({'reply','pong' | {'pong',_},_}) has nothing in common with {'close',binary()},_} | {'reply',{'binary',binary()} | {'ping',binary()} | {'text',binary()},_}, which is the expected return type for the caaviour
```
And, as far as I know, these depend on elixir-lang/gen_stage#203:
```
lib/nostrum/cache/guild/guild_supervisor.ex:12: Function init/1 has no local return
lib/nostrum/cache/guild/guild_supervisor.ex:13: The call 'Elixir.Supervisor':init([#{'id':=_, 'start':={atom(),atom(),[any()]}, 'modt'=>'permanent' | 'temporary' | 'transient', 'shutdown'=>'brutal_kill' | 'infinity' | non_neg_integer(), 'type'=>'supervisor' | 'worfor_one'},...]) breaks the contract ([supervisor:child_spec() | {module(),term()} | module()],[init_option()]) -> {'ok',tuple()}
lib/nostrum/consumer.ex:209: Function start_link/1 has no local return
lib/nostrum/consumer.ex:210: The call 'Elixir.ConsumerSupervisor':start_link('Elixir.Nostrum.Consumer',Vmod@1::any()) breaks the conc()],[option()]) -> 'Elixir.Supervisor':on_start()
lib/nostrum/dummy.ex:26: Function start_link/0 has no local return
```

Otherwise, all warnings were fixed appropriately.