### PR TITLE
Ignore dialyzer warnings for functions that use Porcelain.

### DIFF
--- a/lib/nostrum/voice/audio.ex
+++ b/lib/nostrum/voice/audio.ex
@@ -1,6 +1,9 @@
 defmodule Nostrum.Voice.Audio do
   @moduledoc false
 
+  @dialyzer {:nowarn_function, spawn_youtubedl: 1}
+  @dialyzer {:nowarn_function, spawn_ffmpeg: 3}
+
   require Logger
 
   alias Nostrum.Error.VoiceError


### PR DESCRIPTION
Porcelain process spawning functions can return an error tuple even though it's not specified in the type specs. Until [this PR](https://github.com/alco/porcelain/pull/54) is merged and Porcelain has another release, these added attributes will allow dialyzer to ignore the false positives.