### PR TITLE
Parse interaction types properly and document types.

### DIFF
--- a/lib/nostrum/struct/application_command_interaction_data.ex
+++ b/lib/nostrum/struct/application_command_interaction_data.ex
@@ -1,13 +1,12 @@
 defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @moduledoc "Struct for interaction data."
 
-  alias Nostrum.Snowflake
-
   alias Nostrum.Struct.{
     ApplicationCommandInteractionDataOption,
     ApplicationCommandInteractionDataResolved
   }
 
+  alias Nostrum.Snowflake
   alias Nostrum.Util
 
   defstruct [:id, :name, :resolved, :options, :custom_id, :component_type]

--- a/lib/nostrum/struct/application_command_interaction_data_option.ex
+++ b/lib/nostrum/struct/application_command_interaction_data_option.ex
@@ -3,6 +3,10 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
 
   # seasons greetings from `AbstractBeanModelParserFactory.java`.
 
+  alias Nostrum.Snowflake
+  alias Nostrum.Struct.Channel
+  alias Nostrum.Struct.Guild.Role
+  alias Nostrum.Struct.User
   alias Nostrum.Util
 
   defstruct [:name, :type, :value, :options]
@@ -22,10 +26,24 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
   @typedoc """
   Parameter value.
 
-  Mutually exclusive with `options`.
+  The type of this depends on the `t:type/0`:
+
+  - For `t:type/0` of `3`, this will be a `t:String.t/0`.
+  - For `t:type/0` of `4`, this will be a `t:integer/0`.
+  - For `t:type/0` of `5`, this will be a `t:boolean/0`.
+  - For `t:type/0` of `6`, this will be a `t:Nostrum.Struct.User.id/0`. The
+    corresponding guild member _and_ user can be looked up in
+    `t:Nostrum.Struct.ApplicationCommandInteractionData.resolved/0`.
+  - For `t:type/0` of `7`, this will be a `t:Nostrum.Struct.Channel.id/0`. The
+    corresponding channel can be looked up in
+    `t:Nostrum.Struct.ApplicationCommandInteractionData.resolved/0`.
+  - For `t:type/0` of `8`, this will be a `t:Nostrum.Struct.Guild.Role.id/0`. The
+    corresponding role can be looked up in
+    `t:Nostrum.Struct.ApplicationCommandInteractionData.resolved/0`.
+
+  Mutually exclusive with `options`. If `options` is not `nil`, this will be `nil`.
   """
-  # OptionType.t() ?
-  @type value :: String.t() | nil
+  @type value :: String.t() | integer() | boolean() | User.id() | Channel.id() | Role.id() | nil
 
   @typedoc """
   Parameter options for subcommands.
@@ -42,13 +60,16 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
           options: options
         }
 
+  defp parse_value(type, value) when type in [6, 7, 8], do: Util.cast(value, Snowflake)
+  defp parse_value(_type, value), do: value
+
   @doc false
   @spec to_struct(map()) :: __MODULE__.t()
   def to_struct(map) do
     %__MODULE__{
       name: map.name,
       type: map.type,
-      value: map[:value],
+      value: parse_value(map.type, map[:value]),
       options: Util.cast(map[:options], {:list, {:struct, __MODULE__}})
     }
   end

--- a/test/nostrum/struct/interaction_test.exs
+++ b/test/nostrum/struct/interaction_test.exs
@@ -77,7 +77,7 @@ defmodule Nostrum.Struct.InteractionTest do
                    %ApplicationCommandInteractionDataOption{
                      name: "name",
                      type: 8,
-                     value: "451824027976073216"
+                     value: 451_824_027_976_073_216
                    },
                    %ApplicationCommandInteractionDataOption{
                      name: "action",


### PR DESCRIPTION
Discord sends other types than string here occasionally. That said, when
a snowflake arrives, we want to decode it from string to integer, which
makes looking it up in the `resolved` type easier. Document the new
types for the user.

Fixes #235.