### PR TITLE
Fix `guild_permissions` type failure.

### DIFF
--- a/lib/nostrum/struct/guild/member.ex
+++ b/lib/nostrum/struct/guild/member.ex
@@ -118,7 +118,7 @@ defmodule Nostrum.Struct.Guild.Member do
 
     member_permissions =
       member_role_ids
-      |> Enum.map(&Map.get(guild.roles, &1))
+      |> Enum.map(&Enum.find(guild.roles, fn role -> role.id == &1 end))
       |> Enum.filter(&(!match?(nil, &1)))
       |> Enum.reduce(0, fn role, bitset_acc ->
         bitset_acc ||| role.permissions
@@ -154,7 +154,7 @@ defmodule Nostrum.Struct.Guild.Member do
     if Enum.member?(guild_perms, :administrator) do
       Permission.all()
     else
-      channel = Map.get(guild.channels, channel_id)
+      channel = Enum.find(guild.channels, &(&1.id == channel_id))
 
       everyone_role_id = guild.id
       role_ids = [everyone_role_id | member.roles]

--- a/test/nostrum/struct/guild/member_test.exs
+++ b/test/nostrum/struct/guild/member_test.exs
@@ -19,7 +19,7 @@ defmodule Nostrum.Struct.MemberTest do
     test "returns all perms if admin" do
       member = %Member{roles: [10]}
       role = %Role{id: 10, permissions: Permission.to_bitset([:administrator])}
-      guild = %Guild{roles: %{role.id => role}}
+      guild = %Guild{roles: [role]}
 
       result = Member.guild_permissions(member, guild)
 
@@ -41,7 +41,7 @@ defmodule Nostrum.Struct.MemberTest do
       role = %Role{id: 10, permissions: Permission.to_bitset(role_perms)}
 
       guild = %Guild{
-        roles: %{role.id => role}
+        roles: [role]
       }
 
       result = Member.guild_permissions(member, guild)
@@ -67,9 +67,9 @@ defmodule Nostrum.Struct.MemberTest do
       channel = %Channel{id: context[:channel_id]}
 
       guild = %Guild{
-        channels: %{channel.id => channel},
-        members: %{member.user.id => member},
-        roles: %{role.id => role}
+        channels: [channel],
+        members: [member],
+        roles: [role]
       }
 
       result = Member.guild_channel_permissions(member, guild, context[:channel_id])
@@ -98,8 +98,8 @@ defmodule Nostrum.Struct.MemberTest do
 
       guild = %Guild{
         id: context[:guild_id],
-        channels: %{channel.id => channel},
-        roles: %{everyone_role.id => everyone_role, role.id => role}
+        channels: [channel],
+        roles: [everyone_role, role]
       }
 
       result = Member.guild_channel_permissions(member, guild, context[:channel_id])
@@ -125,8 +125,8 @@ defmodule Nostrum.Struct.MemberTest do
 
       guild = %Guild{
         id: context[:guild_id],
-        channels: %{channel.id => channel},
-        roles: %{everyone_role.id => everyone_role, role.id => role}
+        channels: [channel],
+        roles: [everyone_role, role]
       }
 
       result = Member.guild_channel_permissions(member, guild, context[:channel_id])
@@ -151,8 +151,8 @@ defmodule Nostrum.Struct.MemberTest do
 
       guild = %Guild{
         id: context[:guild_id],
-        channels: %{channel.id => channel},
-        roles: %{everyone_role.id => everyone_role, role.id => role}
+        channels: [channel],
+        roles: [everyone_role, role]
       }
 
       result = Member.guild_channel_permissions(member, guild, context[:channel_id])


### PR DESCRIPTION
Spotted by a test in `nosedrum`:

    ** (BadMapError) expected a map, got: [%Nostrum.Struct.Guild.Role{color: nil, hoist: nil, id: 125910, managed: nil, mentionable: nil, name: nil, permissions: 4, position: nil}]
     code: assert {:noperm, _reason} = predicate.(message)
     stacktrace:
       (elixir 1.11.2) lib/map.ex:469: Map.get([%Nostrum.Struct.Guild.Role{color: nil, hoist: nil, id: 125910, managed: nil, mentionable: nil, name: nil, permissions: 4, position: nil}], 555, nil)
       (elixir 1.11.2) lib/enum.ex:1399: Enum."-map/2-lists^map/1-0-"/2
       (nostrum 0.4.5) lib/nostrum/struct/guild/member.ex:121: Nostrum.Struct.Guild.Member.guild_permissions/2
       (nosedrum 0.2.0) lib/nosedrum/predicates.ex:121: anonymous fn/2 in Nosedrum.Predicates.has_permission/1
       test/nosedrum/predicates_test.exs:107: (test)

Tests are also updated to reflect the proper type.