### PR TITLE
Switch porcelain dependency to git

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule Nostrum.Mixfile do
       {:poison, "~> 3.0"},
       {:gun, "~> 1.3"},
       {:kcl, "~> 1.3"},
-      {:porcelain, "~> 2.0"},
+      {:porcelain, git: "https://github.com/alco/porcelain"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:credo, "~> 1.4", only: [:dev, :test]},
       {:dialyxir, "~> 1.0.0", only: [:dev], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -28,7 +28,7 @@
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
   "poly1305": {:hex, :poly1305, "1.0.2", "c6bb74cbe79747cc12aa1580791c2bd8e0f062bc8faaf117b756e675cfaea03d", [:mix], [{:chacha20, "~> 1.0", [hex: :chacha20, repo: "hexpm", optional: false]}, {:equivalex, "~> 1.0", [hex: :equivalex, repo: "hexpm", optional: false]}], "hexpm", "d0a0f8be324e7bfdd61e8e52215024a025816f3a7f665c274ad5bea154480c2b"},
-  "porcelain": {:hex, :porcelain, "2.0.3", "2d77b17d1f21fed875b8c5ecba72a01533db2013bd2e5e62c6d286c029150fdc", [:mix], [], "hexpm", "dc996ab8fadbc09912c787c7ab8673065e50ea1a6245177b0c24569013d23620"},
+  "porcelain": {:git, "https://github.com/alco/porcelain", "d240c7946e12f7fc878a6663b4e31952c78dc1da", []},
   "recon": {:hex, :recon, "2.5.0", "2f7fcbec2c35034bade2f9717f77059dc54eb4e929a3049ca7ba6775c0bd66cd", [:mix, :rebar3], [], "hexpm", "72f3840fedd94f06315c523f6cecf5b4827233bed7ae3fe135b2a0ebeab5e196"},
   "salsa20": {:hex, :salsa20, "1.0.2", "558fddb4169b1f90b1748d42e9221ba8d1354c414a03361308cc7bc0fd2f45c7", [:mix], [], "hexpm", "8d0d394c67da8d44073cbf2c030c4e0e04e7bed92967761be60419d8d46df18d"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},


### PR DESCRIPTION
Porcelain isn't being actively developed, and v2.0.3 in hex.pm is nearly 5 years old. Master branch on GitHub fixes all deprecation warnings.