### PR TITLE
Move avatar CDN URLs to constants.ex

### DIFF
--- a/lib/nostrum/constants.ex
+++ b/lib/nostrum/constants.ex
@@ -3,6 +3,7 @@ defmodule Nostrum.Constants do
 
   # REFERENCE: https://gist.github.com/SinisterRectus/9518f3e7d0d1ccb4335b2a0d389c30b0
   def base_url, do: Application.get_env(:nostrum, :api_url, "https://discordapp.com/api/v6")
+  def cdn_url, do: Application.get_env(:nostrum, :cdn_url, "https://cdn.discordapp.com")
   def gateway, do: "/gateway"
   def gateway_bot, do: "/gateway/bot"
 
@@ -91,6 +92,9 @@ defmodule Nostrum.Constants do
   def channel_call_ring(channel_id), do: "/channels/#{channel_id}/call/ring"
   def group_recipient(group_id, user_id), do: "/channels/#{group_id}/recipients/#{user_id}"
   def guild_me_nick(guild_id), do: "/guilds/#{guild_id}/members/@me/nick"
+
+  def cdn_avatar(id, avatar, image_format), do: "/avatars/#{id}/#{avatar}.#{image_format}"
+  def cdn_embed_avatar(image_name), do: "/embed/avatars/#{image_name}.png"
 
   def opcodes do
     %{

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -23,7 +23,9 @@ defmodule Nostrum.Struct.User do
   """
 
   alias Nostrum.Struct.Snowflake
-  alias Nostrum.Util
+  alias Nostrum.{Util, Constants}
+
+  use HTTPoison.Base
 
   defstruct [
     :id,
@@ -121,11 +123,11 @@ defmodule Nostrum.Struct.User do
       |> String.to_integer()
       |> rem(5)
 
-    "https://cdn.discordapp.com/embed/avatars/#{image_name}.png"
+    URI.encode(Constants.cdn_url() <> Constants.cdn_embed_avatar(image_name))
   end
 
   def avatar_url(%__MODULE__{id: id, avatar: avatar}, image_format),
-    do: "https://cdn.discordapp.com/avatars/#{id}/#{avatar}.#{image_format}"
+    do: URI.encode(Constants.cdn_url() <> Constants.cdn_avatar(id, avatar, image_format))
 
   @doc """
   Returns a user's `:username` and `:discriminator` separated by a hashtag.


### PR DESCRIPTION
Implements 3 new functions to `lib/nostrum/constants.ex`:
```elixir
iex(4)> Nostrum.Constants.cdn_url
"https://cdn.discordapp.com"
iex(5)> Nostrum.Constants.cdn_avatar "1", "2", "3"
"/avatars/1/2.3"
iex(6)> Nostrum.Constants.cdn_embed_avatar "0"    
"/embed/avatars/0.png"
```

Closes #81 