### PR TITLE
Fix ModuleUndefined error in InteractionOption

### DIFF
--- a/lib/nostrum/struct/application_command_interaction_data_option.ex
+++ b/lib/nostrum/struct/application_command_interaction_data_option.ex
@@ -50,7 +50,7 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
       type: map.type,
       value: map[:value],
       options:
-        Util.cast(map[:options], {:list, {:struct, ApplicationCommandInteractionDataOption}})
+        Util.cast(map[:options], {:list, {:struct, __MODULE__}})
     }
   end
 end

--- a/lib/nostrum/struct/application_command_interaction_data_option.ex
+++ b/lib/nostrum/struct/application_command_interaction_data_option.ex
@@ -49,8 +49,7 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
       name: map.name,
       type: map.type,
       value: map[:value],
-      options:
-        Util.cast(map[:options], {:list, {:struct, __MODULE__}})
+      options: Util.cast(map[:options], {:list, {:struct, __MODULE__}})
     }
   end
 end


### PR DESCRIPTION
The `to_struct/1` fn in `Nostrum.Struct.ApplicationCommandInteractionDataOption` was not passing the correct arguments to `Nostrum.Util.cast/2`

Leading to an `UndefinedFunction` error when a slash command's sub-command is called.