### PR TITLE
Fix Api.create_message! typespec

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -242,7 +242,8 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Same as `create_message/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec create_message!(Channel.id() | Message.t(), options | String.t()) :: no_return | Message.t()
+  @spec create_message!(Channel.id() | Message.t(), options | String.t()) ::
+          no_return | Message.t()
   def create_message!(channel_id, options) do
     create_message(channel_id, options)
     |> bangify

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -242,7 +242,7 @@ defmodule Nostrum.Api do
   @doc ~S"""
   Same as `create_message/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
-  @spec create_message!(Channel.id() | Message.t(), options) :: no_return | Message.t()
+  @spec create_message!(Channel.id() | Message.t(), options | String.t()) :: no_return | Message.t()
   def create_message!(channel_id, options) do
     create_message(channel_id, options)
     |> bangify


### PR DESCRIPTION
`Api.create_message` treats the options parameter as the message content if it is a string. This is represented in the typespec for `Api.create_message`. `Api.create_message!` simply passes the options parameter to `Api.create_message`, so it should have the same typespec for this parameter.