### PR TITLE
Add new public guild fields

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1416,6 +1416,10 @@ defmodule Nostrum.Api do
     (VIP only)
     * `:system_channel_id` (`t:Nostrum.Snowflake.t/0`) - the id of the
     channel to which system messages are sent
+    * `:rules_channel_id` (`t:Nostrum.Snowflake.t/0`) - the id of the channel that
+    is used for rules in public guilds
+    * `:public_updates_channel_id` (`t:Nostrum.Snowflake.t/0`) - the id of the channel
+    where admins and moderators receive notices from Discord in public guilds
 
   ## Examples
 

--- a/lib/nostrum/struct/channel.ex
+++ b/lib/nostrum/struct/channel.ex
@@ -30,7 +30,7 @@ defmodule Nostrum.Struct.Channel do
   ```
   """
 
-  alias Nostrum.Struct.{Overwrite, User}
+  alias Nostrum.Struct.{Channel, Guild, Message, Overwrite, User}
   alias Nostrum.{Snowflake, Util}
 
   defstruct [
@@ -61,7 +61,7 @@ defmodule Nostrum.Struct.Channel do
   @type id :: Snowflake.t()
 
   @typedoc "The id of the channel's guild"
-  @type guild_id :: Snowflake.t()
+  @type guild_id :: Guild.id()
 
   @typedoc "The ordered position of the channel"
   @type position :: integer
@@ -79,7 +79,7 @@ defmodule Nostrum.Struct.Channel do
   @type nsfw :: boolean
 
   @typedoc "Id of the last message sent"
-  @type last_message_id :: Snowflake.t() | nil
+  @type last_message_id :: Message.id() | nil
 
   @typedoc "The bitrate of the voice channel"
   @type bitrate :: integer
@@ -94,13 +94,13 @@ defmodule Nostrum.Struct.Channel do
   @type icon :: String.t() | nil
 
   @typedoc "The id of the DM creator"
-  @type owner_id :: Snowflake.t()
+  @type owner_id :: User.id()
 
   @typedoc "The application id of the group DM creator if it is bot-created"
   @type application_id :: Snowflake.t() | nil
 
   @typedoc "The id of the parent category for a channel"
-  @type parent_id :: Snowflake.t() | nil
+  @type parent_id :: Channel.id() | nil
 
   @typedoc "When the last pinned message was pinned"
   @type last_pin_timestamp :: String.t() | nil

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -36,6 +36,7 @@ defmodule Nostrum.Struct.Emoji do
   """
 
   alias Nostrum.{Constants, Snowflake, Util}
+  alias Nostrum.Struct.Guild.Role
   alias Nostrum.Struct.User
 
   defstruct [
@@ -86,7 +87,7 @@ defmodule Nostrum.Struct.Emoji do
   @type name :: String.t()
 
   @typedoc "Roles this emoji is whitelisted to"
-  @type roles :: [Snowflake.t()] | nil
+  @type roles :: [Role.id()] | nil
 
   @typedoc "User that created this emoji"
   @type user :: User.t() | nil

--- a/lib/nostrum/struct/event/message_delete.ex
+++ b/lib/nostrum/struct/event/message_delete.ex
@@ -3,7 +3,7 @@ defmodule Nostrum.Struct.Event.MessageDelete do
   Struct representing a Message Delete event
   """
 
-  alias Nostrum.Snowflake
+  alias Nostrum.Struct.{Guild, Message}
 
   defstruct [
     :id,
@@ -12,17 +12,17 @@ defmodule Nostrum.Struct.Event.MessageDelete do
   ]
 
   @typedoc "Id of the deleted message"
-  @type id :: Snowflake.t()
+  @type id :: Message.id()
 
   @typedoc "Channel id of the deleted message"
-  @type channel_id :: Snowflake.t()
+  @type channel_id :: Channel.id()
 
   @typedoc """
   Guild id of the deleted message
 
   `nil` if a non-guild message was deleted.
   """
-  @type guild_id :: Snowflake.t() | nil
+  @type guild_id :: Guild.id() | nil
 
   @type t :: %__MODULE__{
           id: id,

--- a/lib/nostrum/struct/event/message_delete_bulk.ex
+++ b/lib/nostrum/struct/event/message_delete_bulk.ex
@@ -3,7 +3,7 @@ defmodule Nostrum.Struct.Event.MessageDeleteBulk do
   Struct representing a Message Delete Bulk event
   """
 
-  alias Nostrum.Snowflake
+  alias Nostrum.Struct.{Guild, Message}
 
   defstruct [
     :channel_id,
@@ -12,17 +12,17 @@ defmodule Nostrum.Struct.Event.MessageDeleteBulk do
   ]
 
   @typedoc "Channel id of the deleted message"
-  @type channel_id :: Snowflake.t()
+  @type channel_id :: Channel.id()
 
   @typedoc """
   Guild id of the deleted message
 
   `nil` if a non-guild message was deleted.
   """
-  @type guild_id :: Snowflake.t() | nil
+  @type guild_id :: Guild.id() | nil
 
   @typedoc "Ids of the deleted messages"
-  @type ids :: [Snowflake.t(), ...]
+  @type ids :: [Message.id(), ...]
 
   @type t :: %__MODULE__{
           channel_id: channel_id,

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -53,13 +53,13 @@ defmodule Nostrum.Struct.Guild do
   @type splash :: String.t() | nil
 
   @typedoc "The id of the guild owner"
-  @type owner_id :: Snowflake.t()
+  @type owner_id :: User.id()
 
   @typedoc "The id of the voice region"
   @type region :: String.t()
 
   @typedoc "The id of the guild's afk channel"
-  @type afk_channel_id :: Snowflake.t() | nil
+  @type afk_channel_id :: Channel.id() | nil
 
   @typedoc "The time someone must be afk before being moved"
   @type afk_timeout :: integer
@@ -68,7 +68,7 @@ defmodule Nostrum.Struct.Guild do
   @type embed_enabled :: boolean | nil
 
   @typedoc "The id of the embedded channel"
-  @type embed_channel_id :: Snowflake.t() | nil
+  @type embed_channel_id :: Channel.id() | nil
 
   @typedoc "The level of verification"
   @type verification_level :: integer
@@ -108,24 +108,24 @@ defmodule Nostrum.Struct.Guild do
   @typedoc """
   The channel id for the server widget.
   """
-  @type widget_channel_id :: Snowflake.t()
+  @type widget_channel_id :: Channel.id()
 
   @typedoc """
   The id of the channel to which system messages are sent.
   """
-  @type system_channel_id :: Snowflake.t() | nil
+  @type system_channel_id :: Channel.id() | nil
 
   @typedoc """
   The id of the channel that is used for rules. This is only available to guilds that
   contain ``PUBLIC`` in `t:features/0`.
   """
-  @type rules_channel_id :: Snowflake.t() | nil
+  @type rules_channel_id :: Channel.id() | nil
 
   @typedoc """
   The id of the channel where admins and moderators receive notices from Discord. This
   is only available to guilds that contain ``PUBLIC`` in `t:features/0`.
   """
-  @type public_updates_channel_id :: Snowflake.t() | nil
+  @type public_updates_channel_id :: Channel.id() | nil
 
   @typedoc "Date the bot user joined the guild"
   @type joined_at :: String.t() | nil

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -29,6 +29,8 @@ defmodule Nostrum.Struct.Guild do
     :widget_enabled,
     :widget_channel_id,
     :system_channel_id,
+    :rules_channel_id,
+    :public_updates_channel_id,
     :joined_at,
     :large,
     :unavailable,
@@ -113,6 +115,18 @@ defmodule Nostrum.Struct.Guild do
   """
   @type system_channel_id :: Snowflake.t() | nil
 
+  @typedoc """
+  The id of the channel that is used for rules. This is only available to guilds that
+  contain ``PUBLIC`` in `t:features/0`.
+  """
+  @type rules_channel_id :: Snowflake.t() | nil
+
+  @typedoc """
+  The id of the channel where admins and moderators receive notices from Discord. This
+  is only available to guilds that contain ``PUBLIC`` in `t:features/0`.
+  """
+  @type public_updates_channel_id :: Snowflake.t() | nil
+
   @typedoc "Date the bot user joined the guild"
   @type joined_at :: String.t() | nil
 
@@ -159,6 +173,8 @@ defmodule Nostrum.Struct.Guild do
           widget_enabled: nil,
           widget_channel_id: nil,
           system_channel_id: nil,
+          rules_channel_id: nil,
+          public_updates_channel_id: nil,
           joined_at: nil,
           large: nil,
           unavailable: nil,
@@ -193,6 +209,8 @@ defmodule Nostrum.Struct.Guild do
           widget_enabled: widget_enabled,
           widget_channel_id: widget_channel_id,
           system_channel_id: system_channel_id,
+          rules_channel_id: rules_channel_id,
+          public_updates_channel_id: public_updates_channel_id,
           joined_at: nil,
           large: nil,
           unavailable: nil,
@@ -227,6 +245,8 @@ defmodule Nostrum.Struct.Guild do
           widget_enabled: nil,
           widget_channel_id: nil,
           system_channel_id: nil,
+          rules_channel_id: nil,
+          public_updates_channel_id: nil,
           joined_at: nil,
           large: nil,
           unavailable: true,
@@ -261,6 +281,8 @@ defmodule Nostrum.Struct.Guild do
           widget_enabled: widget_enabled,
           widget_channel_id: widget_channel_id,
           system_channel_id: system_channel_id,
+          rules_channel_id: rules_channel_id,
+          public_updates_channel_id: public_updates_channel_id,
           joined_at: joined_at,
           large: large,
           unavailable: false,
@@ -348,6 +370,8 @@ defmodule Nostrum.Struct.Guild do
       |> Map.update(:application_id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:widget_channel_id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:system_channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:rules_channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:public_updates_channel_id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:members, nil, &Util.cast(&1, {:index, [:user, :id], {:struct, Member}}))
       |> Map.update(:channels, nil, &Util.cast(&1, {:index, [:id], {:struct, Channel}}))
 

--- a/lib/nostrum/struct/guild/member.ex
+++ b/lib/nostrum/struct/guild/member.ex
@@ -23,6 +23,7 @@ defmodule Nostrum.Struct.Guild.Member do
 
   alias Nostrum.Permission
   alias Nostrum.Struct.{Channel, Guild, User}
+  alias Nostrum.Struct.Guild.Role
   alias Nostrum.{Snowflake, Util}
 
   defstruct [
@@ -48,7 +49,7 @@ defmodule Nostrum.Struct.Guild.Member do
   @type nick :: String.t() | nil
 
   @typedoc "A list of role ids"
-  @type roles :: [Snowflake.t()]
+  @type roles :: [Role.id()]
 
   @typedoc """
   Date the user joined the guild.

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -3,8 +3,8 @@ defmodule Nostrum.Struct.Message do
   Struct representing a Discord message.
   """
 
-  alias Nostrum.Struct.{Embed, User}
-  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Struct.{Embed, Guild, User}
+  alias Nostrum.Struct.Guild.{Member, Role}
   alias Nostrum.Struct.Message.{Activity, Application, Attachment, Reaction, Reference}
   alias Nostrum.{Snowflake, Util}
 
@@ -38,10 +38,10 @@ defmodule Nostrum.Struct.Message do
   @type id :: Snowflake.t()
 
   @typedoc "The id of the guild"
-  @type guild_id :: Snowflake.t() | nil
+  @type guild_id :: Guild.id() | nil
 
   @typedoc "The id of the channel"
-  @type channel_id :: Snowflake.t()
+  @type channel_id :: Channel.id()
 
   @typedoc "The user struct of the author"
   @type author :: User.t()
@@ -65,7 +65,7 @@ defmodule Nostrum.Struct.Message do
   @type mentions :: [User.t()]
 
   @typedoc "List of roles ids mentioned in the message"
-  @type mention_roles :: [Snowflake.t()]
+  @type mention_roles :: [Role.id()]
 
   @typedoc "List of attached files in the message"
   @type attachments :: [Attachment.t()]


### PR DESCRIPTION
I implemented the new fields `rules_channel_id` and `public_updates_channel_id` that Discord recently added for public (discoverable) guilds.

Works properly in my testing. Per the contributing guidelines, I ran `mix credo --strict`, but the warnings that popped up didn't seem to be related to my changes.