### PR TITLE
Support specifying audit log reasons in API-facing functions.

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1884,8 +1884,7 @@ defmodule Nostrum.Api do
           Guild.id(),
           [%{id: Role.id(), position: integer}],
           AuditLogEntry.reason()
-        ) ::
-          error | {:ok, [Role.t()]}
+        ) :: error | {:ok, [Role.t()]}
   def modify_guild_role_positions(guild_id, positions, reason \\ nil)
       when is_snowflake(guild_id) and is_list(positions) do
     %{
@@ -1906,8 +1905,7 @@ defmodule Nostrum.Api do
           Guild.id(),
           [%{id: Role.id(), position: integer}],
           AuditLogEntry.reason()
-        ) ::
-          no_return | [Role.t()]
+        ) :: no_return | [Role.t()]
   def modify_guild_role_positions!(guild_id, positions, reason \\ nil) do
     modify_guild_role_positions(guild_id, positions, reason)
     |> bangify


### PR DESCRIPTION
Tested API methods:

- `modify_channel/2`
- `modify_channel/3`
- `create_channel_invite/2`
- `create_channel_invite/3`
- `modify_guild_emoji/2`
- `modify_guild_emoji/3`
- `modify_guild/2`
- `modify_guild/3`
- `add_guild_member_role/3`
- `add_guild_member_role/4`
- `remove_guild_member_role/3`
- `remove_guild_member_role/4`
- `remove_guild_member/3`
- `create_guild_ban/4`
- `create_guild_ban/3`
- `remove_guild_ban/3`
- `remove_guild_ban/2`
- `create_guild_role/2`
- `create_guild_role/3`
- `delete_guild_role/2`
- `delete_guild_role/3` (discord seems to ignore the reason here)