### PR TITLE
Do not cast all incoming keys to atoms.

### DIFF
--- a/lib/nostrum/cache/guild/guild_server.ex
+++ b/lib/nostrum/cache/guild/guild_server.ex
@@ -202,7 +202,7 @@ defmodule Nostrum.Cache.Guild.GuildServer do
 
   def handle_call({:update, :voice_state, guild_id, vsu}, _from, %{voice_states: vs_list} = state) do
     # Remove heavy and duplicate data from voice state
-    vsu = vsu |> Map.delete(:member)
+    vsu = vsu |> Map.delete("member")
     vs_list = vs_list |> Enum.reject(fn v -> v.user_id == vsu.user_id end)
 
     new_voice_states =

--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -114,7 +114,7 @@ defmodule Nostrum.Consumer do
            {guild_id :: integer, old_emojis :: [Nostrum.Struct.Emoji.t()],
             new_emojis :: [Nostrum.Struct.Emoji.t()]}, WSState.t()}
   @type guild_integrations_update ::
-          {:GUILD_INTEGERATIONS_UPDATE, GuildIntegrationsUpdate.t(), WSState.t()}
+          {:GUILD_INTEGRATIONS_UPDATE, GuildIntegrationsUpdate.t(), WSState.t()}
   @type guild_member_add ::
           {:GUILD_MEMBER_ADD,
            {guild_id :: integer, new_member :: Nostrum.Struct.Guild.Member.t()}, WSState.t()}

--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -22,7 +22,24 @@ defmodule Nostrum.Consumer do
 
   alias Nostrum.Shard.Stage.Cache
   alias Nostrum.Struct.{Channel, WSState}
-  alias Nostrum.Struct.Event.{MessageDelete, MessageDeleteBulk, SpeakingUpdate}
+
+  alias Nostrum.Struct.Event.{
+    ChannelPinsUpdate,
+    GuildBanAdd,
+    GuildBanRemove,
+    GuildIntegrationsUpdate,
+    MessageDelete,
+    MessageDeleteBulk,
+    MessageReactionAdd,
+    MessageReactionRemove,
+    MessageReactionRemoveAll,
+    MessageReactionRemoveEmoji,
+    Ready,
+    SpeakingUpdate,
+    TypingStart,
+    VoiceServerUpdate,
+    VoiceState
+  }
 
   @doc """
   Callback used to handle events.
@@ -75,11 +92,11 @@ defmodule Nostrum.Consumer do
           {:CHANNEL_UPDATE, {old_channel :: Channel.t() | nil, new_channel :: Channel.t()},
            WSState.t()}
   @type channel_pins_ack :: {:CHANNEL_PINS_ACK, map, WSState.t()}
-  @type channel_pins_update :: {:CHANNEL_PINS_UPDATE, map, WSState.t()}
+  @type channel_pins_update :: {:CHANNEL_PINS_UPDATE, ChannelPinsUpdate.t(), WSState.t()}
   @type guild_ban_add ::
-          {:GUILD_BAN_ADD, {guild_id :: integer, Nostrum.Struct.User.t()}, WSState.t()}
+          {:GUILD_BAN_ADD, GuildBanAdd.t(), WSState.t()}
   @type guild_ban_remove ::
-          {:GUILD_BAN_REMOVE, {guild_id :: integer, Nostrum.Struct.User.t()}, WSState.t()}
+          {:GUILD_BAN_REMOVE, GuildBanRemove.t(), WSState.t()}
   @type guild_create :: {:GUILD_CREATE, new_guild :: Nostrum.Struct.Guild.t(), WSState.t()}
   @type guild_available :: {:GUILD_AVAILABLE, new_guild :: Nostrum.Struct.Guild.t(), WSState.t()}
   @type guild_unavailable ::
@@ -96,7 +113,8 @@ defmodule Nostrum.Consumer do
           {:GUILD_EMOJIS_UPDATE,
            {guild_id :: integer, old_emojis :: [Nostrum.Struct.Emoji.t()],
             new_emojis :: [Nostrum.Struct.Emoji.t()]}, WSState.t()}
-  @type guild_integrations_update :: {:GUILD_INTEGERATIONS_UPDATE, map, WSState.t()}
+  @type guild_integrations_update ::
+          {:GUILD_INTEGERATIONS_UPDATE, GuildIntegrationsUpdate.t(), WSState.t()}
   @type guild_member_add ::
           {:GUILD_MEMBER_ADD,
            {guild_id :: integer, new_member :: Nostrum.Struct.Guild.Member.t()}, WSState.t()}
@@ -133,10 +151,13 @@ defmodule Nostrum.Consumer do
   @type message_delete_bulk :: {:MESSAGE_DELETE_BULK, MessageDeleteBulk.t(), WSState.t()}
   @type message_update ::
           {:MESSAGE_UPDATE, updated_message :: Nostrum.Struct.Message.t(), WSState.t()}
-  @type message_reaction_add :: {:MESSAGE_REACTION_ADD, map, WSState.t()}
-  @type message_reaction_remove :: {:MESSAGE_REACTION_REMOVE, map, WSState.t()}
-  @type message_reaction_remove_all :: {:MESSAGE_REACTION_REMOVE_ALL, map, WSState.t()}
-  @type message_reaction_remove_emoji :: {:MESSAGE_REACTION_REMOVE_EMOJI, map, WSState.t()}
+  @type message_reaction_add :: {:MESSAGE_REACTION_ADD, MessageReactionAdd.t(), WSState.t()}
+  @type message_reaction_remove ::
+          {:MESSAGE_REACTION_REMOVE, MessageReactionRemove.t(), WSState.t()}
+  @type message_reaction_remove_all ::
+          {:MESSAGE_REACTION_REMOVE_ALL, MessageReactionRemoveAll.t(), WSState.t()}
+  @type message_reaction_remove_emoji ::
+          {:MESSAGE_REACTION_REMOVE_EMOJI, MessageReactionRemoveEmoji.t(), WSState.t()}
   @type message_ack :: {:MESSAGE_ACK, map, WSState.t()}
   @typedoc """
   Dispatched when a user's presence is updated.
@@ -146,9 +167,9 @@ defmodule Nostrum.Consumer do
   @type presence_update ::
           {:PRESENCE_UPDATE,
            {guild_id :: integer, old_presence :: map | nil, new_presence :: map}, WSState.t()}
-  @type ready :: {:READY, map, WSState.t()}
+  @type ready :: {:READY, Ready.t(), WSState.t()}
   @type resumed :: {:RESUMED, map, WSState.t()}
-  @type typing_start :: {:TYPING_START, map, WSState.t()}
+  @type typing_start :: {:TYPING_START, TypingStart.t(), WSState.t()}
   @type user_settings_update :: no_return
   @typedoc """
   Dispatched when a user is updated.
@@ -160,8 +181,8 @@ defmodule Nostrum.Consumer do
            {old_user :: Nostrum.Struct.User.t() | nil, new_user :: Nostrum.Struct.User.t()},
            WSState.t()}
   @type voice_speaking_update :: {:VOICE_SPEAKING_UPDATE, SpeakingUpdate.t(), WSState.t()}
-  @type voice_state_update :: {:VOICE_STATE_UPDATE, map, WSState.t()}
-  @type voice_server_update :: {:VOICE_SERVER_UPDATE, map, WSState.t()}
+  @type voice_state_update :: {:VOICE_STATE_UPDATE, VoiceState.t(), WSState.t()}
+  @type voice_server_update :: {:VOICE_SERVER_UPDATE, VoiceServerUpdate.t(), WSState.t()}
   @type webhooks_update :: {:WEBHOOKS_UPDATE, map, WSState.t()}
 
   @type event ::

--- a/lib/nostrum/shard/event.ex
+++ b/lib/nostrum/shard/event.ex
@@ -3,13 +3,10 @@ defmodule Nostrum.Shard.Event do
 
   alias Nostrum.Shard.Payload
   alias Nostrum.Shard.Stage.Producer
-  alias Nostrum.Util
 
   require Logger
 
   def handle(:dispatch, payload, state) do
-    payload = Util.safe_atom_map(payload)
-
     if Application.get_env(:nostrum, :log_dispatch_events),
       do: payload.t |> inspect() |> Logger.debug()
 

--- a/lib/nostrum/struct/application_command_interaction_data.ex
+++ b/lib/nostrum/struct/application_command_interaction_data.ex
@@ -2,10 +2,15 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @moduledoc "Struct for interaction data."
 
   alias Nostrum.Snowflake
-  alias Nostrum.Struct.ApplicationCommandInteractionDataOption
+
+  alias Nostrum.Struct.{
+    ApplicationCommandInteractionDataOption,
+    ApplicationCommandInteractionDataResolved
+  }
+
   alias Nostrum.Util
 
-  defstruct [:id, :name, :options]
+  defstruct [:id, :name, :resolved, :options, :custom_id, :component_type]
 
   @typedoc "ID of the invoked command"
   @type id :: Snowflake.t()
@@ -13,8 +18,17 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @typedoc "Name of the invoked command"
   @type name :: String.t()
 
+  @typedoc "Converted users & roles & channels"
+  @type resolved :: ApplicationCommandInteractionDataResolved.t() | nil
+
   @typedoc "Parameters and values supplied by the user, if applicable"
   @type options :: ApplicationCommandInteractionDataOption.t() | nil
+
+  @typedoc "For components, the ``custom_id`` of the component"
+  @type custom_id :: String.t() | nil
+
+  @typedoc "For components, the ``type`` of the component"
+  @type component_type :: Integer.t() | nil
 
   @typedoc """
   Command interaction data for slash commands.
@@ -27,22 +41,23 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @type t :: %__MODULE__{
           id: id,
           name: name,
-          options: options
+          resolved: resolved,
+          options: options,
+          custom_id: custom_id,
+          component_type: component_type
         }
 
   @doc false
   @spec to_struct(map()) :: __MODULE__.t()
   def to_struct(map) do
-    new =
-      map
-      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
-      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
-      |> Map.update(
-        :options,
-        nil,
-        &Util.cast(&1, {:list, {:struct, ApplicationCommandInteractionDataOption}})
-      )
-
-    struct(__MODULE__, new)
+    %__MODULE__{
+      id: map["id"],
+      name: map["name"],
+      resolved: Util.cast(map["resolved"], {:struct, ApplicationCommandInteractionDataResolved}),
+      options:
+        Util.cast(map["options"], {:list, {:struct, ApplicationCommandInteractionDataOption}}),
+      custom_id: map["custom_id"],
+      component_type: map["component_type"]
+    }
   end
 end

--- a/lib/nostrum/struct/application_command_interaction_data_option.ex
+++ b/lib/nostrum/struct/application_command_interaction_data_option.ex
@@ -5,10 +5,18 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
 
   alias Nostrum.Util
 
-  defstruct [:name, :value, :options]
+  defstruct [:name, :type, :value, :options]
 
   @typedoc "Parameter name"
   @type name :: String.t()
+
+  @typedoc """
+  The application command option type.
+
+  See https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-type
+  for more details.
+  """
+  @type type :: 1..9
 
   @typedoc """
   Parameter value.
@@ -28,6 +36,7 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
   @typedoc "Command interaction data struct"
   @type t :: %__MODULE__{
           name: name,
+          type: type,
           value: value,
           options: options
         }
@@ -35,15 +44,12 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
   @doc false
   @spec to_struct(map()) :: __MODULE__.t()
   def to_struct(map) do
-    new =
-      map
-      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
-      |> Map.update(
-        :options,
-        nil,
-        &Util.cast(&1, {:list, {:struct, ApplicationCommandInteractionDataOption}})
-      )
-
-    struct(__MODULE__, new)
+    %__MODULE__{
+      name: map["name"],
+      type: map["type"],
+      value: map["value"],
+      options:
+        Util.cast(map["options"], {:list, {:struct, ApplicationCommandInteractionDataOption}})
+    }
   end
 end

--- a/lib/nostrum/struct/application_command_interaction_data_resolved.ex
+++ b/lib/nostrum/struct/application_command_interaction_data_resolved.ex
@@ -1,0 +1,75 @@
+defmodule Nostrum.Struct.ApplicationCommandInteractionDataResolved do
+  @moduledoc "Converted interaction payload."
+
+  alias Nostrum.Snowflake
+  alias Nostrum.Struct.Channel
+  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Struct.Guild.Role
+  alias Nostrum.Struct.User
+  alias Nostrum.Util
+
+  defstruct [:users, :members, :roles, :channels]
+
+  @typedoc "IDs and corresponding users"
+  @type users :: %{User.id() => User.t()} | nil
+
+  @typedoc """
+  IDs and corresponding partial members.
+
+  These members are *missing* values on the following fields:
+
+  - ``user``
+  - ``deaf``
+  - ``mute``
+
+  The corresponding user data can be looked up in ``users``. For members that
+  are part of this map, data for the corresponding user will always be included.
+  """
+  @type members :: %{User.id() => Member.t()} | nil
+
+  @typedoc "IDs and corresponding roles"
+  @type roles :: %{Role.id() => Role.t()} | nil
+
+  @typedoc """
+  IDs and corresponding partial channels.
+
+  The channels in this map *only* have the following keys set:
+
+  - ``id``
+  - ``name``
+  - ``type``
+  - ``permissions``
+  """
+  @type channels :: %{Channel.id() => Channel.guild_text_channel()} | nil
+
+  @typedoc "Resolved interaction data"
+  @type t :: %__MODULE__{
+          users: users,
+          members: members(),
+          roles: roles(),
+          channels: channels()
+        }
+
+  # Parse the given mapping of strings to some corresponding arguments.
+  # String snowflakes are transformed to integers, because our runtime
+  # supports arbitrary-sized integers. Take that.
+  defp map_parse(nil, _target_type) do
+    nil
+  end
+
+  defp map_parse(structure, target_type) do
+    structure
+    |> Enum.map(fn {k, v} -> {Util.cast(k, Snowflake), Util.cast(v, target_type)} end)
+    |> :maps.from_list()
+  end
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      users: map_parse(map["users"], {:struct, User}),
+      members: map_parse(map["members"], {:struct, Member}),
+      roles: map_parse(map["roles"], {:struct, Role}),
+      channels: map_parse(map["channels"], {:struct, Channel})
+    }
+  end
+end

--- a/lib/nostrum/struct/event/channel_pins_update.ex
+++ b/lib/nostrum/struct/event/channel_pins_update.ex
@@ -1,0 +1,42 @@
+defmodule Nostrum.Struct.Event.ChannelPinsUpdate do
+  @moduledoc "Represents an update to channel pins."
+
+  alias Nostrum.Struct.Channel
+  alias Nostrum.Struct.Guild
+
+  defstruct [:guild_id, :channel_id, :last_pin_timestamp]
+
+  @typedoc "The ID of the guild, if the pin update was on a guild"
+  @type guild_id :: Guild.id() | nil
+
+  @typedoc "The ID of the channel"
+  @type channel_id :: Channel.id()
+
+  @typedoc "The time at which the most recent pinned message was pinned"
+  @type last_pin_timestamp :: DateTime.t() | nil
+
+  @typedoc "Event sent when a message is pinned or unpinned in a text channel"
+  @type t :: %__MODULE__{
+          guild_id: guild_id,
+          channel_id: channel_id,
+          last_pin_timestamp: last_pin_timestamp
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      guild_id: map["guild_id"],
+      channel_id: map["channel_id"],
+      last_pin_timestamp: parse_stamp(map["last_pin_timestamp"])
+    }
+  end
+
+  defp parse_stamp(nil) do
+    nil
+  end
+
+  defp parse_stamp(stamp) do
+    {:ok, casted, 0} = DateTime.from_iso8601(stamp)
+    casted
+  end
+end

--- a/lib/nostrum/struct/event/guild_ban_add.ex
+++ b/lib/nostrum/struct/event/guild_ban_add.ex
@@ -1,0 +1,29 @@
+defmodule Nostrum.Struct.Event.GuildBanAdd do
+  @moduledoc "Sent when a user is banned from a guild"
+
+  alias Nostrum.Struct.Guild
+  alias Nostrum.Struct.User
+  alias Nostrum.Util
+
+  defstruct [:guild_id, :user]
+
+  @typedoc "ID of the guild"
+  @type guild_id :: Guild.id()
+
+  @typedoc "Banned user"
+  @type user :: User.t()
+
+  @typedoc "Event sent when a user is banned from a guild"
+  @type t :: %__MODULE__{
+          guild_id: guild_id,
+          user: user
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      guild_id: map["guild_id"],
+      user: Util.cast(map["user"], {:struct, User})
+    }
+  end
+end

--- a/lib/nostrum/struct/event/guild_ban_remove.ex
+++ b/lib/nostrum/struct/event/guild_ban_remove.ex
@@ -1,0 +1,29 @@
+defmodule Nostrum.Struct.Event.GuildBanRemove do
+  @moduledoc "Sent when a user is unbanned from a guild"
+
+  alias Nostrum.Struct.Guild
+  alias Nostrum.Struct.User
+  alias Nostrum.Util
+
+  defstruct [:guild_id, :user]
+
+  @typedoc "ID of the guild"
+  @type guild_id :: Guild.id()
+
+  @typedoc "Unbanned user"
+  @type user :: User.t()
+
+  @typedoc "Event sent when a user is unbanned from a guild"
+  @type t :: %__MODULE__{
+          guild_id: guild_id,
+          user: user
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      guild_id: map["guild_id"],
+      user: Util.cast(map["user"], {:struct, User})
+    }
+  end
+end

--- a/lib/nostrum/struct/event/guild_integrations_update.ex
+++ b/lib/nostrum/struct/event/guild_integrations_update.ex
@@ -1,0 +1,20 @@
+defmodule Nostrum.Struct.Event.GuildIntegrationsUpdate do
+  @moduledoc "Sent when a guild integration is updated"
+
+  alias Nostrum.Struct.Guild
+
+  defstruct [:guild_id]
+
+  @typedoc "ID of the guild whose integrations were updated"
+  @type guild_id :: Guild.id()
+
+  @typedoc "Event sent when a guild integration is updated"
+  @type t :: %__MODULE__{
+          guild_id: guild_id
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{guild_id: map["guild_id"]}
+  end
+end

--- a/lib/nostrum/struct/event/message_reaction_add.ex
+++ b/lib/nostrum/struct/event/message_reaction_add.ex
@@ -1,0 +1,49 @@
+defmodule Nostrum.Struct.Event.MessageReactionAdd do
+  @moduledoc "Sent when a user adds a reaction to a message"
+
+  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Struct.{Channel, Emoji, Message, User}
+  alias Nostrum.Util
+
+  defstruct [:user_id, :channel_id, :message_id, :guild_id, :member, :emoji]
+
+  @typedoc "ID of the user who added the reaction"
+  @type user_id :: User.id()
+
+  @typedoc "Channel in which the reaction was added"
+  @type channel_id :: Channel.id()
+
+  @typedoc "Message to which the reaction was added"
+  @type message_id :: Message.id()
+
+  @typedoc "Guild ID in which the reaction was added, if applicable"
+  @type guild_id :: Guild.id() | nil
+
+  @typedoc "The member who reacted, if this happened on a guild"
+  @type member :: Member.t() | nil
+
+  @typedoc "The (partial) emoji used to react"
+  @type emoji :: Emoji.t()
+
+  @typedoc "Event sent when a user adds a reaction to a message"
+  @type t :: %__MODULE__{
+          user_id: user_id,
+          channel_id: channel_id,
+          message_id: message_id,
+          guild_id: guild_id,
+          member: member,
+          emoji: emoji
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      user_id: map["user_id"],
+      channel_id: map["channel_id"],
+      message_id: map["message_id"],
+      guild_id: map["guild_id"],
+      member: Util.cast(map["member"], {:struct, Member}),
+      emoji: Util.cast(map["emoji"], {:struct, Emoji})
+    }
+  end
+end

--- a/lib/nostrum/struct/event/message_reaction_remove.ex
+++ b/lib/nostrum/struct/event/message_reaction_remove.ex
@@ -1,0 +1,44 @@
+defmodule Nostrum.Struct.Event.MessageReactionRemove do
+  @moduledoc "Sent when a user removes a reaction from a message"
+
+  alias Nostrum.Struct.{Channel, Emoji, Guild, Message, User}
+  alias Nostrum.Util
+
+  defstruct [:user_id, :channel_id, :message_id, :guild_id, :emoji]
+
+  # XXX: is this correct?
+  @typedoc "Author of the reaction"
+  @type user_id :: User.id()
+
+  @typedoc "ID of the channel in which the reaction was created"
+  @type channel_id :: Channel.id()
+
+  @typedoc "ID of the message to which the reaction was attached"
+  @type message_id :: Message.id()
+
+  @typedoc "ID of the guild on which the message lives, if applicable"
+  @type guild_id :: Guild.id() | nil
+
+  @typedoc "Partial emoji object that was removed"
+  @type emoji :: Emoji.t() | nil
+
+  @typedoc "Event sent when a user removes a reaction from a message"
+  @type t :: %__MODULE__{
+          user_id: user_id,
+          channel_id: channel_id,
+          message_id: message_id,
+          guild_id: guild_id,
+          emoji: emoji
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      user_id: map["user_id"],
+      channel_id: map["channel_id"],
+      message_id: map["message_id"],
+      guild_id: map["guild_id"],
+      emoji: Util.cast(map["emoji"], {:struct, Emoji})
+    }
+  end
+end

--- a/lib/nostrum/struct/event/message_reaction_remove_all.ex
+++ b/lib/nostrum/struct/event/message_reaction_remove_all.ex
@@ -1,0 +1,32 @@
+defmodule Nostrum.Struct.Event.MessageReactionRemoveAll do
+  @moduledoc "Sent when a user explicitly removes all reactions from a message"
+
+  alias Nostrum.Struct.{Channel, Guild, Message}
+
+  defstruct [:channel_id, :message_id, :guild_id]
+
+  @typedoc "ID of the channel in which the message resides."
+  @type channel_id :: Channel.id()
+
+  @typedoc "ID of the message from which all reactions were removed."
+  @type message_id :: Message.id()
+
+  @typedoc "ID of the guild for the message, if applicable."
+  @type guild_id :: Guild.id() | nil
+
+  @typedoc "Event sent when a user explicitly removes all reactions from a message"
+  @type t :: %__MODULE__{
+          channel_id: channel_id,
+          message_id: message_id,
+          guild_id: guild_id
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      channel_id: map["channel_id"],
+      message_id: map["message_id"],
+      guild_id: map["guild_id"]
+    }
+  end
+end

--- a/lib/nostrum/struct/event/message_reaction_remove_emoji.ex
+++ b/lib/nostrum/struct/event/message_reaction_remove_emoji.ex
@@ -1,0 +1,38 @@
+defmodule Nostrum.Struct.Event.MessageReactionRemoveEmoji do
+  @moduledoc "Sent when a bot removes all instances of a given emoji from the reactions of a message"
+
+  alias Nostrum.Struct.{Channel, Emoji, Guild, Message}
+  alias Nostrum.Util
+
+  defstruct [:channel_id, :guild_id, :message_id, :emoji]
+
+  @typedoc "Channel in which the message resides."
+  @type channel_id :: Channel.id()
+
+  @typedoc "Guild on which the message resides, if applicable."
+  @type guild_id :: Guild.id() | nil
+
+  @typedoc "Message from which the emoji was removed."
+  @type message_id :: Message.id()
+
+  @typedoc "The (partial) emoji that was removed."
+  @type emoji :: Emoji.t()
+
+  @typedoc "Event sent when a bot removes all instances of a given emoji from the reactions of a message"
+  @type t :: %__MODULE__{
+          channel_id: channel_id,
+          guild_id: guild_id,
+          message_id: message_id,
+          emoji: emoji
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      channel_id: map["channel_id"],
+      guild_id: map["guild_id"],
+      message_id: map["message_id"],
+      emoji: Util.cast(map["emoji"], {:struct, Emoji})
+    }
+  end
+end

--- a/lib/nostrum/struct/event/partial_application.ex
+++ b/lib/nostrum/struct/event/partial_application.ex
@@ -1,0 +1,29 @@
+defmodule Nostrum.Struct.Event.PartialApplication do
+  @moduledoc "Sent on `READY`"
+
+  defstruct [:id, :flags]
+
+  @typedoc "ID of the application"
+  @type id :: Snowflake.t()
+
+  @typedoc """
+  Public flags of the application.
+
+  See https://discord.com/developers/docs/resources/application#application-object-application-flags
+  """
+  @type flags :: non_neg_integer()
+
+  @typedoc "Event sent as part of the `READY` payload."
+  @type t :: %__MODULE__{
+          id: id,
+          flags: flags
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      id: map["id"],
+      flags: map["flags"]
+    }
+  end
+end

--- a/lib/nostrum/struct/event/ready.ex
+++ b/lib/nostrum/struct/event/ready.ex
@@ -1,0 +1,62 @@
+defmodule Nostrum.Struct.Event.Ready do
+  @moduledoc "Sent after initial handshake with the gateway"
+
+  alias Nostrum.Struct.Event.PartialApplication
+  alias Nostrum.Struct.Guild.UnavailableGuild
+  alias Nostrum.Struct.User
+  alias Nostrum.Util
+
+  defstruct [:v, :user, :guilds, :session_id, :shard, :application]
+
+  @typedoc """
+  Gateway version.
+  See https://discord.com/developers/docs/topics/gateway#gateways-gateway-versions
+  """
+  @type v :: non_neg_integer()
+
+  @typedoc "Information about the bot user"
+  @type user :: User.t()
+
+  @typedoc "The guilds that the bot user is in"
+  @type guilds :: [UnavailableGuild.t()]
+
+  @typedoc """
+  Used for resuming connections.
+
+  If you are wondering whether you need to use this, you probably don't.
+  Nostrum handles reconnections for you.
+  """
+  @type session_id :: String.t()
+
+  @typedoc """
+  A pair of two integers ``{shard_id, num_shards}``.
+
+  For more information, see
+  https://discord.com/developers/docs/topics/gateway#sharding.
+  """
+  @type shard :: {Integer.t(), non_neg_integer()} | nil
+
+  @typedoc "Partial application object with `id` and `flags`"
+  @type application :: PartialApplication.t()
+
+  @typedoc "Event sent after initial handshake with the gateway"
+  @type t :: %__MODULE__{
+          v: v,
+          user: user,
+          guilds: guilds,
+          session_id: session_id,
+          shard: shard,
+          application: application
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      v: map["v"],
+      user: Util.cast(map["user"], {:struct, User}),
+      guilds: Util.cast(map["guilds"], {:list, {:struct, UnavailableGuild}}),
+      shard: :erlang.list_to_tuple(map["shard"]),
+      application: Util.cast(map["application"], {:struct, PartialApplication})
+    }
+  end
+end

--- a/lib/nostrum/struct/event/typing_start.ex
+++ b/lib/nostrum/struct/event/typing_start.ex
@@ -1,0 +1,46 @@
+defmodule Nostrum.Struct.Event.TypingStart do
+  @moduledoc "Sent when a user starts typing in a channel"
+
+  alias Nostrum.Struct.Channel
+  alias Nostrum.Struct.Guild
+  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Struct.User
+  alias Nostrum.Util
+
+  defstruct [:channel_id, :guild_id, :user_id, :timestamp, :member]
+
+  @typedoc "Channel in which the user started typing"
+  @type channel_id :: Channel.id()
+
+  @typedoc "ID of the guild where the user started typing, if applicable"
+  @type guild_id :: Guild.id() | nil
+
+  @typedoc "ID of the user who started typing"
+  @type user_id :: User.id()
+
+  @typedoc "Unix time (in seconds) of when the user started typing"
+  @type timestamp :: pos_integer()
+
+  @typedoc "The member who started typing if this happened in a guild"
+  @type member :: Member.t()
+
+  @typedoc "Event sent when a user starts typing in a channel"
+  @type t :: %__MODULE__{
+          channel_id: channel_id,
+          guild_id: guild_id,
+          user_id: user_id,
+          timestamp: timestamp,
+          member: member
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      channel_id: map["channel_id"],
+      guild_id: map["guild_id"],
+      user_id: map["user_id"],
+      timestamp: map["timestamp"],
+      member: Util.cast(map["member"], {:struct, Member})
+    }
+  end
+end

--- a/lib/nostrum/struct/event/voice_server_update.ex
+++ b/lib/nostrum/struct/event/voice_server_update.ex
@@ -1,0 +1,32 @@
+defmodule Nostrum.Struct.Event.VoiceServerUpdate do
+  @moduledoc "Sent when a guild's voice server is updated"
+
+  alias Nostrum.Struct.Guild
+
+  defstruct [:token, :guild_id, :endpoint]
+
+  @typedoc "Voice connection token"
+  @type token :: String.t()
+
+  @typedoc "Guild this voice server update is for"
+  @type guild_id :: Guild.id()
+
+  @typedoc "The voice server host"
+  @type endpoint :: String.t() | nil
+
+  @typedoc "Event sent when a guild's voice server is updated"
+  @type t :: %__MODULE__{
+          token: token,
+          guild_id: guild_id,
+          endpoint: endpoint
+        }
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      token: map["token"],
+      guild_id: map["guild_id"],
+      endpoint: map["endpoint"]
+    }
+  end
+end

--- a/lib/nostrum/struct/event/voice_state.ex
+++ b/lib/nostrum/struct/event/voice_state.ex
@@ -1,0 +1,109 @@
+defmodule Nostrum.Struct.Event.VoiceState do
+  @moduledoc "Represents a user's voice connection status"
+
+  alias Nostrum.Struct.Channel
+  alias Nostrum.Struct.Guild
+  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Struct.User
+  alias Nostrum.Util
+
+  defstruct [
+    :guild_id,
+    :channel_id,
+    :user_id,
+    :member,
+    :session_id,
+    :deaf?,
+    :mute?,
+    :self_deaf?,
+    :self_mute?,
+    :self_stream?,
+    :self_video?,
+    :suppress?,
+    :request_to_speak_timestamp
+  ]
+
+  @typedoc "Guild ID this voice state is for, if applicable"
+  @type guild_id :: Guild.id() | nil
+
+  @typedoc "Channel ID this voice state is for"
+  @type channel_id :: Channel.id()
+
+  @typedoc "User this voice state is for"
+  @type user_id :: User.id()
+
+  @typedoc "Guild member this voice state is for, if applicable"
+  @type member :: Member.t() | nil
+
+  @typedoc "Session ID for this voice state"
+  @type session_id :: String.t()
+
+  @typedoc "Whether this user is deafened by the server"
+  @type deaf? :: boolean
+
+  @typedoc "Whether this user is muteened by the server"
+  @type mute? :: boolean
+
+  @typedoc "Whether this user is locally deafened"
+  @type self_deaf? :: boolean
+
+  @typedoc "Whether this user is locally muted"
+  @type self_mute? :: boolean
+
+  @typedoc "Whether the user is streaming using \"Go Live\""
+  @type self_stream? :: boolean
+
+  @typedoc "Whether this user's camera is enabled"
+  @type self_video? :: boolean
+
+  @typedoc "Whether this user is muted by the current user"
+  @type suppress? :: boolean
+
+  @typedoc "Time at which the user requested to speak, if applicable"
+  @type request_to_speak_timestamp :: DateTime.t() | nil
+
+  @typedoc "Event sent when a user's voice status is updated"
+  @type t :: %__MODULE__{
+          guild_id: guild_id,
+          channel_id: channel_id,
+          user_id: user_id,
+          member: member,
+          session_id: session_id,
+          deaf?: deaf?,
+          mute?: mute?,
+          self_deaf?: self_deaf?,
+          self_mute?: self_mute?,
+          self_stream?: self_stream?,
+          self_video?: self_video?,
+          suppress?: suppress?,
+          request_to_speak_timestamp: request_to_speak_timestamp
+        }
+
+  defp convert_stamp(nil) do
+    nil
+  end
+
+  defp convert_stamp(stamp) do
+    {:ok, casted, 0} = DateTime.from_iso8601(stamp)
+    casted
+  end
+
+  @doc false
+  def to_struct(map) do
+    %__MODULE__{
+      guild_id: map["guild_id"],
+      channel_id: map["channel_id"],
+      user_id: map["user_id"],
+      member: Util.cast(map["member"], {:struct, Member}),
+      session_id: map["session_id"],
+      deaf?: map["deaf"],
+      mute?: map["mute"],
+      self_deaf?: map["self_deaf"],
+      self_mute?: map["self_mute"],
+      self_stream?: map["self_stream"],
+      self_video?: map["self_video"],
+      suppress?: map["suppress"],
+      request_to_speak_timestamp: convert_stamp(map["request_to_speak_timestamp"])
+    }
+  end
+end

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -161,30 +161,6 @@ defmodule Nostrum.Util do
   end
 
   @doc """
-  Converts a map into an atom-keyed map.
-
-  Given a map with variable type keys, returns the same map with all keys as `atoms`.
-
-  This function will attempt to convert keys to an existing atom, and if that fails will default to
-  creating a new atom while displaying a warning. The idea here is that we should be able to see
-  if any results from Discord are giving variable keys. Since we *will* define all
-  types of objects returned by Discord, the amount of new atoms created *SHOULD* be 0. 👀
-  """
-  @spec safe_atom_map(map) :: map
-  def safe_atom_map(term) do
-    cond do
-      is_map(term) ->
-        for {key, value} <- term, into: %{}, do: {maybe_to_atom(key), safe_atom_map(value)}
-
-      is_list(term) ->
-        Enum.map(term, fn item -> safe_atom_map(item) end)
-
-      true ->
-        term
-    end
-  end
-
-  @doc """
   Attempts to convert a string to an atom.
 
   If atom does not currently exist, will warn that we're doing an unsafe conversion.

--- a/lib/nostrum/voice/session.ex
+++ b/lib/nostrum/voice/session.ex
@@ -5,7 +5,6 @@ defmodule Nostrum.Voice.Session do
   alias Nostrum.Constants
   alias Nostrum.Shard.Stage.Producer
   alias Nostrum.Struct.{VoiceState, VoiceWSState}
-  alias Nostrum.Util
   alias Nostrum.Voice
   alias Nostrum.Voice.{Event, Payload}
 
@@ -91,7 +90,6 @@ defmodule Nostrum.Voice.Session do
       frame
       |> :erlang.iolist_to_binary()
       |> Poison.decode!()
-      |> Util.safe_atom_map()
 
     from_handle =
       payload.op

--- a/test/nostrum/struct/interaction_test.exs
+++ b/test/nostrum/struct/interaction_test.exs
@@ -1,0 +1,103 @@
+defmodule Nostrum.Struct.InteractionTest do
+  alias Nostrum.Struct.{
+    ApplicationCommandInteractionData,
+    ApplicationCommandInteractionDataOption,
+    ApplicationCommandInteractionDataResolved,
+    Interaction,
+    User
+  }
+
+  alias Nostrum.Struct.Guild.{Role, Member}
+
+  use ExUnit.Case, async: true
+
+  @payload %{
+    "application_id" => 455_589_479_713_865_749,
+    "channel_id" => 455_589_923_626_549_259,
+    "data" => %{
+      "id" => 793_152_718_839_087_135,
+      "name" => "role",
+      "options" => [
+        %{"name" => "name", "type" => 8, "value" => "451824027976073216"},
+        %{"name" => "action", "type" => 3, "value" => "assign"}
+      ],
+      "resolved" => %{
+        "roles" => %{
+          "451824027976073216" => %{
+            "color" => 0,
+            "hoist" => false,
+            "id" => 451_824_027_976_073_216,
+            "managed" => false,
+            "mentionable" => false,
+            "name" => "@everyone",
+            "permissions" => "109625859648",
+            "position" => 0
+          }
+        }
+      }
+    },
+    "guild_id" => 451_824_027_976_073_216,
+    "id" => 857_721_405_302_112_276,
+    "member" => %{
+      "avatar" => nil,
+      "deaf" => false,
+      "is_pending" => false,
+      "joined_at" => "2018-05-31T19:07:22.755000+00:00",
+      "mute" => false,
+      "nick" => "blob",
+      "pending" => false,
+      "permissions" => "137438953471",
+      "premium_since" => nil,
+      "roles" => [451_824_750_399_062_036, 458_692_275_199_803_406],
+      "user" => %{
+        "avatar" => "d52bf0e27ed56fcde93f8ee345ba8977",
+        "discriminator" => "2359",
+        "id" => 196_989_358_165_852_114,
+        "public_flags" => 0,
+        "username" => "Volcyy"
+      }
+    },
+    "token" => "bob",
+    "type" => 2,
+    "version" => 1
+  }
+
+  describe "Interaction.to_struct/1" do
+    test "casts interaction properly" do
+      assert %Interaction{
+               application_id: 455_589_479_713_865_749,
+               channel_id: 455_589_923_626_549_259,
+               data: %ApplicationCommandInteractionData{
+                 id: 793_152_718_839_087_135,
+                 name: "role",
+                 options: [
+                   %ApplicationCommandInteractionDataOption{
+                     name: "name",
+                     type: 8,
+                     value: "451824027976073216"
+                   },
+                   %ApplicationCommandInteractionDataOption{
+                     name: "action",
+                     type: 3,
+                     value: "assign"
+                   }
+                 ],
+                 resolved: %ApplicationCommandInteractionDataResolved{
+                   roles: %{
+                     451_824_027_976_073_216 => %Role{}
+                   }
+                 }
+               },
+               guild_id: 451_824_027_976_073_216,
+               id: 857_721_405_302_112_276,
+               member: %Member{
+                 user: %User{}
+               },
+               user: nil,
+               token: "bob",
+               type: 2,
+               version: 1
+             } = Interaction.to_struct(@payload)
+    end
+  end
+end


### PR DESCRIPTION
This is only adjusted in the session and voice session dispatcher. That said,
it should be compatible with the current code: atoms are transformed in most
`to_struct` methods via `maybe_to_atom` anyways. In order to fix an atom leak,
the following changes are introduced additionally:

- Adding new keys from the API to interaction structs.
- Adding the `ApplicationCommandInteractionDataResolved` struct.

This may or may not break some things. I will test it with
[bolt](https://github.com/jchristgit/bolt) to look out for any problems, but if
I inferred everything correctly, it would work just fine with existing code.

Note that the new way of converting incoming data to structs also allows us to
slowly phase out `maybe_to_atom`, with the drawback that we need to specify
parsed keys manually.

Fixes #252.