### PR TITLE
Remove whitespace from Nostrum.Struct.Message

### DIFF
--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -182,7 +182,7 @@ defmodule Nostrum.Struct.Message do
 
     struct(__MODULE__, new)
   end
-  
+
   @doc """
   Takes the message and produces a URL that, when clicked from the user client, will 
   jump them to that message, assuming they have access to the message and the message 

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -189,6 +189,7 @@ defmodule Nostrum.Struct.Message do
   is valid.
   """
   def to_url(%__MODULE__{} = msg) do
-    "https://discord.com/channels/" <> (msg.guild_id || "@me") <> "/" <> msg.channel_id <> "/" <> msg.id
+    "https://discord.com/channels/" <>
+      (msg.guild_id || "@me") <> "/" <> msg.channel_id <> "/" <> msg.id
   end
 end


### PR DESCRIPTION
Resolves a credo nag that was preventing CI from passing.﻿
