### PR TITLE
Fix a typo in `Api.remove_guild_ban/2`.

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1618,7 +1618,7 @@ defmodule Nostrum.Api do
   """
   @spec remove_guild_ban(integer, integer) :: error | {:ok}
   def remove_guild_ban(guild_id, user_id) do
-    request(:remove, Constants.guild_ban(guild_id, user_id))
+    request(:delete, Constants.guild_ban(guild_id, user_id))
   end
 
   @doc ~S"""


### PR DESCRIPTION
`:remove` returns
```elixir
{:error, %{message: %{"code" => 0, "message" => "405: Method Not Allowed"}, status_code: 405}}
```
and `:delete` appears to work properly (tested locally on my bot)