### PR TITLE
Dializer Fixes for `Nostrum.Util`

### DIFF
--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -136,13 +136,13 @@ defmodule Nostrum.Util do
     end
   end
 
-  @doc """
-  Returns the gateway url for current websocket connections.
+  @doc ~S"""
+  Returns the gateway url and shard count for current websocket connections.
 
   If by chance no gateway connection has been made, will fetch the url to use and store it
   for future use.
   """
-  @spec gateway() :: String.t()
+  @spec gateway() :: {String.t(), integer}
   def gateway do
     case :ets.lookup(:gateway_url, "url") do
       [] -> get_new_gateway_url()

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -219,7 +219,7 @@ defmodule Nostrum.Util do
   end
 
   @doc false
-  @spec fullsweep_after() :: non_neg_integer
+  @spec fullsweep_after() :: {:fullsweep_after, non_neg_integer}
   def fullsweep_after do
     {:fullsweep_after,
      Application.get_env(

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -117,7 +117,7 @@ defmodule Nostrum.Util do
     end
   end
 
-  @doc ~S"""
+  @doc """
   Returns the gateway url and shard count for current websocket connections.
 
   If by chance no gateway connection has been made, will fetch the url to use and store it

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -4,28 +4,9 @@ defmodule Nostrum.Util do
   """
 
   alias Nostrum.{Api, Constants}
-  alias Nostrum.Shard.Stage.Producer
   alias Nostrum.Struct.Snowflake
 
   require Logger
-
-  @doc """
-  Gets all producers Nostrum event producers.
-
-  To be used when creating custom consumer processes.
-
-  ## Example
-  ```Elixir
-  # Inside of your custom consumer process init callback
-  def init(state) do
-    {:consumer, state, subscribe_to: Nostrum.Util.producers}
-  end
-  ```
-  """
-  @spec producers() :: list(pid)
-  def producers do
-    Producer
-  end
 
   @doc """
   Helper for defining all the methods used for struct and encoding transformations.


### PR DESCRIPTION
Changes:
- Deleted `Util.producers/0`. From what I read on the discord, this is unused. If I misunderstood, give me a heads up.
- Fixed typespecs for `Util.gateway/0` and `Util.fullsweep_after/0`. These are purely static analysis fixes for dialyzer.
