### PR TITLE
Create `to_url` function for Message

### DIFF
--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -182,4 +182,13 @@ defmodule Nostrum.Struct.Message do
 
     struct(__MODULE__, new)
   end
+  
+  @doc """
+  Takes the message and produces a URL that, when clicked from the user client, will 
+  jump them to that message, assuming they have access to the message and the message 
+  is valid.
+  """
+  def to_url(%__MODULE__{} = msg) do
+    "https://discord.com/channels/" <> (msg.guild_id || "@me") <> "/" <> msg.channel_id <> "/" <> msg.id
+  end
 end


### PR DESCRIPTION
Takes the message and produces a URL that, when clicked from the user client, will   jump them to that message, assuming they have access to the message and the message is valid.

Note: this is the output of Credo, however none of these were added by my commit. I can add the newline if desired.

>   Software Design                                                                                                                                           
┃ 
┃ [D] → Found a TODO tag in a comment: # TODO: Jump down the rabbit hole
┃       lib/nostrum/struct/embed.ex:518 #(Nostrum.Struct.Embed.from)
┃ [D] → Found a TODO tag in a comment: # TODO: Once gun 2.0 is released, the block below can be simplified to:
┃       lib/nostrum/shard/session.ex:86 #(Nostrum.Shard.Session.await_ws_upgrade)
┃ [D] → Found a TODO tag in a comment: # TODO: Add per shard cache
┃       lib/nostrum/shard.ex:16 #(Nostrum.Shard.init)
┃ [D] → Found a TODO tag in a comment: # TODO: Add per shard ratelimiter
┃       lib/nostrum/shard.ex:15 #(Nostrum.Shard.init)
┃ [D] → Found a TODO tag in a comment: # TODO: pretty print for discord errors
┃       lib/nostrum/error/api_error.ex:29 #(Nostrum.Error.ApiError)
> 
>   Code Readability                                                                                                                                          
┃ 
┃ [R] ↘ There should be no trailing white-space at the end of a line.
┃       lib/nostrum/struct/message.ex:185:1 #(Nostrum.Struct.Message.to_struct)