### PR TITLE
Pluggable cache backends

### DIFF
--- a/lib/nostrum/cache/user_cache.ex
+++ b/lib/nostrum/cache/user_cache.ex
@@ -1,7 +1,7 @@
 defmodule Nostrum.Cache.UserCache do
   @default_cache_implementation Nostrum.Cache.UserCache.ETS
   @moduledoc """
-  Cache behaviour for users.
+  Cache behaviour & dispatcher for users.
   """
 
   alias Nostrum.Struct.User

--- a/lib/nostrum/cache/user_cache/ets.ex
+++ b/lib/nostrum/cache/user_cache/ets.ex
@@ -1,0 +1,87 @@
+defmodule Nostrum.Cache.UserCache.ETS do
+  @table_name :users
+  @moduledoc """
+  An ETS-based cache for users.
+
+  The default table name under which users are cached is `#{@table_name}`.
+  In addition to the cache behaviour implementations provided by this module,
+  you can also call regular ETS table methods on it, such as `:ets.info`.
+  """
+
+  @behaviour Nostrum.Cache.UserCache
+
+  alias Nostrum.Struct.User
+
+  @doc "Set up the cache for tests."
+  def setup do
+    :ets.new(@table_name, [:set, :public, :named_table])
+  end
+
+  @impl Nostrum.Cache.UserCache
+  @spec bulk_create([Map.t()]) :: :ok
+  def bulk_create(members) do
+    Enum.each(members, &:ets.insert(@table_name, {&1.user.id, &1.user}))
+  end
+
+  @impl Nostrum.Cache.UserCache
+  @spec create(Map.t()) :: User.t()
+  def create(user) do
+    :ets.insert(@table_name, {user.id, user})
+    User.to_struct(user)
+  end
+
+  @impl Nostrum.Cache.UserCache
+  @spec delete(User.id()) :: User.t() | :noop
+  def delete(id) do
+    case lookup(id) do
+      {:ok, user} ->
+        :ets.delete(@table_name, id)
+        User.to_struct(user)
+
+      _ ->
+        :noop
+    end
+  end
+
+  @impl Nostrum.Cache.UserCache
+  @spec get(User.id()) :: {:ok, User.t()} | {:error, atom}
+  def get(id) do
+    case lookup(id) do
+      {:ok, user} -> {:ok, User.to_struct(user)}
+      error -> error
+    end
+  end
+
+  @impl Nostrum.Cache.UserCache
+  @spec update(Map.t()) :: {User.t(), User.t()} | :noop
+  def update(info) do
+    with {:ok, u} <- lookup(info.id),
+         new_user = Map.merge(u, info),
+         false <- u == new_user do
+      :ets.insert(@table_name, {new_user.id, new_user})
+      {User.to_struct(u), User.to_struct(new_user)}
+    else
+      {:error, _} ->
+        # User just came online, make sure to cache if possible
+        if Enum.all?([:username, :discriminator], &Map.has_key?(info, &1)),
+          do: :ets.insert(@table_name, {info.id, info})
+
+        :noop
+
+      true ->
+        :noop
+    end
+  end
+
+  @doc false
+  @spec lookup(User.id()) :: {:error, :user_not_found} | {:ok, map}
+  def lookup(id) do
+    case :ets.lookup(@table_name, id) do
+      [] ->
+        {:error, :user_not_found}
+
+      [{^id, user}] ->
+        {:ok, user}
+    end
+  end
+end

--- a/lib/nostrum/cache/user_cache/ets.ex
+++ b/lib/nostrum/cache/user_cache/ets.ex
@@ -19,8 +19,8 @@ defmodule Nostrum.Cache.UserCache.ETS do
 
   @impl Nostrum.Cache.UserCache
   @spec bulk_create([Map.t()]) :: :ok
-  def bulk_create(members) do
-    Enum.each(members, &:ets.insert(@table_name, {&1.user.id, &1.user}))
+  def bulk_create(users) do
+    Enum.each(users, &:ets.insert(@table_name, {&1.id, &1}))
   end
 
   @impl Nostrum.Cache.UserCache

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -174,7 +174,7 @@ defmodule Nostrum.Shard.Dispatch do
   end
 
   def handle_event(:GUILD_MEMBERS_CHUNK = event, p, state) do
-    UserCache.bulk_create(p.members)
+    UserCache.bulk_create(Stream.map(p.members, & &1.user))
     GuildServer.member_chunk(p.guild_id, p.members)
 
     # note: not casted at the moment, deemed mostly internal

--- a/test/nostrum/cache/user_cache_test.exs
+++ b/test/nostrum/cache/user_cache_test.exs
@@ -1,0 +1,96 @@
+defmodule Nostrum.Cache.UserCacheTest do
+  use ExUnit.Case, async: true
+
+  @cache_implementations [
+    Nostrum.Cache.UserCache.ETS
+  ]
+
+  for cache <- @cache_implementations do
+    defmodule :"#{cache}Test" do
+      alias Nostrum.Struct.User
+      use ExUnit.Case
+
+      # this is needed because otherwise we cannot access
+      # the cache in the tests
+      @cache cache
+      @test_user %{
+        id: 12345,
+        username: "test",
+        discriminator: "1234",
+        avatar: nil,
+        bot: true,
+        mfa_enabled: nil,
+        verified: nil
+      }
+      @test_user_two %{
+        id: 54321,
+        username: "test two",
+        discriminator: "4321",
+        avatar: nil,
+        bot: true,
+        mfa_enabled: nil,
+        verified: nil
+      }
+
+      setup do
+        @cache.setup()
+        :ok
+      end
+
+      describe "bulk_create/1" do
+        test "returns `:ok`" do
+          users = [@test_user, @test_user_two]
+          assert :ok = @cache.bulk_create(users)
+        end
+      end
+
+      describe "create/1" do
+        test "returns a struct of the created user" do
+          expected = User.to_struct(@test_user)
+
+          assert ^expected = @cache.create(@test_user)
+        end
+      end
+
+      describe "delete/1" do
+        test "returns `:noop` on uncached user" do
+          assert :noop = @cache.delete(10_258_109_258_109_258_125)
+        end
+
+        test "returns user struct on cached user" do
+          expected = User.to_struct(@test_user)
+          @cache.create(@test_user)
+          assert ^expected = @cache.delete(@test_user.id)
+        end
+      end
+
+      describe "get/1" do
+        test "returns error tuple on unknown user" do
+          assert {:error, _reason} = @cache.get(120_815_092_581_902_580)
+        end
+
+        test "returns cached user on known user" do
+          expected = User.to_struct(@test_user)
+          @cache.create(@test_user)
+          assert {:ok, ^expected} = @cache.get(@test_user.id)
+        end
+      end
+
+      describe "update/1" do
+        test "returns `:noop` on uncached user" do
+          payload = %{id: 8_284_967_893_178_597_859_421}
+          assert :noop = @cache.update(payload)
+        end
+
+        test "returns `{before, after}` on cached user" do
+          expected_before = User.to_struct(@test_user)
+          updated_test_user = Map.put(@test_user, :name, "updated test user")
+          expected_after = User.to_struct(updated_test_user)
+          @cache.create(@test_user)
+
+          assert {^expected_before, ^expected_after} = @cache.update(updated_test_user)
+        end
+      end
+    end
+  end
+end

--- a/test/nostrum/cache/user_cache_test.exs
+++ b/test/nostrum/cache/user_cache_test.exs
@@ -1,11 +1,12 @@
 defmodule Nostrum.Cache.UserCacheTest do
   use ExUnit.Case, async: true
 
-  @cache_implementations [
+  @cache_modules [
+    # Implementations
     Nostrum.Cache.UserCache.ETS
   ]
 
-  for cache <- @cache_implementations do
+  for cache <- @cache_modules do
     defmodule :"#{cache}Test" do
       alias Nostrum.Struct.User
       use ExUnit.Case


### PR DESCRIPTION
This merge request implements support for pluggable caches on the user cache.

The current cache has been moved to `Nostrum.Cache.UserCache.ETS` and is used by default.

There is one remaining issue which is that the `bulk_create` function currently takes a list of guild members. To keep things generic, we should probably just pass this via `Stream.map` in the dispatcher, but I'm curious for other ideas.