### PR TITLE
Allow more than 100 messages in bulk delete

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -754,6 +754,7 @@ defmodule Nostrum.Api do
     snowflake_two_weeks_ago =
       DateTime.utc_now()
       |> DateTime.to_unix()
+      # 60 seconds * 60 * 24 * 14 = 14 days / 2 weeks
       |> Kernel.-(60 * 60 * 24 * 14)
       |> DateTime.from_unix!()
       |> Snowflake.from_datetime!()

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -734,7 +734,9 @@ defmodule Nostrum.Api do
   `messages` is a list of `Nostrum.Struct.Message.id` that you wish to delete.
   When given more than 100 messages, this function will chunk the given message
   list into blocks of 100 and send them off to the API. It will stop deleting
-  on the first error that occurs.
+  on the first error that occurs. Keep in mind that deleting thousands of
+  messages will take a pretty long time and it may be proper to just delete
+  the channel you want to bulk delete in and recreate it.
 
   This method can only delete messages sent within the last two weeks.
   `Filter` is an optional parameter that specifies whether messages sent over

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -749,10 +749,17 @@ defmodule Nostrum.Api do
     do: send_chunked_delete(messages, channel_id)
 
   def bulk_delete_messages(channel_id, messages, true) do
+    alias Nostrum.Struct.Snowflake
+
+    snowflake_two_weeks_ago =
+      DateTime.utc_now()
+      |> DateTime.to_unix()
+      |> Kernel.-(60 * 60 * 24 * 14)
+      |> DateTime.from_unix!()
+      |> Snowflake.from_datetime!()
+
     messages
-    |> Stream.filter(fn message_id ->
-      (message_id >>> 22) + 1_420_070_400_000 > Util.now() - 14 * 24 * 60 * 60 * 1000
-    end)
+    |> Stream.filter(&(&1 > snowflake_two_weeks_ago))
     |> send_chunked_delete(channel_id)
   end
 

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -750,7 +750,7 @@ defmodule Nostrum.Api do
 
   def bulk_delete_messages(channel_id, messages, true) do
     messages
-    |> Enum.filter(fn message_id ->
+    |> Stream.filter(fn message_id ->
       (message_id >>> 22) + 1_420_070_400_000 > Util.now() - 14 * 24 * 60 * 60 * 1000
     end)
     |> send_chunked_delete(channel_id)

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -732,6 +732,9 @@ defmodule Nostrum.Api do
   Deletes multiple messages from a channel.
 
   `messages` is a list of `Nostrum.Struct.Message.id` that you wish to delete.
+  When given more than 100 messages, this function will chunk the given message
+  list into blocks of 100 and send them off to the API. It will stop deleting
+  on the first error that occurs.
 
   This method can only delete messages sent within the last two weeks.
   `Filter` is an optional parameter that specifies whether messages sent over

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -756,9 +756,9 @@ defmodule Nostrum.Api do
   end
 
   @spec send_chunked_delete(
-    Nostrum.Struct.Snowflake.t(),
-    [Nostrum.Struct.Message.id()]
-  ) :: error | {:ok}
+          Nostrum.Struct.Snowflake.t(),
+          [Nostrum.Struct.Message.id()]
+        ) :: error | {:ok}
   def send_chunked_delete(channel_id, messages) do
     messages
     |> Enum.chunk_every(100)


### PR DESCRIPTION
Previously `Api.bulk_delete_messages/3` would error (from the Discord API) when given more than 100 messages at once. With this PR, the message list will be chunked into blocks of 100 and sent off to the API chunk by chunk.