### PR TITLE
Add Elixir 1.10 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: elixir
 
 elixir:
   - '1.9.0'
+  - '1.10.0'
 otp_release: '22.0'
 
 script:


### PR DESCRIPTION
This PR adds the latest elixir version to CI as a safety check for nostrum's unit tests.