### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '22.0'
-          elixir-version: '1.9'
+          elixir-version: '1.12'
       - uses: actions/cache@v2
         with:
           path: deps

--- a/docs/static/Intro.md
+++ b/docs/static/Intro.md
@@ -1,7 +1,7 @@
 # Intro
 Nostrum is a an Elixir library that can be used to interact with Discord.
 
-Nostrum currently supports versions of Elixir at or above v. 1.9.
+Nostrum currently supports versions of Elixir at or above v. 1.10.
 
 With a platform like Discord, there are many moving parts and an attempt was made
 to break these parts into smaller logical pieces.


### PR DESCRIPTION
- Change docs workflow to build with Elixir v1.12
- Change Intro.md to specify that Nostrum targets Elixir v1.10 and up