### PR TITLE
Update configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # If you run "mix test --cover", coverage assets end up here.
 /cover
 
+# Provide your own token during test
+/config/secret.exs
+
 # The directory Mix downloads your dependencies sources to.
 /deps
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,3 +5,5 @@ config :nostrum,
   num_shards: :auto
 
 config :logger, :console, metadata: [:shard]
+
+if File.exists?("config/secret.exs"), do: import_config("secret.exs")

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :nostrum,
   token: "",


### PR DESCRIPTION
Adds a way to add secret configs during testing.

I also realized that Nostrum was still using `Mix.Config`, which have been deprecated, so I updated that as well