### PR TITLE
Fix Credo and Format errors, bump Elixir 1.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 
 elixir:
-  - '1.6.6'
+  - '1.7.4'
 otp_release: '20.3'
 
 script:

--- a/docs/static/Intro.md
+++ b/docs/static/Intro.md
@@ -1,7 +1,7 @@
 # Intro
 Nostrum is a an Elixir library that can be used to interact with Discord.
 
-Nostrum currently supports the latest stable version of Elixir, v. 1.4.
+Nostrum currently supports the latest stable version of Elixir, v. 1.7.
 
 With a platform like Discord, there are many moving parts and an attempt was made
 to break these parts into smaller logical pieces.

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -48,7 +48,7 @@ defmodule Nostrum.Api do
   alias Nostrum.{Constants, Util}
   alias Nostrum.Struct.{Channel, Embed, Emoji, Guild, Invite, Message, User, Webhook}
   alias Nostrum.Struct.Guild.{Member, Role}
-  alias Nostrum.Shard.{Supervisor, Session}
+  alias Nostrum.Shard.{Session, Supervisor}
 
   @typedoc """
   Represents a failed response from the API.

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -2,8 +2,8 @@ defmodule Nostrum.Shard.Dispatch do
   @moduledoc false
 
   alias Nostrum.Cache.{ChannelCache, PresenceCache, UserCache}
-  alias Nostrum.Cache.Me
   alias Nostrum.Cache.Guild.GuildServer
+  alias Nostrum.Cache.Me
   alias Nostrum.Shard.Session
   alias Nostrum.Struct.{Guild, Message, User}
   alias Nostrum.Struct.Guild.UnavailableGuild

--- a/lib/nostrum/struct/channel.ex
+++ b/lib/nostrum/struct/channel.ex
@@ -30,9 +30,7 @@ defmodule Nostrum.Struct.Channel do
   ```
   """
 
-  alias Nostrum.Struct.Overwrite
-  alias Nostrum.Struct.Snowflake
-  alias Nostrum.Struct.User
+  alias Nostrum.Struct.{Overwrite, Snowflake, User}
   alias Nostrum.Util
 
   defstruct [

--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -35,6 +35,7 @@ defmodule Nostrum.Struct.Embed do
 
   alias Nostrum.Struct.Embed.{Author, Field, Footer, Image, Provider, Thumbnail, Video}
   alias Nostrum.Util
+  alias Poison.Encoder
 
   defstruct [
     :title,
@@ -52,13 +53,13 @@ defmodule Nostrum.Struct.Embed do
     :fields
   ]
 
-  defimpl Poison.Encoder do
+  defimpl Encoder do
     def encode(embed, options) do
       embed
       |> Map.from_struct()
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Map.new()
-      |> Poison.Encoder.encode(options)
+      |> Encoder.encode(options)
     end
   end
 

--- a/lib/nostrum/struct/embed/author.ex
+++ b/lib/nostrum/struct/embed/author.ex
@@ -4,6 +4,7 @@ defmodule Nostrum.Struct.Embed.Author do
   """
 
   alias Nostrum.Util
+  alias Poison.Encoder
 
   defstruct [
     :name,
@@ -12,13 +13,13 @@ defmodule Nostrum.Struct.Embed.Author do
     :proxy_icon_url
   ]
 
-  defimpl Poison.Encoder do
+  defimpl Encoder do
     def encode(author, options) do
       author
       |> Map.from_struct()
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Map.new()
-      |> Poison.Encoder.encode(options)
+      |> Encoder.encode(options)
     end
   end
 

--- a/lib/nostrum/struct/embed/field.ex
+++ b/lib/nostrum/struct/embed/field.ex
@@ -4,6 +4,7 @@ defmodule Nostrum.Struct.Embed.Field do
   """
 
   alias Nostrum.Util
+  alias Poison.Encoder
 
   defstruct [
     :name,
@@ -11,13 +12,13 @@ defmodule Nostrum.Struct.Embed.Field do
     :inline
   ]
 
-  defimpl Poison.Encoder do
+  defimpl Encoder do
     def encode(field, options) do
       field
       |> Map.from_struct()
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Map.new()
-      |> Poison.Encoder.encode(options)
+      |> Encoder.encode(options)
     end
   end
 

--- a/lib/nostrum/struct/embed/footer.ex
+++ b/lib/nostrum/struct/embed/footer.ex
@@ -4,6 +4,7 @@ defmodule Nostrum.Struct.Embed.Footer do
   """
 
   alias Nostrum.Util
+  alias Poison.Encoder
 
   defstruct [
     :text,
@@ -11,13 +12,13 @@ defmodule Nostrum.Struct.Embed.Footer do
     :proxy_icon_url
   ]
 
-  defimpl Poison.Encoder do
+  defimpl Encoder do
     def encode(footer, options) do
       footer
       |> Map.from_struct()
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Map.new()
-      |> Poison.Encoder.encode(options)
+      |> Encoder.encode(options)
     end
   end
 

--- a/lib/nostrum/struct/embed/image.ex
+++ b/lib/nostrum/struct/embed/image.ex
@@ -4,6 +4,7 @@ defmodule Nostrum.Struct.Embed.Image do
   """
 
   alias Nostrum.Util
+  alias Poison.Encoder
 
   defstruct [
     :url,
@@ -12,13 +13,13 @@ defmodule Nostrum.Struct.Embed.Image do
     :width
   ]
 
-  defimpl Poison.Encoder do
+  defimpl Encoder do
     def encode(image, options) do
       image
       |> Map.from_struct()
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Map.new()
-      |> Poison.Encoder.encode(options)
+      |> Encoder.encode(options)
     end
   end
 

--- a/lib/nostrum/struct/embed/provider.ex
+++ b/lib/nostrum/struct/embed/provider.ex
@@ -4,19 +4,20 @@ defmodule Nostrum.Struct.Embed.Provider do
   """
 
   alias Nostrum.Util
+  alias Poison.Encoder
 
   defstruct [
     :name,
     :url
   ]
 
-  defimpl Poison.Encoder do
+  defimpl Encoder do
     def encode(provider, options) do
       provider
       |> Map.from_struct()
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Map.new()
-      |> Poison.Encoder.encode(options)
+      |> Encoder.encode(options)
     end
   end
 

--- a/lib/nostrum/struct/embed/thumbnail.ex
+++ b/lib/nostrum/struct/embed/thumbnail.ex
@@ -4,6 +4,7 @@ defmodule Nostrum.Struct.Embed.Thumbnail do
   """
 
   alias Nostrum.Util
+  alias Poison.Encoder
 
   defstruct [
     :url,
@@ -12,13 +13,13 @@ defmodule Nostrum.Struct.Embed.Thumbnail do
     :width
   ]
 
-  defimpl Poison.Encoder do
+  defimpl Encoder do
     def encode(thumbnail, options) do
       thumbnail
       |> Map.from_struct()
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Map.new()
-      |> Poison.Encoder.encode(options)
+      |> Encoder.encode(options)
     end
   end
 

--- a/lib/nostrum/struct/embed/video.ex
+++ b/lib/nostrum/struct/embed/video.ex
@@ -4,6 +4,7 @@ defmodule Nostrum.Struct.Embed.Video do
   """
 
   alias Nostrum.Util
+  alias Poison.Encoder
 
   defstruct [
     :url,
@@ -11,13 +12,13 @@ defmodule Nostrum.Struct.Embed.Video do
     :width
   ]
 
-  defimpl Poison.Encoder do
+  defimpl Encoder do
     def encode(video, options) do
       video
       |> Map.from_struct()
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Map.new()
-      |> Poison.Encoder.encode(options)
+      |> Encoder.encode(options)
     end
   end
 

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -35,9 +35,8 @@ defmodule Nostrum.Struct.Emoji do
   See `t:Nostrum.Struct.Emoji.api_name/0` for more information.
   """
 
-  alias Nostrum.Struct.Snowflake
-  alias Nostrum.Struct.User
   alias Nostrum.{Constants, Util}
+  alias Nostrum.Struct.{Snowflake, User}
 
   defstruct [
     :id,

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -3,11 +3,8 @@ defmodule Nostrum.Struct.Guild do
   Struct representing a Discord guild.
   """
 
-  alias Nostrum.Struct.Channel
-  alias Nostrum.Struct.Emoji
-  alias Nostrum.Struct.Guild.Member
-  alias Nostrum.Struct.Guild.Role
-  alias Nostrum.Struct.Snowflake
+  alias Nostrum.Struct.{Channel, Emoji, Snowflake}
+  alias Nostrum.Struct.Guild.{Member, Role}
   alias Nostrum.{Constants, Util}
 
   defstruct [

--- a/lib/nostrum/struct/invite.ex
+++ b/lib/nostrum/struct/invite.ex
@@ -3,9 +3,7 @@ defmodule Nostrum.Struct.Invite do
   Struct representing a Discord invite.
   """
 
-  alias Nostrum.Struct.Channel
-  alias Nostrum.Struct.Guild
-  alias Nostrum.Struct.User
+  alias Nostrum.Struct.{Channel, Guild, User}
   alias Nostrum.Util
 
   defstruct [

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -3,13 +3,8 @@ defmodule Nostrum.Struct.Message do
   Struct representing a Discord message.
   """
 
-  alias Nostrum.Struct.Embed
-  alias Nostrum.Struct.Message.Activity
-  alias Nostrum.Struct.Message.Application
-  alias Nostrum.Struct.Message.Attachment
-  alias Nostrum.Struct.Message.Reaction
-  alias Nostrum.Struct.Snowflake
-  alias Nostrum.Struct.User
+  alias Nostrum.Struct.{Embed, Snowflake, User}
+  alias Nostrum.Struct.Message.{Activity, Application, Attachment, Reaction}
   alias Nostrum.Util
 
   defstruct [

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -4,12 +4,12 @@ defmodule Nostrum.Struct.Message do
   """
 
   alias Nostrum.Struct.Embed
-  alias Nostrum.Struct.User
   alias Nostrum.Struct.Message.Activity
   alias Nostrum.Struct.Message.Application
   alias Nostrum.Struct.Message.Attachment
   alias Nostrum.Struct.Message.Reaction
   alias Nostrum.Struct.Snowflake
+  alias Nostrum.Struct.User
   alias Nostrum.Util
 
   defstruct [

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -23,7 +23,7 @@ defmodule Nostrum.Struct.User do
   """
 
   alias Nostrum.Struct.Snowflake
-  alias Nostrum.{Util, Constants}
+  alias Nostrum.{Constants, Util}
 
   defstruct [
     :id,

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -220,10 +220,10 @@ defmodule Nostrum.Util do
 
   # Handles the case where the given term is already indexed
   def cast(values, {:index, index_by, type}) when is_map(values), do: values
+
   def cast(values, {:index, index_by, type}) when is_list(values) do
     values
-    |> Enum.map(&{&1 |> get_in(index_by) |> cast(Snowflake), cast(&1, type)})
-    |> Enum.into(%{})
+    |> Enum.into(%{}, &{&1 |> get_in(index_by) |> cast(Snowflake), cast(&1, type)})
   end
 
   def cast(value, {:struct, module}) when is_map(value) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Nostrum.Mixfile do
     [
       app: :nostrum,
       version: "0.3.0",
-      elixir: "~> 1.4",
+      elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: "An elixir Discord library",


### PR DESCRIPTION
Fix failing Travis master build

* Enum.map/2 |> Enum.into/2 --> Enum.into/3
* Added some Poison.Encoder aliases
* Ordering of aliases
* Bump Elixir version to 1.7.4