### PR TITLE
Fixed typo with `:joined_at` field in Guild struct

### DIFF
--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -117,7 +117,7 @@ defmodule Nostrum.Struct.Guild do
   """
   @type system_channel_id :: Snowflake.t() | nil
 
-  @typedoc "Date the guild was created"
+  @typedoc "Date the bot user joined the guild"
   @type joined_at :: String.t() | nil
 
   @typedoc "Whether the guild is considered 'large'"


### PR DESCRIPTION
* Issue was that the `:joined_at` documentation was incorrectly stating that this field returned the guild's creation date.
* It's now been corrected to say that `:joined_at` is the bot user's join date for that guild.