### PR TITLE
Give unique IDs to per-scheduler consumers.

### DIFF
--- a/examples/cache.ex
+++ b/examples/cache.ex
@@ -3,7 +3,9 @@ defmodule ExampleSupervisor do
     import Supervisor.Spec
 
     # List comprehension creates a consumer per cpu core
-    children = for i <- 1..System.schedulers_online(), do: ExampleConsumer
+    children =
+      for i <- 1..System.schedulers_online(),
+          do: Supervisor.child_spec({ExampleConsumer, []}, [:consumer, i])
 
     Supervisor.start_link(children, strategy: :one_for_one)
   end

--- a/examples/cache.ex
+++ b/examples/cache.ex
@@ -3,7 +3,7 @@ defmodule ExampleSupervisor do
     # List comprehension creates a consumer per cpu core
     children =
       for i <- 1..System.schedulers_online(),
-          do: Supervisor.child_spec({ExampleConsumer, []}, id: [:consumer, i])
+          do: Supervisor.child_spec({ExampleConsumer, []}, id: {:consumer, i})
 
     Supervisor.start_link(children, strategy: :one_for_one)
   end

--- a/examples/cache.ex
+++ b/examples/cache.ex
@@ -1,11 +1,9 @@
 defmodule ExampleSupervisor do
   def start do
-    import Supervisor.Spec
-
     # List comprehension creates a consumer per cpu core
     children =
       for i <- 1..System.schedulers_online(),
-          do: Supervisor.child_spec({ExampleConsumer, []}, [:consumer, i])
+          do: Supervisor.child_spec({ExampleConsumer, []}, id: [:consumer, i])
 
     Supervisor.start_link(children, strategy: :one_for_one)
   end


### PR DESCRIPTION
As seen in https://github.com/jchristgit/bolt/commit/5f5586eaf3a64c1858c0023f4f73aed1842c1c57, when creating multiple consumer processes, the supervisor needs to have a unique ID (any term) to identify them.