### PR TITLE
fix: `Dispatch` expected `Channel` struct but it's map with string keys

### DIFF
--- a/lib/nostrum/cache/guild_cache.ex
+++ b/lib/nostrum/cache/guild_cache.ex
@@ -221,7 +221,7 @@ defmodule Nostrum.Cache.GuildCache do
   def channel_create(guild_id, channel) do
     [{_id, guild}] = :ets.lookup(@table_name, guild_id)
     new_channel = Util.cast(channel, {:struct, Channel})
-    new_channels = Map.put(guild.channels, channel.id, new_channel)
+    new_channels = Map.put(guild.channels, channel["id"], new_channel)
     new_guild = %{guild | channels: new_channels}
     true = :ets.update_element(@table_name, guild_id, {2, new_guild})
     new_channel

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -59,13 +59,13 @@ defmodule Nostrum.Shard.Dispatch do
     end
   end
 
-  def handle_event(:CHANNEL_CREATE = event, %{type: 1} = p, state) do
+  def handle_event(:CHANNEL_CREATE = event, %{"type" => 1} = p, state) do
     {event, ChannelCache.create(p), state}
   end
 
-  def handle_event(:CHANNEL_CREATE = event, %{type: t} = p, state) when t in [0, 2] do
-    :ets.insert(:channel_guild_map, {p.id, p.guild_id})
-    {event, GuildCache.channel_create(p.guild_id, p), state}
+  def handle_event(:CHANNEL_CREATE = event, %{"type" => t} = p, state) when t in [0, 2] do
+    :ets.insert(:channel_guild_map, {p["id"], p["guild_id"]})
+    {event, GuildCache.channel_create(p["guild_id"], p), state}
   end
 
   # Ignore group channels
@@ -73,22 +73,22 @@ defmodule Nostrum.Shard.Dispatch do
     :noop
   end
 
-  def handle_event(:CHANNEL_DELETE = event, %{type: 1} = p, state) do
-    {event, ChannelCache.delete(p.id), state}
+  def handle_event(:CHANNEL_DELETE = event, %{"type" => 1} = p, state) do
+    {event, ChannelCache.delete(p["id"]), state}
   end
 
-  def handle_event(:CHANNEL_DELETE = event, %{type: t} = p, state) when t in [0, 2] do
-    :ets.delete(:channel_guild_map, p.id)
-    {event, GuildCache.channel_delete(p.guild_id, p.id), state}
-  end
-
-  def handle_event(:CHANNEL_UPDATE = event, p, state) do
-    {event, GuildCache.channel_update(p["guild_id"], p), state}
+  def handle_event(:CHANNEL_DELETE = event, %{"type" => t} = p, state) when t in [0, 2] do
+    :ets.delete(:channel_guild_map, p["id"])
+    {event, GuildCache.channel_delete(p["guild_id"], p["id"]), state}
   end
 
   def handle_event(:CHANNEL_DELETE, _p, _state) do
     # Ignore group channels
     :noop
+  end
+
+  def handle_event(:CHANNEL_UPDATE = event, p, state) do
+    {event, GuildCache.channel_update(p["guild_id"], p), state}
   end
 
   def handle_event(:CHANNEL_PINS_ACK = event, p, state), do: {event, p, state}


### PR DESCRIPTION
In `Dispatch`'s `handle_event` functions, the payloads are maps with string keys, not atoms as the code expected.

The code doesn't seem to have changed in 4 years so I am not sure what is going on. Am I missing something or did we make a change recently that broke this?

Example payloads:

```elixir
:CHANNEL_DELETE
%{
  "bitrate" => 64000,
  "guild_hashes" => %{
    channels: %{hash: "FUnLGUp92zY"},
    metadata: %{hash: "e3mMLdqJvmU"},
    roles: %{hash: "RqryBXuGhAQ"},
    version: 1
  },
  "guild_id" => 808702654830084096,
  "id" => 873254279505399808,
  "name" => "Haha",
  "nsfw" => false,
  "parent_id" => 846862417451548682,
  "permission_overwrites" => [
    %{
      "allow" => 1024,
      "allow_new" => "1024",
      "deny" => 0,
      "deny_new" => "0",
      "id" => 668940363196792849,
      "type" => :member
    },
    %{
      "allow" => 0,
      "allow_new" => "0",
      "deny" => 1024,
      "deny_new" => "1024",
      "id" => 808702654830084096,
      "type" => :role
    }
  ],
  "position" => 9,
  "rtc_region" => nil,
  "type" => 2,
  "user_limit" => 0
}
```