### PR TITLE
Improve Gateway Error Handling

### DIFF
--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -152,9 +152,14 @@ defmodule Nostrum.Util do
 
   defp get_new_gateway_url do
     case Api.request(:get, Constants.gateway_bot(), "") do
+      # Handle deeper API error.
+      # For example, not including a token can result in a somewhat opaque 401 unauthorized error
+      {:error, %Nostrum.Error.ApiError{response: %{message: message}}} ->
+        raise(message)
+
       {:error, %{status_code: code, message: message}} ->
         raise(Nostrum.Error.ApiError, status_code: code, message: message)
-
+  
       {:ok, body} ->
         body = Poison.decode!(body)
 

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -154,7 +154,9 @@ defmodule Nostrum.Util do
     case Api.request(:get, Constants.gateway_bot(), "") do
       # Handle deeper API error.
       # For example, not including a token can result in a somewhat opaque 401 unauthorized error
-      {:error, %Nostrum.Error.ApiError{response: %{message: message}}} ->
+      {:error, error}} ->
+        raise(error)
+      
         raise(message)
 
       {:error, %{status_code: code, message: message}} ->

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -145,18 +145,16 @@ defmodule Nostrum.Util do
   @spec gateway() :: String.t()
   def gateway do
     case :ets.lookup(:gateway_url, "url") do
-      [{"url", url, shards}] ->
-        {url, shards}
-      [] -> 
-        case get_new_gateway_url() do
-          {:ok, url, shards} -> {url, shards}
-          {:error, message} -> raise(message)
-        end
+      [] -> get_new_gateway_url()
+      [{"url", url, shards}] -> {url, shards}
     end
   end
 
   defp get_new_gateway_url do
     case Api.request(:get, Constants.gateway_bot(), "") do
+      {:error, %{status_code: code, message: message}} ->
+        raise(Nostrum.Error.ApiError, status_code: code, message: message)
+
       {:ok, body} ->
         body = Poison.decode!(body)
 
@@ -164,10 +162,7 @@ defmodule Nostrum.Util do
         shards = if body["shards"], do: body["shards"], else: 1
 
         :ets.insert(:gateway_url, {"url", url, shards})
-
-        {:ok, url, shards}
-      
-      {:error, message} -> {:error, message}
+        {url, shards}
     end
   end
 
@@ -224,7 +219,7 @@ defmodule Nostrum.Util do
   end
 
   # Handles the case where the given term is already indexed
-  def cast(values, {:index, _index_by, _type}) when is_map(values), do: values
+  def cast(values, {:index, index_by, type}) when is_map(values), do: values
   def cast(values, {:index, index_by, type}) when is_list(values) do
     values
     |> Enum.map(&{&1 |> get_in(index_by) |> cast(Snowflake), cast(&1, type)})


### PR DESCRIPTION
`Util.get_new_gateway_url/0` was not matching the cases of `Api.request/3`
correctly, which resulted in `CaseClauseError` being thrown when real
errors were occurring beneath.

Added a less restrictive case that bubbles up an ok/error tuple to
`Util.gateway/0` and allows it to make a decision on how to handle the error.

`Util.gateway/0` now raises the returned error message if `Util.get_new_gateway_url/0` fails.