### PR TITLE
Fix `gun_down` crash caused by gun 2.0 migration

### DIFF
--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -132,7 +132,7 @@ defmodule Nostrum.Shard.Session do
   end
 
   def handle_info(
-        {:gun_down, _conn, _proto, _reason, _killed_streams, _unprocessed_streams},
+        {:gun_down, _conn, _proto, _reason, _killed_streams},
         state
       ) do
     # Try to cancel the internal timer, but


### PR DESCRIPTION
The `UnprocessedStreams` parameter was removed in gun 2.0.

[gun_down in 1.3](https://ninenines.eu/docs/en/gun/1.3/manual/gun_down/)
[gun_down in 2.0](https://ninenines.eu/docs/en/gun/2.0/manual/gun_down/)
