### PR TITLE
Fix for Nostrum.Api.get_current_user_guilds/1.

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -2176,7 +2176,7 @@ defmodule Nostrum.Api do
 
   def get_current_user_guilds(options) when is_map(options) do
     request(:get, Constants.me_guilds(), "", params: options)
-    |> handle_request_with_decode({:struct, Guild})
+    |> handle_request_with_decode({:list, {:struct, Guild}})
   end
 
   @doc ~S"""

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -227,7 +227,7 @@ defmodule Nostrum.Util do
   def cast(value, {:struct, module}) when is_map(value) do
     module.to_struct(value)
   end
-  
+
   def cast(values, {:struct, module}) when is_list(values) do
     Enum.map(values, &module.to_struct/1)
   end

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -227,6 +227,10 @@ defmodule Nostrum.Util do
   def cast(value, {:struct, module}) when is_map(value) do
     module.to_struct(value)
   end
+  
+  def cast(values, {:struct, module}) when is_list(values) do
+    Enum.map(values, &module.to_struct/1)
+  end
 
   def cast(value, module) do
     case module.cast(value) do

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -228,10 +228,6 @@ defmodule Nostrum.Util do
     module.to_struct(value)
   end
 
-  def cast(values, {:struct, module}) when is_list(values) do
-    Enum.map(values, &module.to_struct/1)
-  end
-
   def cast(value, module) do
     case module.cast(value) do
       {:ok, result} -> result


### PR DESCRIPTION
It is an indirect fix as the issue was in `Nostrum.Util.cast/2`, where it did not expect to receive more than one value in a case where `{:struct, module}` was passed as the `type`. In the case of a call originating from `Nostrum.Api.get_current_user_guilds/1`, `Nostrum.Util.cast/2` reached the last "match all" pattern and failed as it was not intended to handle that scenario.

Behavior before the fix:
```elixir
iex(1)> Nostrum.Api.get_current_user_guilds limit: 1
** (UndefinedFunctionError) function :struct.cast/2 is undefined (module :struct is not available)
    :struct.cast([%{icon: "4365a9295ac51200f0a2ae4048dff277", id: "473537126680494111", name: "Curie Dev", owner: false, permissions: 2146958847}], {:struct, Nostrum.Struct.Guild})
    (nostrum) lib/nostrum/util.ex:236: Nostrum.Util.cast/2
    (nostrum) lib/nostrum/api.ex:2577: Nostrum.Api.handle_request_with_decode/2
```

Behavior after the fix (works as described in documentation):
```elixir
iex(1)> Nostrum.Api.get_current_user_guilds limit: 1
{:ok,
 [
   %Nostrum.Struct.Guild{
     afk_channel_id: nil,
     afk_timeout: nil,
     application_id: nil,
     channels: nil,
     default_message_notifications: nil,
     embed_channel_id: nil,
     embed_enabled: nil,
     emojis: nil,
     explicit_content_filter: nil,
     features: nil,
     icon: "4365a9295ac51200f0a2ae4048dff277",
     id: 473537126680494111,
     joined_at: nil,
     large: nil,
     member_count: nil,
     members: nil,
     mfa_level: nil,
     name: "Curie Dev",
     owner_id: nil,
     region: nil,
     roles: nil,
     splash: nil,
     system_channel_id: nil,
     unavailable: nil,
     verification_level: nil,
     voice_states: nil,
     widget_channel_id: nil,
     widget_enabled: nil
   }
 ]}
```