### PR TITLE
Adjustment for Nostrum.Api.get_channel_messages!/3

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -693,7 +693,7 @@ defmodule Nostrum.Api do
   Same as `get_channel_messages/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @spec get_channel_messages!(Channel.id(), limit, locator) :: no_return | [Message.t()]
-  def get_channel_messages!(channel_id, limit, locator) do
+  def get_channel_messages!(channel_id, limit, locator \\ {}) do
     get_channel_messages(channel_id, limit, locator)
     |> bangify
   end

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -94,7 +94,7 @@ defmodule Nostrum.Struct.User do
 
   If `:avatar` is `nil`, the default avatar url is returned.
 
-  Supported image formats are PNG, JPEG, GIF, WebP, and GIF.
+  Supported image formats are PNG, JPEG, WebP, and GIF.
 
   ## Examples
 


### PR DESCRIPTION
Added a default value for argument `locator` so that function's argument signature would match the non-banged counterpart.