### PR TITLE
Replaced deprecated time units (1.8.0)

### DIFF
--- a/lib/nostrum/struct/snowflake.ex
+++ b/lib/nostrum/struct/snowflake.ex
@@ -127,7 +127,7 @@ defmodule Nostrum.Struct.Snowflake do
   def from_datetime(%DateTime{} = datetime) do
     use Bitwise
 
-    unix_time_ms = DateTime.to_unix(datetime, :milliseconds)
+    unix_time_ms = DateTime.to_unix(datetime, :millisecond)
     discord_time_ms = unix_time_ms - Constants.discord_epoch()
 
     if discord_time_ms >= 0 do
@@ -164,7 +164,7 @@ defmodule Nostrum.Struct.Snowflake do
 
     time_elapsed_ms = (snowflake >>> 22) + Constants.discord_epoch()
 
-    {:ok, datetime} = DateTime.from_unix(time_elapsed_ms, :milliseconds)
+    {:ok, datetime} = DateTime.from_unix(time_elapsed_ms, :millisecond)
     datetime
   end
 end

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -80,7 +80,7 @@ defmodule Nostrum.Util do
   @spec now() :: integer
   def now do
     DateTime.utc_now()
-    |> DateTime.to_unix(:milliseconds)
+    |> DateTime.to_unix(:millisecond)
   end
 
   @doc """


### PR DESCRIPTION
With Elixir 1.8.0, calling functions from `DateTime` module with [deprecated time units](https://github.com/elixir-lang/elixir/blob/v1.8/CHANGELOG.md#4-hard-deprecations) will produce a warning on each function call.
```
warning: deprecated time unit: :milliseconds. A time unit should be :second, :millisecond, 
:microsecond, :nanosecond, or a positive integer
  (elixir) lib/calendar/iso.ex:717: Calendar.ISO.precision_for_unit/1
  (elixir) lib/calendar/iso.ex:708: Calendar.ISO.from_unix/2
  (elixir) lib/calendar/datetime.ex:118: DateTime.from_unix/3
  (elixir) lib/calendar/datetime.ex:166: DateTime.from_unix!/3
```
