### PR TITLE
Add dependency to :inets

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Nostrum.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :inets],
       mod: {Nostrum.Application, []}
     ]
   end


### PR DESCRIPTION
While packaging an application that depended on nostrum, I came across a runtime error that claimed the built-in Erlang httpd_util module was missing.  Adding :inets as an extra_application fixes the error, because distillery will bundle the httpd_util module while making a release.