### PR TITLE
Continuation from #110: Add get_guild_ban and fix typo, cast into struct.

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1867,12 +1867,12 @@ defmodule Nostrum.Api do
   @doc """
   Gets a ban object for the given user from a guild.
   """
-  @spec get_guild_ban(integer, integer) :: error | {:ok, Nostrum.Struct.User.t()}
+  @spec get_guild_ban(integer, integer) :: error | {:ok, Guild.Ban.t()}
   def get_guild_ban(guild_id, user_id) do
     request(:get, Constants.guild_ban(guild_id, user_id))
-    |> handle_request_with_decode
+    |> handle_request_with_decode({:struct, Guild.Ban})
   end
-  
+
   @doc """
   Gets a list of users banned from a guild.
 

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1865,7 +1865,16 @@ defmodule Nostrum.Api do
   end
 
   @doc """
-  Gets a list of users banend from a guild.
+  Gets a ban object for the given user from a guild.
+  """
+  @spec get_guild_ban(integer, integer) :: error | {:ok, Nostrum.Struct.User.t()}
+  def get_guild_ban(guild_id, user_id) do
+    request(:get, Constants.guild_ban(guild_id, user_id))
+    |> handle_request_with_decode
+  end
+  
+  @doc """
+  Gets a list of users banned from a guild.
 
   Guild to get bans for is specified by `guild_id`.
   """

--- a/lib/nostrum/struct/guild/ban.ex
+++ b/lib/nostrum/struct/guild/ban.ex
@@ -1,0 +1,34 @@
+defmodule Nostrum.Struct.Guild.Ban do
+  @moduledoc """
+  Represents a guild ban.
+  """
+
+  alias Nostrum.Struct.User
+  alias Nostrum.Util
+
+  defstruct [
+    :reason,
+    :user
+  ]
+
+  @typedoc "The reason for the ban"
+  @type reason :: String.t() | nil
+
+  @typedoc "The banned user"
+  @type user :: User.t()
+
+  @type t :: %__MODULE__{
+          reason: reason,
+          user: user
+        }
+
+  @doc false
+  def to_struct(map) do
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
+
+    struct(__MODULE__, new)
+  end
+end


### PR DESCRIPTION
```elixir
iex(2)> Nostrum.Api.get_guild_ban(x, y)
{:ok,
 %Nostrum.Struct.Guild.Ban{
   reason: "spamming",
   user: %Nostrum.Struct.User{
     avatar: "xxxx",
     bot: nil,
     discriminator: "0000",
     email: nil,
     id: zzzz,
     mfa_enabled: nil,
     public_flags: %Nostrum.Struct.User.Flags{
       bug_hunter_level_1: false,
       bug_hunter_level_2: false,
       early_supporter: false,
       hypesquad_balance: false,
       hypesquad_bravery: true,
       hypesquad_brilliance: false,
       hypesquad_events: false,
       partner: false,
       staff: false,
       system: false,
       team_user: false,
       verified_bot: false,
       verified_developer: false
     },
     username: "gggg",
     verified: nil
   }
 }}
```