### PR TITLE
 Fix `GUILD_UPDATE` making some fields `nil` 

### DIFF
--- a/lib/nostrum/cache/guild_cache.ex
+++ b/lib/nostrum/cache/guild_cache.ex
@@ -203,7 +203,7 @@ defmodule Nostrum.Cache.GuildCache do
   def update(payload) do
     [{_id, old_guild}] = :ets.lookup(@table_name, payload.id)
     casted = Util.cast(payload, {:struct, Guild})
-    new_guild = Map.merge(old_guild, casted)
+    new_guild = Guild.merge(old_guild, casted)
     true = :ets.update_element(@table_name, payload.id, {2, new_guild})
     {old_guild, new_guild}
   end

--- a/lib/nostrum/struct/application_command_interaction_data.ex
+++ b/lib/nostrum/struct/application_command_interaction_data.ex
@@ -51,7 +51,7 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @typedoc since: "0.5.0"
   @type interaction_type :: integer() | nil
 
-  @typedoc "ID of the user or message targeted by a context menu command"
+  @typedoc "id of the user or message targeted by a context menu command"
   @typedoc since: "0.5.0"
   @type target_id :: Snowflake.t() | nil
 

--- a/lib/nostrum/struct/application_command_interaction_data.ex
+++ b/lib/nostrum/struct/application_command_interaction_data.ex
@@ -51,7 +51,7 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @typedoc since: "0.5.0"
   @type interaction_type :: integer() | nil
 
-  @typedoc "id of the user or message targeted by a context menu command"
+  @typedoc "ID of the user or message targeted by a context menu command"
   @typedoc since: "0.5.0"
   @type target_id :: Snowflake.t() | nil
 

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -1,4 +1,16 @@
 defmodule Nostrum.Struct.Guild do
+
+  # fields that are only sent on GUILD_CREATE
+  @guild_create_fields [
+    :joined_at,
+    :large,
+    :unavailable,
+    :member_count,
+    :voice_states,
+    :members,
+    :channels
+  ]
+
   @moduledoc """
   Struct representing a Discord guild.
   """
@@ -361,4 +373,20 @@ defmodule Nostrum.Struct.Guild do
 
     struct(__MODULE__, new)
   end
+
+  @doc false
+  @spec merge(t, t) :: t
+  def merge(old_guild, new_guild) do
+    Map.merge(old_guild, new_guild, &handle_key_conflict/3)
+  end
+
+  # Make it so that values which are only sent on GUILD_CREATE are not replaced with nil
+  defp handle_key_conflict(key, old, nil) when key in @guild_create_fields do
+    old
+  end
+
+  defp handle_key_conflict(_key, _old, new) do
+    new
+  end
+
 end

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -1,5 +1,4 @@
 defmodule Nostrum.Struct.Guild do
-
   # fields that are only sent on GUILD_CREATE
   @guild_create_fields [
     :joined_at,
@@ -388,5 +387,4 @@ defmodule Nostrum.Struct.Guild do
   defp handle_key_conflict(_key, _old, new) do
     new
   end
-
 end


### PR DESCRIPTION
This fixes a fatal bug where if a Guild is updated, a member or channel update will then cause a `BadMapError`.