### PR TITLE
Kill unused alias.

### DIFF
--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -23,7 +23,6 @@ defmodule Nostrum.Consumer do
   alias Nostrum.Shard.Stage.Cache
   alias Nostrum.Struct.{Channel, WSState}
   alias Nostrum.Struct.Event.{MessageDelete, MessageDeleteBulk, SpeakingUpdate}
-  alias Nostrum.Util
 
   @doc """
   Callback used to handle events.


### PR DESCRIPTION
This has been blobbering up CI warnings for a while.