### PR TITLE
Add three missing fields to interaction data

### DIFF
--- a/lib/nostrum/struct/application_command_interaction_data.ex
+++ b/lib/nostrum/struct/application_command_interaction_data.ex
@@ -51,7 +51,7 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @typedoc since: "0.5.0"
   @type interaction_type :: integer() | nil
 
-  @typedoc "id of the user or message targeted by a context menu command"
+  @typedoc "ID of the user or message targeted by a context menu command"
   @typedoc since: "0.5.0"
   @type target_id :: Snowflake.t() | nil
 

--- a/lib/nostrum/struct/application_command_interaction_data.ex
+++ b/lib/nostrum/struct/application_command_interaction_data.ex
@@ -10,7 +10,17 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
 
   alias Nostrum.Util
 
-  defstruct [:id, :name, :resolved, :options, :custom_id, :component_type]
+  defstruct [
+    :id,
+    :name,
+    :resolved,
+    :options,
+    :custom_id,
+    :component_type,
+    :type,
+    :values,
+    :target_id
+  ]
 
   @typedoc "ID of the invoked command"
   @type id :: Snowflake.t() | nil
@@ -34,6 +44,24 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @type component_type :: integer() | nil
 
   @typedoc """
+  The type of application command invoked.
+  Official reference:
+  https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types
+  """
+  @typedoc since: "0.5.0"
+  @type interaction_type :: integer() | nil
+
+  @typedoc "id of the user or message targeted by a context menu command"
+  @typedoc since: "0.5.0"
+  @type target_id :: Snowflake.t() | nil
+
+  @typedoc """
+  For select menu components, this will be a list of the values the user selected.
+  """
+  @typedoc since: "0.5.0"
+  @type select_values :: [String.t()] | nil
+
+  @typedoc """
   Command interaction data for slash commands.
 
   Used as part of `t:Nostrum.Struct.Interaction.t/0`.
@@ -44,10 +72,13 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @type t :: %__MODULE__{
           id: id,
           name: name,
+          type: interaction_type,
           resolved: resolved,
           options: options,
           custom_id: custom_id,
-          component_type: component_type
+          component_type: component_type,
+          values: select_values,
+          target_id: target_id
         }
 
   @doc false
@@ -56,11 +87,14 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
     %__MODULE__{
       id: map[:id],
       name: map[:name],
+      type: map[:type],
       resolved: Util.cast(map[:resolved], {:struct, ApplicationCommandInteractionDataResolved}),
       options:
         Util.cast(map[:options], {:list, {:struct, ApplicationCommandInteractionDataOption}}),
       custom_id: map[:custom_id],
-      component_type: map[:component_type]
+      component_type: map[:component_type],
+      values: map[:values],
+      target_id: map[:target_id]
     }
   end
 end


### PR DESCRIPTION
`InteractionData` was missing the `target_id`, `type`, and `values` fields for [InteractionData](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure). This PR adds them.