### PR TITLE
Bump version and Elixir version.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule Nostrum.Mixfile do
   def project do
     [
       app: :nostrum,
-      version: "0.4.7",
-      elixir: "~> 1.9",
+      version: "0.5.0",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Elixir version 1.9 has been untested in CI for a while now, per
https://github.com/Kraigie/nostrum/pull/193.

This does not adjust the version in any installation guides yet, as we
have not (and can not) published a release yet.