### PR TITLE
Remove overly cautious "sanity wait" for rate limiting

### DIFF
--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -22,7 +22,6 @@ defmodule Nostrum.Api.Ratelimiter do
 
   @major_parameters ["channels", "guilds", "webhooks"]
   @gregorian_epoch 62_167_219_200
-  @sanity_wait 500
 
   @doc """
   Starts the ratelimiter.
@@ -109,7 +108,7 @@ defmodule Nostrum.Api.Ratelimiter do
       "RATELIMITER: Waiting #{timeout}ms to process request with route #{request.route}"
     )
 
-    Process.sleep(timeout + @sanity_wait)
+    Process.sleep(timeout)
     GenServer.call(Ratelimiter, {:queue, request, from}, :infinity)
   end
 


### PR DESCRIPTION
I think we all want stability in a library like Nostrum so I understand why a sanity wait was added in the first place. 

However, 500ms seems like a very long time to wait in addition to an accurate retry-after. Furthermore, the time it took for the original request to come back with the rate limiting header in addition to the time it will take for the retried request to reach discord servers (let's say 50ms for each at best) should be more than enough to guarantee we are well over the retry-after limitation.

If you are not comfortable removing it entirely, then let us please consider lowering it to something like 100ms.