### PR TITLE
Do not document `num_shards` setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ The file should be located at `/config/config.exs`. To run Nostrum you need the
 following two fields:
 ```Elixir
 config :nostrum,
-  token: "666", # The token of your bot as a string
-  num_shards: 2 # The number of shards you want to run your bot under, or :auto.
+  token: "666" # The token of your bot as a string
 ```
 
 For more information about the differences between dev and stable as well as

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,6 @@ import Config
 
 config :nostrum,
   token: "",
-  num_shards: :auto,
   ffmpeg: "ffmpeg",
   youtubedl: "youtube-dl"
 

--- a/docs/static/Gateway Intents.md
+++ b/docs/static/Gateway Intents.md
@@ -10,7 +10,6 @@ To pass intents you should use the following configuration:
 ```elixir
 config :nostrum,
   token: "bot_token",
-  num_shards: :auto,
   gateway_intents: [
       :guilds,
       # other gateway intents

--- a/docs/static/Intro.md
+++ b/docs/static/Intro.md
@@ -73,7 +73,7 @@ config :nostrum,
 
 The following fields are also supported:
 
- - `num_shards` - A fixed number of shards to run, or `:auto` to have Nostrum determine it automatically.
+ - `num_shards` - A fixed number of shards to run, or `:auto` to have Nostrum determine it automatically. Defaults to `:auto`.
  - `ffmpeg` - Specifies the path to the `ffmpeg` executable for playing audio. Defaults to `"ffmpeg"`.
  - `youtubedl` - Specifies the path to the `youtube-dl` executable for playing audio with youtube-dl support. Defaults to `"youtube-dl"`.
  - `gateway_intents` - This field takes a list of atoms representing gateway intents for Nostrum to subscribe to from the Discord API. More information can be found in the [gateway intents](gateway-intents.html) documentation page.

--- a/docs/static/Intro.md
+++ b/docs/static/Intro.md
@@ -68,15 +68,12 @@ The file should be located at `/config/config.exs`. To run Nostrum you need the
 following two fields:
 ```Elixir
 config :nostrum,
-  token: 666, # The token of your bot as a string
-  num_shards: 2 # The number of shards you want to run your bot under, or :auto.
+  token: 666  # The token of your bot as a string
 ```
-If you don't know what `num_shards` is or don't have your bot on a lot of guilds
-you can omit the field and it will default to 1. You can also set this option to
-`:auto` and Nostrum will automatically get the recommended number of shards.
 
 The following fields are also supported:
 
+ - `num_shards` - A fixed number of shards to run, or `:auto` to have Nostrum determine it automatically.
  - `ffmpeg` - Specifies the path to the `ffmpeg` executable for playing audio. Defaults to `"ffmpeg"`.
  - `youtubedl` - Specifies the path to the `youtube-dl` executable for playing audio with youtube-dl support. Defaults to `"youtube-dl"`.
  - `gateway_intents` - This field takes a list of atoms representing gateway intents for Nostrum to subscribe to from the Discord API. More information can be found in the [gateway intents](gateway-intents.html) documentation page.

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -106,7 +106,7 @@ defmodule Nostrum.Util do
   @spec num_shards() :: integer
   def num_shards do
     num =
-      with :auto <- Application.get_env(:nostrum, :num_shards),
+      with :auto <- Application.get_env(:nostrum, :num_shards, :auto),
            {_url, shards} <- gateway(),
            do: shards
 


### PR DESCRIPTION
Attempt to decomplicate a bit. Nostrum is built on Erlang, and Erlang is
smart, so we do not need to document this configuration value, as it is
not needed. Save users some time.