### PR TITLE
fix: update_status now handles status as :atom

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -123,7 +123,7 @@ defmodule Nostrum.Api do
   """
   @spec update_status(status, String.t(), integer, String.t() | nil) :: :ok
   def update_status(status, game, type \\ 0, stream \\ nil) do
-    Supervisor.update_status(status, game, stream, type)
+    Supervisor.update_status(to_string(status), game, stream, type)
     :ok
   end
 


### PR DESCRIPTION
Updated `Nostrum.Api.update_status` to reflect `@type status :: :dnd | :idle | :online | :invisible`