### PR TITLE
docs: correct spelling of allowed_mentions atoms

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -178,10 +178,10 @@ defmodule Nostrum.Api do
     * `:all` (default) - Ping everything as usual
     * `:none` - Nobody will be pinged
     * `:everyone` - Allows to ping @here and @everone
-    * `:user` - Allows to ping users
+    * `:users` - Allows to ping users
     * `:roles` - Allows to ping roles
-    * `{:user, list}` - Allows to ping list of users. Can contain up to 100 ids of users.
-    * `{:role, list}` - Allows to ping list of roles. Can contain up to 100 ids of roles.
+    * `{:users, list}` - Allows to ping list of users. Can contain up to 100 ids of users.
+    * `{:roles, list}` - Allows to ping list of roles. Can contain up to 100 ids of roles.
     * list - a list containing the values above.
 
   ### Message reference


### PR DESCRIPTION
Changes the spelling of `:user` and `:role` in the documentation to be pluralised correctly to match how it actually is in the code. Accidentally pinged everyone thanks to this, good thing it was in a testing guild 😅

Relevant lines
https://github.com/Kraigie/nostrum/blob/517894fd9d256210c3acdf5698b2dcc3be5b4990/lib/nostrum/api.ex#L3352-L3358