### PR TITLE
Fix `MessageDelete.to_struct` for direct messages

### DIFF
--- a/lib/nostrum/struct/event/message_delete.ex
+++ b/lib/nostrum/struct/event/message_delete.ex
@@ -36,7 +36,7 @@ defmodule Nostrum.Struct.Event.MessageDelete do
       id: map["id"],
       channel_id: map["channel_id"],
       # https://github.com/discord/discord-api-docs/issues/296
-      guild_id: map.guild_id
+      guild_id: map[:guild_id]
     }
   end
 end


### PR DESCRIPTION
`:guild_id` is not set when a direct message is deleted. This change ensures that we don't crash when that happens.