### PR TITLE
Fixes Logger deprecation warning.

### DIFF
--- a/lib/nostrum/shard/event.ex
+++ b/lib/nostrum/shard/event.ex
@@ -10,7 +10,9 @@ defmodule Nostrum.Shard.Event do
   def handle(:dispatch, payload, state) do
     payload = Util.safe_atom_map(payload)
 
-    if Application.get_env(:nostrum, :log_dispatch_events), do: Logger.debug(payload.t)
+    if Application.get_env(:nostrum, :log_dispatch_events),
+      do: payload.t |> inspect() |> Logger.debug()
+
     Producer.notify(Producer, payload, state)
 
     if payload.t == :READY do


### PR DESCRIPTION
As of Elixir 1.10, any values other than strings, lists or maps passed to Logger results in a deprecation warning.

Example: warning: passing :PRESENCE_UPDATE to Logger is deprecated, expected a binary or an iolist