### PR TITLE
Permissions update per: discord/discord-api-docs#3672

### DIFF
--- a/lib/nostrum/permission.ex
+++ b/lib/nostrum/permission.ex
@@ -31,6 +31,10 @@ defmodule Nostrum.Permission do
   """
   @type bitset :: non_neg_integer
 
+  @typedoc """
+  This grouping is from an older version of the permission API and no longer applies
+  """
+  @typedoc deprecated: "See t.0"
   @type general_permission ::
           :create_instant_invite
           | :kick_members
@@ -46,6 +50,9 @@ defmodule Nostrum.Permission do
           | :manage_webhooks
           | :manage_emojis
 
+  @typedoc """
+  The permissions that apply to text channels.
+  """
   @type text_permission ::
           :create_instant_invite
           | :manage_channels
@@ -68,6 +75,9 @@ defmodule Nostrum.Permission do
           | :use_external_stickers
           | :send_messages_in_threads
 
+  @typedoc """
+  The permissions that apply to voice channels.
+  """
   @type voice_permission ::
           :create_instant_invite
           | :manage_channels
@@ -82,6 +92,38 @@ defmodule Nostrum.Permission do
           | :use_vad
           | :manage_roles
 
+  @typedoc """
+  The permissions that apply to stage channels.
+  """
+  @typedoc since: "0.5"
+  @type stage_permission ::
+          :create_instant_invite
+          | :manage_channels
+          | :view_channel
+          | :connect
+          | :mute_members
+          | :deafen_members
+          | :move_members
+          | :manage_roles
+          | :request_to_speak
+
+  @typedoc """
+  The permissions which apply to general server administration.
+  """
+  @typedoc since: "0.5"
+  @type server_permission ::
+          :kick_members
+          | :ban_members
+          | :administrator
+          | :manage_guild
+          | :view_audit_log
+          | :view_guild_insights
+          | :change_nickname
+          | :manage_nicknames
+          | :manage_emojis_and_stickers
+  @typedoc """
+  The full permission type.
+  """
   @type t ::
           :create_instant_invite
           | :kick_members

--- a/lib/nostrum/permission.ex
+++ b/lib/nostrum/permission.ex
@@ -47,7 +47,10 @@ defmodule Nostrum.Permission do
           | :manage_emojis
 
   @type text_permission ::
-          :add_reactions
+          :create_instant_invite
+          | :manage_channels
+          | :add_reactions
+          | :view_channel
           | :send_messages
           | :send_tts_messages
           | :manage_messages
@@ -56,51 +59,108 @@ defmodule Nostrum.Permission do
           | :read_message_history
           | :mention_everyone
           | :use_external_emojis
+          | :manage_roles
+          | :manage_webhooks
+          | :use_application_commands
+          | :manage_threads
+          | :create_public_threads
+          | :create_private_threads
+          | :use_external_stickers
+          | :send_messages_in_threads
 
   @type voice_permission ::
-          :connect
+          :create_instant_invite
+          | :manage_channels
+          | :priority_speaker
+          | :stream
+          | :view_channel
+          | :connect
           | :speak
           | :mute_members
           | :deafen_members
           | :move_members
           | :use_vad
-          | :priority_speaker
+          | :manage_roles
 
   @type t ::
-          general_permission
-          | text_permission
-          | voice_permission
+          :create_instant_invite
+          | :kick_members
+          | :ban_members
+          | :administrator
+          | :manage_channels
+          | :manage_guild
+          | :add_reactions
+          | :view_audit_log
+          | :priority_speaker
+          | :stream
+          | :view_channel
+          | :send_messages
+          | :send_tts_messages
+          | :manage_messages
+          | :embed_links
+          | :attach_files
+          | :read_message_history
+          | :mention_everyone
+          | :use_external_emojis
+          | :view_guild_insights
+          | :connect
+          | :speak
+          | :mute_members
+          | :deafen_members
+          | :move_members
+          | :use_vad
+          | :change_nickname
+          | :manage_nicknames
+          | :manage_roles
+          | :manage_webhooks
+          | :manage_emojis_and_stickers
+          | :use_application_commands
+          | :request_to_speak
+          | :manage_threads
+          | :create_public_threads
+          | :create_private_threads
+          | :use_external_stickers
+          | :send_messages_in_threads
 
   @permission_to_bit_map %{
-    create_instant_invite: 0x00000001,
-    kick_members: 0x00000002,
-    ban_members: 0x00000004,
-    administrator: 0x00000008,
-    manage_channels: 0x00000010,
-    manage_guild: 0x00000020,
-    add_reactions: 0x00000040,
-    view_audit_log: 0x00000080,
-    priority_speaker: 0x00000100,
-    view_channel: 0x00000400,
-    send_messages: 0x00000800,
-    send_tts_messages: 0x00001000,
-    manage_messages: 0x00002000,
-    embed_links: 0x00004000,
-    attach_files: 0x00008000,
-    read_message_history: 0x00010000,
-    mention_everyone: 0x00020000,
-    use_external_emojis: 0x00040000,
-    connect: 0x00100000,
-    speak: 0x00200000,
-    mute_members: 0x00400000,
-    deafen_members: 0x00800000,
-    move_members: 0x01000000,
-    use_vad: 0x02000000,
-    change_nickname: 0x04000000,
-    manage_nicknames: 0x08000000,
-    manage_roles: 0x10000000,
-    manage_webhooks: 0x20000000,
-    manage_emojis: 0x40000000
+    create_instant_invite: 0x0000000001,
+    kick_members: 0x0000000002,
+    ban_members: 0x0000000004,
+    administrator: 0x0000000008,
+    manage_channels: 0x0000000010,
+    manage_guild: 0x0000000020,
+    add_reactions: 0x0000000040,
+    view_audit_log: 0x0000000080,
+    priority_speaker: 0x0000000100,
+    stream: 0x0000000200,
+    view_channel: 0x0000000400,
+    send_messages: 0x0000000800,
+    send_tts_messages: 0x0000001000,
+    manage_messages: 0x0000002000,
+    embed_links: 0x0000004000,
+    attach_files: 0x0000008000,
+    read_message_history: 0x0000010000,
+    mention_everyone: 0x0000020000,
+    use_external_emojis: 0x0000040000,
+    view_guild_insights: 0x0000080000,
+    connect: 0x0000100000,
+    speak: 0x0000200000,
+    mute_members: 0x0000400000,
+    deafen_members: 0x0000800000,
+    move_members: 0x0001000000,
+    use_vad: 0x0002000000,
+    change_nickname: 0x0004000000,
+    manage_nicknames: 0x0008000000,
+    manage_roles: 0x0010000000,
+    manage_webhooks: 0x0020000000,
+    manage_emojis_and_stickers: 0x0040000000,
+    use_application_commands: 0x0080000000,
+    request_to_speak: 0x0100000000,
+    manage_threads: 0x0400000000,
+    create_public_threads: 0x0800000000,
+    create_private_threads: 0x1000000000,
+    use_external_stickers: 0x2000000000,
+    send_messages_in_threads: 0x4000000000
   }
 
   @bit_to_permission_map Map.new(@permission_to_bit_map, fn {k, v} -> {v, k} end)


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/pull/3672/commits/2ed2414441169930349aae215f1d5c8946160299

Slightly early, but there were several missing permissions potentially causing issues so this one may want to go through early. I don't think it would do any harm to push this to main?

The thread permissions are due to go into effect on 9/7.