### PR TITLE
Remove response decode from `Api.execute_webhook/4`

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -2828,7 +2828,6 @@ defmodule Nostrum.Api do
       args,
       params: [wait: wait]
     )
-    |> handle_request_with_decode
   end
 
   def execute_webhook(webhook_id, webhook_token, %{content: _} = args, wait) do
@@ -2838,7 +2837,6 @@ defmodule Nostrum.Api do
       args,
       params: [wait: wait]
     )
-    |> handle_request_with_decode
   end
 
   @doc """


### PR DESCRIPTION
When receiving a successful response from webhook execution, it would be unnecessarily passed for decoding and raise
```elixir
** (FunctionClauseError) no function clause matching in Nostrum.Api.handle_request_with_decode/1

    The following arguments were given to Nostrum.Api.handle_request_with_decode/1:

        # 1
        {:ok}

    Attempted function clauses (showing 2 out of 2):

        defp handle_request_with_decode(-{:ok, body}-)
        defp handle_request_with_decode(-{:error, _} = error-)

    (nostrum 0.4.6) lib/nostrum/api.ex:3255: Nostrum.Api.handle_request_with_decode/1
```