### PR TITLE
Strip minor parameters from `/reactions` endpoint.

### DIFF
--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -147,7 +147,8 @@ defmodule Nostrum.Api.Ratelimiter do
     if String.ends_with?(endpoint, "/messages/_id") and method == :delete do
       "delete:" <> endpoint
     else
-      endpoint
+      # Strips `emoji` and `user_id` suffix off the reaction endpoints.
+      String.replace(endpoint, ~r[/reactions/.+/.+$]iu, "/reactions")
     end
   end
 

--- a/test/nostrum/api/ratelimit_test.exs
+++ b/test/nostrum/api/ratelimit_test.exs
@@ -43,6 +43,18 @@ defmodule Nostrum.Api.RatelimitTest do
     assert result == expected
   end
 
+  test "reaction endpoint" do
+    expected = "/channels/#{@test_channel}/messages/_id/reactions"
+
+    result =
+      Nostrum.Api.Ratelimiter.get_endpoint(
+        "/channels/#{@test_channel}/messages/#{@test_message}/reactions/⬅/@me",
+        :get
+      )
+
+    assert result == expected
+  end
+
   @tag disabled: true
   test "non-major parameter async no 429" do
     [first, second] = @test_users


### PR DESCRIPTION
This should be enough to fix #156, though probably not the best way to do it.

While the new `X-RateLimit-Bucket` should've helped in this situation, in practice we'd still need to strip out the minor parameters, otherwise something like the following would happen:

> We queue a request to `/channels/123456789/messages/_id/reactions/⬅/@me`;
> We haven't seen it before -- our rate limiter says it's alright;
> Discord replies with an OK, we store the bucket for that route;
> We queue a request to `/channels/123456789/messages/_id/reactions/➡/@me`;
> We haven't seen it before -- our rate limiter says it's alright;
> Discord replies with 429.

Because of that, though handling the new header is worthwhile, I consider those two things separate issues.