### PR TITLE
Add banged get with Message struct in channel_cache.ex, fixes #53

### DIFF
--- a/lib/nostrum/cache/channel_cache.ex
+++ b/lib/nostrum/cache/channel_cache.ex
@@ -25,11 +25,11 @@ defmodule Nostrum.Cache.ChannelCache do
   `t:Nostrum.Struct.Channel.dm_channel/0` references. To get channel
   information, a call is made to a `Nostrum.Cache.GuildCache`.
   """
-  @spec get(integer | Nostrum.Struct.Message.t()) :: {:error, atom} | {:ok, Channel.t()}
+  @spec get(Channel.id() | Nostrum.Struct.Message.t()) :: {:error, atom} | {:ok, Channel.t()}
   def get(%Nostrum.Struct.Message{channel_id: channel_id}), do: get(channel_id)
   def get(id), do: GenServer.call(ChannelCache, {:get, id})
 
-  @spec get!(integer | Nostrum.Struct.Message.t()) :: no_return | Channel.t()
+  @spec get!(Channel.id() | Nostrum.Struct.Message.t()) :: no_return | Channel.t()
   def get!(%Nostrum.Struct.Message{channel_id: channel_id}), do: get!(channel_id)
 
   def get!(id) do

--- a/lib/nostrum/cache/channel_cache.ex
+++ b/lib/nostrum/cache/channel_cache.ex
@@ -31,6 +31,7 @@ defmodule Nostrum.Cache.ChannelCache do
 
   @spec get!(integer | Nostrum.Struct.Message.t()) :: no_return | Channel.t()
   def get!(%Nostrum.Struct.Message{channel_id: channel_id}), do: get!(channel_id)
+
   def get!(id) do
     get(id)
     |> Util.bangify_find(id, __MODULE__)

--- a/lib/nostrum/cache/channel_cache.ex
+++ b/lib/nostrum/cache/channel_cache.ex
@@ -33,7 +33,8 @@ defmodule Nostrum.Cache.ChannelCache do
   def get!(%Nostrum.Struct.Message{channel_id: channel_id}), do: get!(channel_id)
 
   def get!(id) do
-    get(id)
+    id
+    |> get
     |> Util.bangify_find(id, __MODULE__)
   end
 

--- a/lib/nostrum/cache/channel_cache.ex
+++ b/lib/nostrum/cache/channel_cache.ex
@@ -25,17 +25,16 @@ defmodule Nostrum.Cache.ChannelCache do
   `t:Nostrum.Struct.Channel.dm_channel/0` references. To get channel
   information, a call is made to a `Nostrum.Cache.GuildCache`.
   """
-  @spec get(id: integer | Nostrum.Struct.Message.t()) :: {:error, atom} | {:ok, Channel.t()}
-  def get(id: id), do: GenServer.call(ChannelCache, {:get, id})
-  def get(%Nostrum.Struct.Message{channel_id: channel_id}), do: get(id: channel_id)
+  @spec get(integer | Nostrum.Struct.Message.t()) :: {:error, atom} | {:ok, Channel.t()}
+  def get(%Nostrum.Struct.Message{channel_id: channel_id}), do: get(channel_id)
+  def get(id), do: GenServer.call(ChannelCache, {:get, id})
 
-  @spec get!(id: integer | Nostrum.Struct.Message.t()) :: no_return | Channel.t()
-  def get!(id: id) do
-    get(id: id)
+  @spec get!(integer | Nostrum.Struct.Message.t()) :: no_return | Channel.t()
+  def get!(%Nostrum.Struct.Message{channel_id: channel_id}), do: get!(channel_id)
+  def get!(id) do
+    get(id)
     |> Util.bangify_find(id, __MODULE__)
   end
-
-  def get!(%Nostrum.Struct.Message{channel_id: channel_id}), do: get!(id: channel_id)
 
   @doc false
   def create(channel), do: GenServer.call(ChannelCache, {:create, channel.id, channel})

--- a/lib/nostrum/cache/channel_cache.ex
+++ b/lib/nostrum/cache/channel_cache.ex
@@ -29,10 +29,13 @@ defmodule Nostrum.Cache.ChannelCache do
   def get(id: id), do: GenServer.call(ChannelCache, {:get, id})
   def get(%Nostrum.Struct.Message{channel_id: channel_id}), do: get(id: channel_id)
 
+  @spec get!(id: integer | Nostrum.Struct.Message.t()) :: no_return | Channel.t()
   def get!(id: id) do
     get(id: id)
     |> Util.bangify_find(id, __MODULE__)
   end
+
+  def get!(%Nostrum.Struct.Message{channel_id: channel_id}), do: get!(id: channel_id)
 
   @doc false
   def create(channel), do: GenServer.call(ChannelCache, {:create, channel.id, channel})


### PR DESCRIPTION
~~I decided to go with a more conservative approach and simply make a banged version of the get with Message struct instead of reworking `get` to not have a single keyword arg but idk.~~

Nevermind, went with reworking `get` to take in a simple argument list.