### PR TITLE
Enabled credo `--strict` flag for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ elixir:
 otp_release: '20.3'
 
 script:
-  - mix credo
+  - mix credo --strict
   - mix format --check-formatted
   - mix test --no-start
   - mix docs


### PR DESCRIPTION
Enables more credo checks to improve code uniformity. ~~Also prevents me from incorrectly ordering aliases.~~