### PR TITLE
Documentation: Display "Nostrum" as package name in sidebar, reference proper `Ratelimiter` callback

### DIFF
--- a/docs/static/API.md
+++ b/docs/static/API.md
@@ -59,5 +59,5 @@ The ratelimiter at a high level works something like this:
 ## Rest Only
 If you only want to use the REST portion of the provided API, the only process
 needed is the ratelimiter. This can be manually started by calling
-`Nostrum.Api.Ratelimiter.start_link/0`. If you don't want to start Nostrum you
+`Nostrum.Api.Ratelimiter.start_link/1`. If you don't want to start Nostrum you
 can add `runtime: false` to the dependency options.

--- a/docs/static/State.md
+++ b/docs/static/State.md
@@ -7,7 +7,7 @@ simple interactions with the cache. Feel free to suggest additional functionalit
 Nostrum uses structs when appropriate to pass around objects from Discord.
 
 In some cases, the struct modules will include helper functions for interacting
-with the struct. See `Nostrum.Struct.Emoji.format_custom_emoji/2` for an example.
+with the struct. See `Nostrum.Struct.Emoji.image_url/1` for an example.
 
 ## Guilds
 Each guild is ran in its own `GenServer` process, all of which are ran under a

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Nostrum.Mixfile do
       start_permanent: Mix.env() == :prod,
       description: "An elixir Discord library",
       package: package(),
-      name: "Elixir",
+      name: "Nostrum",
       source_url: "https://github.com/kraigie/nostrum",
       homepage_url: "https://github.com/kraigie/nostrum",
       deps: deps(),


### PR DESCRIPTION
There's another broken link but I'm not sure what that's supposed to be: 
```elixir
warning: documentation references Nostrum.Struct.Emoji.format_custom_emoji/2 but it doesn't exist or it's listed as @doc false (parsing state docs)
```