### PR TITLE
Nostrum.Cache.GuildCache.all/0 fails with EXIT :noproc

### DIFF
--- a/lib/nostrum/cache/guild_cache.ex
+++ b/lib/nostrum/cache/guild_cache.ex
@@ -3,7 +3,7 @@ defmodule Nostrum.Cache.GuildCache do
   Functions for retrieving guild states.
   """
 
-  alias Nostrum.Cache.Guild.GuildServer
+  alias Nostrum.Cache.Guild.{GuildServer, GuildSupervisor}
   alias Nostrum.Cache.Mapping.ChannelGuild
   alias Nostrum.Struct.Channel
   alias Nostrum.Struct.Guild


### PR DESCRIPTION
Title says it all.  The code references the `GuildSupervisor` without its full prefix (as if it was aliased) instead of the full path `Nostrum.Cache.GuildCache.all`.

This compiles because nothing at compile time knows that `GuildSupervisor` won't be a registered name.  At run time, however, the `GuildSupervisor` is named with its full path, so `Supervisor.which_children/1` can't find the process and exits with the expected `:noproc` status.

This fix adds an alias.