### PR TITLE
Added missing field for Nostrum.Struct.Message

### DIFF
--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -165,7 +165,7 @@ defmodule Nostrum.Shard.Dispatch do
 
   def handle_event(:MESSAGE_DELETE_BULK = event, p, state), do: {event, p, state}
 
-  def handle_event(:MESSAGE_UPDATE = event, p, state), do: {event, p, state}
+  def handle_event(:MESSAGE_UPDATE = event, p, state), do: {event, Message.to_struct(p), state}
 
   def handle_event(:MESSAGE_REACTION_ADD = event, p, state), do: {event, p, state}
 

--- a/lib/nostrum/struct/guild/member.ex
+++ b/lib/nostrum/struct/guild/member.ex
@@ -38,8 +38,11 @@ defmodule Nostrum.Struct.Guild.Member do
     def to_string(member), do: @for.mention(member)
   end
 
-  @typedoc "The user struct"
-  @type user :: User.t()
+  @typedoc """
+  The user struct. This field can be `nil` if Member struct came as a partial Member object included
+  in a message received from a guild channel.
+  """
+  @type user :: User.t() | nil
 
   @typedoc "The nickname of the user"
   @type nick :: String.t() | nil

--- a/lib/nostrum/struct/guild/member.ex
+++ b/lib/nostrum/struct/guild/member.ex
@@ -39,7 +39,7 @@ defmodule Nostrum.Struct.Guild.Member do
   end
 
   @typedoc """
-  The user struct. This field can be `nil` if Member struct came as a partial Member object included
+  The user struct. This field can be `nil` if the Member struct came as a partial Member object included
   in a message received from a guild channel.
   """
   @type user :: User.t() | nil

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -3,8 +3,8 @@ defmodule Nostrum.Struct.Message do
   Struct representing a Discord message.
   """
 
-  alias Nostrum.Struct.Guild.Member
   alias Nostrum.Struct.{Embed, Snowflake, User}
+  alias Nostrum.Struct.Guild.Member
   alias Nostrum.Struct.Message.{Activity, Application, Attachment, Reaction}
   alias Nostrum.Util
 
@@ -103,7 +103,7 @@ defmodule Nostrum.Struct.Message do
   @type application :: Application.t() | nil
 
   @typedoc """
-  Partial Guild Member object received with Message Create event if message came from a guild channel.
+  Partial Guild Member object received with the Message Create event if message came from a guild channel.
   """
   @type member :: Member.t() | nil
 

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -3,6 +3,7 @@ defmodule Nostrum.Struct.Message do
   Struct representing a Discord message.
   """
 
+  alias Nostrum.Struct.Guild.Member
   alias Nostrum.Struct.{Embed, Snowflake, User}
   alias Nostrum.Struct.Message.{Activity, Application, Attachment, Reaction}
   alias Nostrum.Util
@@ -18,6 +19,7 @@ defmodule Nostrum.Struct.Message do
     :embeds,
     :id,
     :guild_id,
+    :member,
     :mention_everyone,
     :mention_roles,
     :mentions,
@@ -100,6 +102,11 @@ defmodule Nostrum.Struct.Message do
   """
   @type application :: Application.t() | nil
 
+  @typedoc """
+  Partial Guild Member object received with Message Create event if message came from a guild channel.
+  """
+  @type member :: Member.t() | nil
+
   @type t :: %__MODULE__{
           activity: activity,
           application: application,
@@ -111,6 +118,7 @@ defmodule Nostrum.Struct.Message do
           embeds: embeds,
           id: id,
           guild_id: guild_id,
+          member: member,
           mention_everyone: mention_everyone,
           mention_roles: mention_roles,
           mentions: mentions,
@@ -150,6 +158,7 @@ defmodule Nostrum.Struct.Message do
       |> Map.update(:webhook_id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:activity, nil, &Util.cast(&1, {:struct, Activity}))
       |> Map.update(:application, nil, &Util.cast(&1, {:struct, Application}))
+      |> Map.update(:member, nil, &Util.cast(&1, {:struct, Member}))
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -219,7 +219,7 @@ defmodule Nostrum.Util do
   end
 
   # Handles the case where the given term is already indexed
-  def cast(values, {:index, index_by, type}) when is_map(values), do: values
+  def cast(values, {:index, _index_by, _type}) when is_map(values), do: values
 
   def cast(values, {:index, index_by, type}) when is_list(values) do
     values


### PR DESCRIPTION
Updated Nostrum.Struct.Message for 1:1 field consistency with Message object sent by Discord.
Annotated the possibility for Nostrum.Struct.Guild.Member struct's field `user` being `nil`.
Message Update event will now provide a Nostrum.Struct.Message struct instead of a map, as event spec suggests.
Fixed warnings for having unused variables in Nostrum.Util.cast/2.