### PR TITLE
Guild Utility Functions

### DIFF
--- a/lib/nostrum/constants.ex
+++ b/lib/nostrum/constants.ex
@@ -95,6 +95,8 @@ defmodule Nostrum.Constants do
 
   def cdn_avatar(id, avatar, image_format), do: "/avatars/#{id}/#{avatar}.#{image_format}"
   def cdn_embed_avatar(image_name), do: "/embed/avatars/#{image_name}.png"
+  def cdn_icon(id, icon, image_format), do: "/icons/#{id}/#{icon}.#{image_format}"
+  def cdn_splash(id, splash, image_format), do: "/splashes/#{id}/#{splash}.#{image_format}"
 
   def opcodes do
     %{

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -8,7 +8,7 @@ defmodule Nostrum.Struct.Guild do
   alias Nostrum.Struct.Guild.Member
   alias Nostrum.Struct.Guild.Role
   alias Nostrum.Struct.Snowflake
-  alias Nostrum.Util
+  alias Nostrum.{Constants, Util}
 
   defstruct [
     :id,
@@ -312,7 +312,7 @@ defmodule Nostrum.Struct.Guild do
   def icon_url(%__MODULE__{icon: nil}, _), do: nil
 
   def icon_url(%__MODULE__{icon: icon, id: id}, image_format),
-    do: "https://cdn.discordapp.com/icons/#{id}/#{icon}.#{image_format}"
+    do: URI.encode(Constants.cdn_url() <> Constants.cdn_icon(id, icon, image_format))
 
   @doc ~S"""
   Returns the URL of a guild's splash, or `nil` if there is no splash.
@@ -339,7 +339,7 @@ defmodule Nostrum.Struct.Guild do
   def splash_url(%__MODULE__{splash: nil}, _), do: nil
 
   def splash_url(%__MODULE__{splash: splash, id: id}, image_format),
-    do: "https://cdn.discordapp.com/splashes/#{id}/#{splash}.#{image_format}"
+    do: URI.encode(Constants.cdn_url() <> Constants.cdn_splash(id, splash, image_format))
 
   @doc false
   def p_encode do

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -290,6 +290,8 @@ defmodule Nostrum.Struct.Guild do
   @doc ~S"""
   Returns the URL of a guild's icon, or `nil` if there is no icon.
 
+  Supported image formats are PNG, JPEG, and WebP.
+
   ## Examples
 
   ```Elixir
@@ -314,6 +316,8 @@ defmodule Nostrum.Struct.Guild do
 
   @doc ~S"""
   Returns the URL of a guild's splash, or `nil` if there is no splash.
+
+  Supported image formats are PNG, JPEG, and WebP.
 
   ## Examples
 

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -312,6 +312,31 @@ defmodule Nostrum.Struct.Guild do
   def icon_url(%__MODULE__{icon: icon, id: id}, image_format),
     do: "https://cdn.discordapp.com/icons/#{id}/#{icon}.#{image_format}"
 
+  @doc ~S"""
+  Returns the URL of a guild's splash, or `nil` if there is no splash.
+
+  ## Examples
+
+  ```Elixir
+  iex> guild = %Nostrum.Struct.Guild{splash: "86e39f7ae3307e811784e2ffd11a7310",
+  ...>                               id: 41771983423143937}
+  iex> Nostrum.Struct.Guild.splash_url(guild)
+  "https://cdn.discordapp.com/splashes/41771983423143937/86e39f7ae3307e811784e2ffd11a7310.webp"
+  iex> Nostrum.Struct.Guild.splash_url(guild, "png")
+  "https://cdn.discordapp.com/splashes/41771983423143937/86e39f7ae3307e811784e2ffd11a7310.png"
+
+  iex> guild = %Nostrum.Struct.Guild{splash: nil}
+  iex> Nostrum.Struct.Guild.splash_url(guild)
+  nil
+  ```
+  """
+  @spec splash_url(t, String.t()) :: String.t() | nil
+  def splash_url(guild, image_format \\ "webp")
+  def splash_url(%__MODULE__{splash: nil}, _), do: nil
+
+  def splash_url(%__MODULE__{splash: splash, id: id}, image_format),
+    do: "https://cdn.discordapp.com/splashes/#{id}/#{splash}.#{image_format}"
+
   @doc false
   def p_encode do
     %__MODULE__{}

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -287,6 +287,31 @@ defmodule Nostrum.Struct.Guild do
           | rest_guild
           | user_guild
 
+  @doc ~S"""
+  Returns the URL of a guild's icon, or `nil` if there is no icon.
+
+  ## Examples
+
+  ```Elixir
+  iex> guild = %Nostrum.Struct.Guild{icon: "86e39f7ae3307e811784e2ffd11a7310",
+  ...>                               id: 41771983423143937}
+  iex> Nostrum.Struct.Guild.icon_url(guild)
+  "https://cdn.discordapp.com/icons/41771983423143937/86e39f7ae3307e811784e2ffd11a7310.webp"
+  iex> Nostrum.Struct.Guild.icon_url(guild, "png")
+  "https://cdn.discordapp.com/icons/41771983423143937/86e39f7ae3307e811784e2ffd11a7310.png"
+
+  iex> guild = %Nostrum.Struct.Guild{icon: nil}
+  iex> Nostrum.Struct.Guild.icon_url(guild)
+  nil
+  ```
+  """
+  @spec icon_url(t, String.t()) :: String.t() | nil
+  def icon_url(guild, image_format \\ "webp")
+  def icon_url(%__MODULE__{icon: nil}, _), do: nil
+
+  def icon_url(%__MODULE__{icon: icon, id: id}, image_format),
+    do: "https://cdn.discordapp.com/icons/#{id}/#{icon}.#{image_format}"
+
   @doc false
   def p_encode do
     %__MODULE__{}

--- a/test/nostrum/struct/guild_test.exs
+++ b/test/nostrum/struct/guild_test.exs
@@ -1,0 +1,7 @@
+defmodule Nostrum.Struct.GuildTest do
+  use ExUnit.Case, async: true
+
+  alias Nostrum.Struct.Guild
+
+  doctest Guild
+end


### PR DESCRIPTION
This adds in two functions for the guild module:

* `image_url/2`: For retrieving a guild's icon URL.
* `splash_url/2`: For retrieving a guild's splash URL.