### PR TITLE
Avatar URL and Full Name Utility Functions for User Module

### DIFF
--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -89,6 +89,38 @@ defmodule Nostrum.Struct.User do
   @spec mention(t) :: String.t()
   def mention(%__MODULE__{id: id}), do: "<@#{id}>"
 
+  @doc """
+  Returns the URL of a user's display avatar.
+
+  If `:avatar` is `nil`, the default avatar url is returned.
+
+  ## Examples
+
+  ```Elixir
+  iex> user = %Nostrum.Struct.User{avatar: "8342729096ea3675442027381ff50dfe",
+  ...>                             id: 80351110224678912}
+  iex> Nostrum.Struct.User.avatar_url(user)
+  "https://cdn.discordapp.com/avatars/80351110224678912/8342729096ea3675442027381ff50dfe.webp"
+  iex> Nostrum.Struct.User.avatar_url(user, "png")
+  "https://cdn.discordapp.com/avatars/80351110224678912/8342729096ea3675442027381ff50dfe.png"
+
+  iex> user = %Nostrum.Struct.User{avatar: nil,
+  ...>                             discriminator: 9999}
+  iex> Nostrum.Struct.User.avatar_url(user)
+  "https://cdn.discordapp.com/embed/avatars/9999.webp"
+  iex> Nostrum.Struct.User.avatar_url(user, "png")
+  "https://cdn.discordapp.com/embed/avatars/9999.png"
+  ```
+  """
+  @spec avatar_url(t, String.t()) :: String.t()
+  def avatar_url(user, image_format \\ "webp")
+
+  def avatar_url(%__MODULE__{avatar: nil, discriminator: disc}, image_format),
+    do: "https://cdn.discordapp.com/embed/avatars/#{disc}.#{image_format}"
+
+  def avatar_url(%__MODULE__{id: id, avatar: avatar}, image_format),
+    do: "https://cdn.discordapp.com/avatars/#{id}/#{avatar}.#{image_format}"
+
   @doc false
   def p_encode do
     %__MODULE__{}

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -105,18 +105,22 @@ defmodule Nostrum.Struct.User do
   "https://cdn.discordapp.com/avatars/80351110224678912/8342729096ea3675442027381ff50dfe.png"
 
   iex> user = %Nostrum.Struct.User{avatar: nil,
-  ...>                             discriminator: "9999"}
+  ...>                             discriminator: "1337"}
   iex> Nostrum.Struct.User.avatar_url(user)
-  "https://cdn.discordapp.com/embed/avatars/9999.webp"
-  iex> Nostrum.Struct.User.avatar_url(user, "png")
-  "https://cdn.discordapp.com/embed/avatars/9999.png"
+  "https://cdn.discordapp.com/embed/avatars/2.png"
   ```
   """
   @spec avatar_url(t, String.t()) :: String.t()
   def avatar_url(user, image_format \\ "webp")
 
-  def avatar_url(%__MODULE__{avatar: nil, discriminator: disc}, image_format),
-    do: "https://cdn.discordapp.com/embed/avatars/#{disc}.#{image_format}"
+  def avatar_url(%__MODULE__{avatar: nil, discriminator: disc}, _) do
+    image_name =
+      disc
+      |> String.to_integer()
+      |> rem(5)
+
+    "https://cdn.discordapp.com/embed/avatars/#{image_name}.png"
+  end
 
   def avatar_url(%__MODULE__{id: id, avatar: avatar}, image_format),
     do: "https://cdn.discordapp.com/avatars/#{id}/#{avatar}.#{image_format}"

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -121,6 +121,23 @@ defmodule Nostrum.Struct.User do
   def avatar_url(%__MODULE__{id: id, avatar: avatar}, image_format),
     do: "https://cdn.discordapp.com/avatars/#{id}/#{avatar}.#{image_format}"
 
+
+  @doc """
+  Returns a user's `:username` and `:discriminator` separated by a hashtag.
+
+  ## Examples
+
+  ```Elixir
+  iex> user = %Nostrum.Struct.User{username: "b1nzy",
+  ...>                             discriminator: "0852"}
+  iex> Nostrum.Struct.User.full_name(user)
+  "b1nzy#0852"
+  ```
+  """
+  @spec full_name(t) :: String.t()
+  def full_name(%__MODULE__{username: username, discriminator: disc}),
+    do: "#{username}##{disc}"
+
   @doc false
   def p_encode do
     %__MODULE__{}

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -121,7 +121,6 @@ defmodule Nostrum.Struct.User do
   def avatar_url(%__MODULE__{id: id, avatar: avatar}, image_format),
     do: "https://cdn.discordapp.com/avatars/#{id}/#{avatar}.#{image_format}"
 
-
   @doc """
   Returns a user's `:username` and `:discriminator` separated by a hashtag.
 

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -105,7 +105,7 @@ defmodule Nostrum.Struct.User do
   "https://cdn.discordapp.com/avatars/80351110224678912/8342729096ea3675442027381ff50dfe.png"
 
   iex> user = %Nostrum.Struct.User{avatar: nil,
-  ...>                             discriminator: 9999}
+  ...>                             discriminator: "9999"}
   iex> Nostrum.Struct.User.avatar_url(user)
   "https://cdn.discordapp.com/embed/avatars/9999.webp"
   iex> Nostrum.Struct.User.avatar_url(user, "png")

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -94,6 +94,8 @@ defmodule Nostrum.Struct.User do
 
   If `:avatar` is `nil`, the default avatar url is returned.
 
+  Supported image formats are PNG, JPEG, GIF, WebP, and GIF.
+
   ## Examples
 
   ```Elixir


### PR DESCRIPTION
This PR adds in two useful functions for working with User structs. These are `avatar_url/2` and `full_name/1`.

* `avatar_url/2` reduces the boilerplate code involved with finding a user's avatar url. It returns the default avatar URL if the user's `:avatar` is `nil`.
* `full_name/1` gives a name to a well known way to identify users on discord.