### PR TITLE
Add MESSAGE_REACTION_REMOVE_EMOJI event and endpoint

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -476,6 +476,37 @@ defmodule Nostrum.Api do
   end
 
   @doc ~S"""
+  Deletes all reactions of a given emoji from a message.
+
+  This endpoint requires the `MANAGE_MESSAGES` permissions. It fires a `t:Nostrum.Consumer.message_reaction_remove_emoji/0` event.
+
+  If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
+
+  See `create_reaction/3` for similar examples.
+  """
+  @spec delete_reaction(Channel.id(), Message.id(), emoji) :: error | {:ok}
+  def delete_reaction(channel_id, message_id, emoji)
+
+  def delete_reaction(channel_id, message_id, %Emoji{} = emoji),
+    do: delete_reaction(channel_id, message_id, Emoji.api_name(emoji))
+
+  def delete_reaction(channel_id, message_id, emoji_api_name) do
+    request(
+      :delete,
+      Constants.channel_reactions_delete_emoji(channel_id, message_id, emoji_api_name)
+    )
+  end
+
+  @doc ~S"""
+  Same as `delete_reaction/3`, but raises `Nostrum.Error.ApiError` in case of failure.
+  """
+  @spec delete_reaction!(Channel.id(), Message.id(), emoji) :: no_return | {:ok}
+  def delete_reaction!(channel_id, message_id, emoji) do
+    delete_reaction(channel_id, message_id, emoji)
+    |> bangify
+  end
+
+  @doc ~S"""
   Gets all users who reacted with an emoji.
 
   This endpoint requires the `VIEW_CHANNEL` and `READ_MESSAGE_HISTORY` permissions.

--- a/lib/nostrum/constants.ex
+++ b/lib/nostrum/constants.ex
@@ -24,6 +24,9 @@ defmodule Nostrum.Constants do
   def channel_reactions_delete(channel_id, message_id),
     do: "/channels/#{channel_id}/messages/#{message_id}/reactions"
 
+  def channel_reactions_delete_emoji(channel_id, message_id, emoji),
+    do: "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}"
+
   def channel_bulk_delete(channel_id), do: "/channels/#{channel_id}/messages/bulk_delete"
 
   def channel_permission(channel_id, overwrite_id),

--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -137,6 +137,7 @@ defmodule Nostrum.Consumer do
   @type message_reaction_add :: {:MESSAGE_REACTION_ADD, map, WSState.t()}
   @type message_reaction_remove :: {:MESSAGE_REACTION_REMOVE, map, WSState.t()}
   @type message_reaction_remove_all :: {:MESSAGE_REACTION_REMOVE_ALL, map, WSState.t()}
+  @type message_reaction_remove_emoji :: {:MESSAGE_REACTION_REMOVE_EMOJI, map, WSState.t()}
   @type message_ack :: {:MESSAGE_ACK, map, WSState.t()}
   @typedoc """
   Dispatched when a user's presence is updated.

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -176,6 +176,8 @@ defmodule Nostrum.Shard.Dispatch do
 
   def handle_event(:MESSAGE_REACTION_REMOVE_ALL = event, p, state), do: {event, p, state}
 
+  def handle_event(:MESSAGE_REACTION_REMOVE_EMOJI = event, p, state), do: {event, p, state}
+
   def handle_event(:MESSAGE_ACK = event, p, state), do: {event, p, state}
 
   def handle_event(:PRESENCE_UPDATE = event, p, state) do


### PR DESCRIPTION
Adds the new `MESSAGE_REACTION_REMOVE_EMOJI` event as well as a new API method `delete_reaction/3`.

hex release when?