### PR TITLE
Fix Nostrum.Consumer options

### DIFF
--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -240,28 +240,21 @@ defmodule Nostrum.Consumer do
   `mod` is the name of the module where you define your event callbacks, which should probably be
   the current module which you can get with `__MODULE__`.
 
-  `options` is a list of general process options. See `t:Nostrum.Consumer.options/0` for more info.
+  `opts` is a list of general process options. See `t:Nostrum.Consumer.options/0` for more info.
   """
   @spec start_link(module, options) :: Supervisor.on_start()
-  def start_link(mod, options \\ [])
+  def start_link(mod, opts \\ []) do
+    {mod_and_opts, cs_opts} =
+      case Keyword.pop(opts, :name) do
+        {nil, mod_opts} -> {[mod, mod_opts], []}
+        {cs_name, mod_opts} -> {[mod, mod_opts], [name: cs_name]}
+      end
 
-  def start_link(mod, [name: name] = options) do
-    ConsumerSupervisor.start_link(
-      __MODULE__,
-      [mod, Keyword.drop(options, [:name])],
-      name: name
-    )
+    ConsumerSupervisor.start_link(__MODULE__, mod_and_opts, cs_opts)
   end
 
-  def start_link(mod, options),
-    do:
-      ConsumerSupervisor.start_link(
-        __MODULE__,
-        [mod, options]
-      )
-
   @doc false
-  def init([mod, opt]) do
+  def init([mod, opts]) do
     default = [strategy: :one_for_one, subscribe_to: [Cache]]
 
     ConsumerSupervisor.init(
@@ -272,7 +265,7 @@ defmodule Nostrum.Consumer do
           restart: :transient
         }
       ],
-      Keyword.merge(default, opt)
+      Keyword.merge(default, opts)
     )
   end
 end


### PR DESCRIPTION
When calling `Nostrum.Consumer.start_link/2` from your own consumer, some option combinations will make it fail to start.

Currently, you can either pass the `name` option for the ConsumerSupervisor
```elixir
# First pattern match
def start_link(mod, [name: name] = options) do
  ConsumerSupervisor.start_link(
    __MODULE__,
    [mod, Keyword.drop(options, [:name])],
    name: name
  )
end
```

Or pass in the rest of the [options](https://kraigie.github.io/nostrum/Nostrum.Consumer.html#t:option/0) for the event handler module
```elixir
# Second pattern match
def start_link(mod, options),
  do:
    ConsumerSupervisor.start_link(
      __MODULE__,
      [mod, options]
    )
```

If `name` and some of the other options get passed together to the `start_link` function, it will fail the first pattern match and put all given options as the event handler module options, making the consumer fail to start with
`** (EXIT) {:bad_opts, "unknown options [name: <whatever_name_was_passed>]"}`

For example, defining the `start_link` function of your own consumer like this is currently not possible
```elixir
def start_link do
  Consumer.start_link(__MODULE__, name: __MODULE__, max_restarts: 0)
end
```