### PR TITLE
Leaving guild fails with 400: Bad Request (#164)

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -2427,7 +2427,13 @@ defmodule Nostrum.Api do
   """
   @spec leave_guild(integer) :: error | {:ok}
   def leave_guild(guild_id) do
-    request(:delete, Constants.me_guild(guild_id))
+    request(%{
+      method: :delete,
+      route: Constants.me_guild(guild_id),
+      body: "",
+      options: [],
+      headers: []
+    })
   end
 
   @doc """


### PR DESCRIPTION
Default headers [`[{"content-type", "application/json"}]`](https://github.com/Kraigie/nostrum/blob/master/lib/nostrum/api.ex#L2833) added by `Nostrum.Api.request/4` causes `Nostrum.Api.leave_guild/1` to fail with `400: Bad Request` response.