### PR TITLE
Request for feedback: add initial audit log retrieval support

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -47,7 +47,7 @@ defmodule Nostrum.Api do
 
   alias Nostrum.{Constants, Util}
   alias Nostrum.Struct.{Channel, Embed, Emoji, Guild, Invite, Message, User, Webhook}
-  alias Nostrum.Struct.Guild.{Member, Role}
+  alias Nostrum.Struct.Guild.{AuditLog, Member, Role}
   alias Nostrum.Shard.{Session, Supervisor}
 
   @typedoc """
@@ -1182,6 +1182,22 @@ defmodule Nostrum.Api do
   def delete_guild_emoji!(guild_id, emoji_id) do
     delete_guild_emoji(guild_id, emoji_id)
     |> bangify
+  end
+
+  @doc ~S"""
+  Get the `t:Nostrum.Struct.Guild.AuditLog.t/0` for the given `guild_id`.
+
+  ## Options
+
+    * `:user_id` (`t:Nostrum.Struct.User.id/0`) - filter the log for a user ID
+    * `:action_type` (`t:Integer.t/0`) - filter the log by audit log type, see [Audit Log Events](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
+    * `:before` (`t:Nostrum.Struct.Snowflake.t/0`) - filter the log before a certain entry ID
+    * `:limit` (`t:positive_integer/0`) - how many entries are returned (default 50, minimum 1, maximum 100)
+  """
+  @spec get_guild_audit_log(Guild.id(), options) :: any()
+  def get_guild_audit_log(guild_id, options \\ []) do
+    request(:get, Constants.guild_audit_logs(guild_id), "", params: options)
+    |> handle_request_with_decode({:struct, AuditLog})
   end
 
   @doc ~S"""

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1194,7 +1194,7 @@ defmodule Nostrum.Api do
     * `:before` (`t:Nostrum.Struct.Snowflake.t/0`) - filter the log before a certain entry ID
     * `:limit` (`t:positive_integer/0`) - how many entries are returned (default 50, minimum 1, maximum 100)
   """
-  @spec get_guild_audit_log(Guild.id(), options) :: any()
+  @spec get_guild_audit_log(Guild.id(), options) :: {:ok, AuditLog.t()} | error
   def get_guild_audit_log(guild_id, options \\ []) do
     request(:get, Constants.guild_audit_logs(guild_id), "", params: options)
     |> handle_request_with_decode({:struct, AuditLog})

--- a/lib/nostrum/constants.ex
+++ b/lib/nostrum/constants.ex
@@ -43,6 +43,7 @@ defmodule Nostrum.Constants do
   def guild_member_role(guild_id, user_id, role_id),
     do: "/guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}"
 
+  def guild_audit_logs(guild_id), do: "/guilds/#{guild_id}/audit-logs"
   def guild_bans(guild_id), do: "/guilds/#{guild_id}/bans"
   def guild_ban(guild_id, user_id), do: "/guilds/#{guild_id}/bans/#{user_id}"
   def guild_roles(guild_id), do: "/guilds/#{guild_id}/roles"

--- a/lib/nostrum/struct/guild/audit_log.ex
+++ b/lib/nostrum/struct/guild/audit_log.ex
@@ -9,13 +9,13 @@ defmodule Nostrum.Struct.Guild.AuditLog do
 
   defstruct [:entries, :users, :webhooks]
 
-  @typedoc "Entries of this guild's audit log."
+  @typedoc "Entries of this guild's audit log"
   @type entries :: [AuditLogEntry.t()]
 
-  @typedoc "Users found in the audit log."
+  @typedoc "Users found in the audit log"
   @type users :: [User.t()]
 
-  @typedoc "Webhooks found in the audit log."
+  @typedoc "Webhooks found in the audit log"
   @type webhooks :: [Webhook.t()]
 
   @type t :: %__MODULE__{

--- a/lib/nostrum/struct/guild/audit_log.ex
+++ b/lib/nostrum/struct/guild/audit_log.ex
@@ -29,9 +29,9 @@ defmodule Nostrum.Struct.Guild.AuditLog do
     new =
       map
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
-      |> Map.update(:audit_log_entries, [], &Util.cast(&1, {:list, {:struct, AuditLogEntry}}))
-      |> Map.update(:users, [], &Util.cast(&1, {:list, {:struct, User}}))
-      |> Map.update(:webhooks, [], &Util.cast(&1, {:list, {:struct, Webhook}}))
+      |> Map.update(:audit_log_entries, nil, &Util.cast(&1, {:list, {:struct, AuditLogEntry}}))
+      |> Map.update(:users, nil, &Util.cast(&1, {:list, {:struct, User}}))
+      |> Map.update(:webhooks, nil, &Util.cast(&1, {:list, {:struct, Webhook}}))
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/struct/guild/audit_log.ex
+++ b/lib/nostrum/struct/guild/audit_log.ex
@@ -26,13 +26,13 @@ defmodule Nostrum.Struct.Guild.AuditLog do
 
   @doc false
   def to_struct(map) do
-    struct(
-      __MODULE__,
-      %{
-        entries: Util.cast(map.audit_log_entries, {:list, {:struct, AuditLogEntry}}),
-        users: Util.cast(map.users, {:list, {:struct, User}}),
-        webhooks: Util.cast(map.webhooks, {:list, {:struct, Webhook}})
-      }
-    )
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:audit_log_entries, [], &Util.cast(&1, {:list, {:struct, AuditLogEntry}}))
+      |> Map.update(:users, [], &Util.cast(&1, {:list, {:struct, User}}))
+      |> Map.update(:webhooks, [], &Util.cast(&1, {:list, {:struct, Webhook}}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/guild/audit_log.ex
+++ b/lib/nostrum/struct/guild/audit_log.ex
@@ -1,0 +1,38 @@
+defmodule Nostrum.Struct.Guild.AuditLog do
+  @moduledoc """
+  Represents a guild's audit log.
+  """
+
+  alias Nostrum.Struct.Guild.AuditLogEntry
+  alias Nostrum.Struct.{User, Webhook}
+  alias Nostrum.Util
+
+  defstruct [:entries, :users, :webhooks]
+
+  @typedoc "Entries of this guild's audit log."
+  @type entries :: [AuditLogEntry.t()]
+
+  @typedoc "Users found in the audit log."
+  @type users :: [User.t()]
+
+  @typedoc "Webhooks found in the audit log."
+  @type webhooks :: [Webhook.t()]
+
+  @type t :: %__MODULE__{
+          entries: entries,
+          users: users,
+          webhooks: webhooks
+        }
+
+  @doc false
+  def to_struct(map) do
+    struct(
+      __MODULE__,
+      %{
+        entries: Util.cast(map.audit_log_entries, {:list, {:struct, AuditLogEntry}}),
+        users: Util.cast(map.users, {:list, {:struct, User}}),
+        webhooks: Util.cast(map.webhooks, {:list, {:struct, Webhook}})
+      }
+    )
+  end
+end

--- a/lib/nostrum/struct/guild/audit_log_entry.ex
+++ b/lib/nostrum/struct/guild/audit_log_entry.ex
@@ -17,7 +17,7 @@ defmodule Nostrum.Struct.Guild.AuditLogEntry do
   ]
 
   @typedoc """
-  An audit log event identifier. See [Audit log events](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+  An audit log event identifier. See [Audit log events](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
   """
   @type action_type :: pos_integer()
 
@@ -25,36 +25,42 @@ defmodule Nostrum.Struct.Guild.AuditLogEntry do
 
   @typedoc """
   Individual changes of this audit log entry.
-  Change keys are documented [here](https://discordapp.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key).
+  Change keys are documented [here](https://discordapp.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key)
   """
-  @type changes :: [%{optional(:old_value) => change_value, optional(:new_value) => change_value, :key => String.t()}]
+  @type changes :: [
+          %{
+            optional(:old_value) => change_value,
+            optional(:new_value) => change_value,
+            :key => String.t()
+          }
+        ]
 
-  @typedoc "The ID of this entry."
+  @typedoc "The ID of this entry"
   @type id :: Snowflake.t()
 
   @typedoc """
-  [Optional audit entry info](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info).
+  [Optional audit entry info](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info)
   """
   @type options :: Map.t()
 
-  @typedoc "The reason for this change, if applicable."
+  @typedoc "The reason for this change, if applicable"
   @type reason :: String.t() | nil
 
-  @typedoc "The ID of the affected entity."
+  @typedoc "The ID of the affected entity"
   @type target_id :: String.t() | nil
 
-  @typedoc "The user who made the changes."
+  @typedoc "The user who made the changes"
   @type user_id :: User.id()
 
   @type t :: %__MODULE__{
-    action_type: action_type,
-    changes: changes,
-    id: id,
-    options: options,
-    reason: reason,
-    target_id: target_id,
-    user_id: user_id
-  }
+          action_type: action_type,
+          changes: changes,
+          id: id,
+          options: options,
+          reason: reason,
+          target_id: target_id,
+          user_id: user_id
+        }
 
   @doc false
   def to_struct(map) do

--- a/lib/nostrum/struct/guild/audit_log_entry.ex
+++ b/lib/nostrum/struct/guild/audit_log_entry.ex
@@ -72,9 +72,6 @@ defmodule Nostrum.Struct.Guild.AuditLogEntry do
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
       |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:user_id, nil, &Util.cast(&1, Snowflake))
-      |> Map.put_new(:changes, nil)
-      |> Map.put_new(:options, nil)
-      |> Map.put_new(:reason, nil)
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/struct/guild/audit_log_entry.ex
+++ b/lib/nostrum/struct/guild/audit_log_entry.ex
@@ -1,0 +1,71 @@
+defmodule Nostrum.Struct.Guild.AuditLogEntry do
+  @moduledoc """
+  Represents a single entry in the guild's audit log.
+  """
+
+  alias Nostrum.Struct.{Snowflake, User}
+  alias Nostrum.Util
+
+  defstruct [
+    :action_type,
+    :changes,
+    :id,
+    :options,
+    :reason,
+    :target_id,
+    :user_id
+  ]
+
+  @typedoc """
+  An audit log event identifier. See [Audit log events](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+  """
+  @type action_type :: pos_integer()
+
+  @typep change_value :: String.t() | Snowflake.t() | Integer.t() | [map()] | boolean()
+
+  @typedoc """
+  Individual changes of this audit log entry.
+  Change keys are documented [here](https://discordapp.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key).
+  """
+  @type changes :: [%{optional(:old_value) => change_value, optional(:new_value) => change_value, :key => String.t()}]
+
+  @typedoc "The ID of this entry."
+  @type id :: Snowflake.t()
+
+  @typedoc """
+  [Optional audit entry info](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info).
+  """
+  @type options :: Map.t()
+
+  @typedoc "The reason for this change, if applicable."
+  @type reason :: String.t() | nil
+
+  @typedoc "The ID of the affected entity."
+  @type target_id :: String.t() | nil
+
+  @typedoc "The user who made the changes."
+  @type user_id :: User.id()
+
+  @type t :: %__MODULE__{
+    action_type: action_type,
+    changes: changes,
+    id: id,
+    options: options,
+    reason: reason,
+    target_id: target_id,
+    user_id: user_id
+  }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      action_type: map.action_type,
+      changes: Map.get(map, :changes, []),
+      id: Util.cast(map.id, Snowflake),
+      options: Map.get(map, :options, %{}),
+      reason: Map.get(map, :reason, nil),
+      target_id: map.target_id,
+      user_id: Util.cast(map.user_id, Snowflake)
+    }
+  end
+end

--- a/lib/nostrum/struct/guild/audit_log_entry.ex
+++ b/lib/nostrum/struct/guild/audit_log_entry.ex
@@ -28,13 +28,15 @@ defmodule Nostrum.Struct.Guild.AuditLogEntry do
   Individual changes of this audit log entry.
   Change keys are documented [here](https://discordapp.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key)
   """
-  @type changes :: [
-          %{
-            optional(:old_value) => change_value,
-            optional(:new_value) => change_value,
-            :key => String.t()
-          }
-        ]
+  @type changes ::
+          [
+            %{
+              optional(:old_value) => change_value,
+              optional(:new_value) => change_value,
+              :key => String.t()
+            }
+          ]
+          | nil
 
   @typedoc "The ID of this entry"
   @type id :: Snowflake.t()
@@ -42,7 +44,7 @@ defmodule Nostrum.Struct.Guild.AuditLogEntry do
   @typedoc """
   [Optional audit entry info](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info)
   """
-  @type options :: Map.t()
+  @type options :: Map.t() | nil
 
   @typedoc "The reason for this change, if applicable"
   @type reason :: String.t() | nil
@@ -70,8 +72,8 @@ defmodule Nostrum.Struct.Guild.AuditLogEntry do
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
       |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:user_id, nil, &Util.cast(&1, Snowflake))
-      |> Map.put_new(:changes, [])
-      |> Map.put_new(:options, %{})
+      |> Map.put_new(:changes, nil)
+      |> Map.put_new(:options, nil)
       |> Map.put_new(:reason, nil)
 
     struct(__MODULE__, new)

--- a/lib/nostrum/struct/guild/audit_log_entry.ex
+++ b/lib/nostrum/struct/guild/audit_log_entry.ex
@@ -3,7 +3,8 @@ defmodule Nostrum.Struct.Guild.AuditLogEntry do
   Represents a single entry in the guild's audit log.
   """
 
-  alias Nostrum.Struct.{Snowflake, User}
+  alias Nostrum.Snowflake
+  alias Nostrum.Struct.User
   alias Nostrum.Util
 
   defstruct [
@@ -64,14 +65,15 @@ defmodule Nostrum.Struct.Guild.AuditLogEntry do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      action_type: map.action_type,
-      changes: Map.get(map, :changes, []),
-      id: Util.cast(map.id, Snowflake),
-      options: Map.get(map, :options, %{}),
-      reason: Map.get(map, :reason, nil),
-      target_id: map.target_id,
-      user_id: Util.cast(map.user_id, Snowflake)
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:user_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.put_new(:changes, [])
+      |> Map.put_new(:options, %{})
+      |> Map.put_new(:reason, nil)
+
+    struct(__MODULE__, new)
   end
 end


### PR DESCRIPTION
This PR adds support for retrieving audit logs. Right now it's more or less just parsing the response from the API. However, the API is a mess. A slight mess. A big mess. Pick your poison.

Since I'm not sure if we should structure this nicer (e.g. should we parse each audit log event type into its own struct? what about new audit log events here). Would be happy for some feedback.