### PR TITLE
Add support for reading message references

### DIFF
--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -5,7 +5,7 @@ defmodule Nostrum.Struct.Message do
 
   alias Nostrum.Struct.{Embed, User}
   alias Nostrum.Struct.Guild.Member
-  alias Nostrum.Struct.Message.{Activity, Application, Attachment, Reaction}
+  alias Nostrum.Struct.Message.{Activity, Application, Attachment, Reaction, Reference}
   alias Nostrum.{Snowflake, Util}
 
   defstruct [
@@ -23,9 +23,11 @@ defmodule Nostrum.Struct.Message do
     :mention_everyone,
     :mention_roles,
     :mentions,
+    :message_reference,
     :nonce,
     :pinned,
     :reactions,
+    :referenced_message,
     :timestamp,
     :tts,
     :type,
@@ -107,6 +109,20 @@ defmodule Nostrum.Struct.Message do
   """
   @type member :: Member.t() | nil
 
+  @typedoc """
+  reference data sent with crossposted messages and replies
+  """
+  @type message_reference :: Reference.t() | nil
+
+  @typedoc """
+  the message associated with the message_reference
+
+  This field is only returned for messages with a type of 19 (REPLY). If the message is a reply but the
+  referenced_message field is not present, the backend did not attempt to fetch the message that was being replied to,
+  so its state is unknown. If the field exists but is null, the referenced message was deleted.
+  """
+  @type referenced_message :: t() | nil
+
   @type t :: %__MODULE__{
           activity: activity,
           application: application,
@@ -122,6 +138,7 @@ defmodule Nostrum.Struct.Message do
           mention_everyone: mention_everyone,
           mention_roles: mention_roles,
           mentions: mentions,
+          message_reference: message_reference,
           nonce: nonce,
           pinned: pinned,
           reactions: reactions,
@@ -159,6 +176,8 @@ defmodule Nostrum.Struct.Message do
       |> Map.update(:activity, nil, &Util.cast(&1, {:struct, Activity}))
       |> Map.update(:application, nil, &Util.cast(&1, {:struct, Application}))
       |> Map.update(:member, nil, &Util.cast(&1, {:struct, Member}))
+      |> Map.update(:message_reference, nil, &Util.cast(&1, {:struct, Reference}))
+      |> Map.update(:referenced_message, nil, &Util.cast(&1, {:struct, __MODULE__}))
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -110,12 +110,12 @@ defmodule Nostrum.Struct.Message do
   @type member :: Member.t() | nil
 
   @typedoc """
-  reference data sent with crossposted messages and replies
+  Reference data sent with crossposted messages and replies
   """
   @type message_reference :: Reference.t() | nil
 
   @typedoc """
-  the message associated with the message_reference
+  The message associated with the message_reference
 
   This field is only returned for messages with a type of 19 (REPLY). If the message is a reply but the
   referenced_message field is not present, the backend did not attempt to fetch the message that was being replied to,
@@ -142,6 +142,7 @@ defmodule Nostrum.Struct.Message do
           nonce: nonce,
           pinned: pinned,
           reactions: reactions,
+          referenced_message: referenced_message,
           timestamp: timestamp,
           tts: tts,
           type: type,

--- a/lib/nostrum/struct/message/reference.ex
+++ b/lib/nostrum/struct/message/reference.ex
@@ -4,6 +4,7 @@ defmodule Nostrum.Struct.Message.Reference do
   """
 
   alias Nostrum.{Snowflake, Util}
+  alias Nostrum.Struct.Message.{Channel, Guild, Message}
 
   defstruct [
     :message_id,
@@ -11,14 +12,14 @@ defmodule Nostrum.Struct.Message.Reference do
     :guild_id
   ]
 
-  @typedoc "id of the originating message"
-  @type message_id :: Snowflake.t()
+  @typedoc "Id of the originating message"
+  @type message_id :: Message.id()
 
-  @typedoc "id of the originating message's channel"
-  @type channel_id :: Snowflake.t()
+  @typedoc "Id of the originating message's channel"
+  @type channel_id :: Channel.id()
 
-  @typedoc "id of the originating message's guild"
-  @type guild_id :: Snowflake.t()
+  @typedoc "Id of the originating message's guild"
+  @type guild_id :: Guild.id()
 
   @type t :: %__MODULE__{
           message_id: message_id,

--- a/lib/nostrum/struct/message/reference.ex
+++ b/lib/nostrum/struct/message/reference.ex
@@ -1,0 +1,40 @@
+defmodule Nostrum.Struct.Message.Reference do
+  @moduledoc """
+  Struct representing a discord message reference.
+  """
+
+  alias Nostrum.{Snowflake, Util}
+
+  defstruct [
+    :message_id,
+    :channel_id,
+    :guild_id
+  ]
+
+  @typedoc "id of the originating message"
+  @type message_id :: Snowflake.t()
+
+  @typedoc "id of the originating message's channel"
+  @type channel_id :: Snowflake.t()
+
+  @typedoc "id of the originating message's guild"
+  @type guild_id :: Snowflake.t()
+
+  @type t :: %__MODULE__{
+          message_id: message_id,
+          channel_id: channel_id,
+          guild_id: guild_id
+        }
+
+  @doc false
+  def to_struct(map) do
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
+  end
+end

--- a/lib/nostrum/struct/message/reference.ex
+++ b/lib/nostrum/struct/message/reference.ex
@@ -4,7 +4,7 @@ defmodule Nostrum.Struct.Message.Reference do
   """
 
   alias Nostrum.{Snowflake, Util}
-  alias Nostrum.Struct.Message.{Channel, Guild, Message}
+  alias Nostrum.Struct.{Channel, Guild, Message}
 
   defstruct [
     :message_id,


### PR DESCRIPTION
Adding support for `message_reference` and `referenced_message` for message objects: https://discord.com/developers/docs/resources/channel#message-object

Per contributing guidelines I ran `mix credo --strict`.  I got some warnings about TODOs, but they are unrelated to my changes.