### PR TITLE
Implement pluggable guild caching.

### DIFF
--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -1,7 +1,6 @@
 defmodule Nostrum.Application do
   @moduledoc false
 
-  alias Nostrum.Cache.GuildCache
   use Application
 
   require Logger
@@ -34,7 +33,6 @@ defmodule Nostrum.Application do
     :ets.new(:presences, [:set, :public, :named_table])
     :ets.new(:guild_shard_map, [:set, :public, :named_table])
     :ets.new(:channel_guild_map, [:set, :public, :named_table])
-    :ets.new(GuildCache.tabname(), [:set, :public, :named_table])
   end
 
   defp check_token, do: check_token(Application.get_env(:nostrum, :token))

--- a/lib/nostrum/cache/cache_supervisor.ex
+++ b/lib/nostrum/cache/cache_supervisor.ex
@@ -1,5 +1,15 @@
 defmodule Nostrum.Cache.CacheSupervisor do
-  @moduledoc false
+  @moduledoc """
+  Supervises caches for nostrum structures.
+
+  See the documentation for the relevant submodules for details:
+
+  - `Nostrum.Cache.ChannelCache`
+  - `Nostrum.Cache.GuildCache`
+  - `Nostrum.Cache.Me`
+  - `Nostrum.Cache.PresenceCache`
+  - `Nostrum.Cache.UserCache`
+  """
 
   use Supervisor
 
@@ -9,7 +19,9 @@ defmodule Nostrum.Cache.CacheSupervisor do
 
   def init([]) do
     children = [
-      Nostrum.Cache.Me
+      Nostrum.Cache.Me,
+      # Uses the configured cache implementation.
+      Nostrum.Cache.GuildCache
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/nostrum/cache/guild_cache/ets.ex
+++ b/lib/nostrum/cache/guild_cache/ets.ex
@@ -1,0 +1,355 @@
+defmodule Nostrum.Cache.GuildCache.ETS do
+  @table_name :nostrum_guilds
+  @moduledoc """
+  An ETS-based cache for guilds.
+
+  The supervisor defined by this module will set up the ETS table associated
+  with it.
+
+  The default table name under which guilds are cached is `#{@table_name}`.
+  In addition to the cache behaviour implementations provided by this module,
+  you can also call regular ETS table methods on it, such as `:ets.info`.
+
+  Note that users should not call the functions not related to this specific
+  implementation of the cache directly. Instead, call the functions of
+  `Nostrum.Cache.GuildCache` directly, which will dispatch to the configured
+  cache.
+  """
+  @moduledoc since: "0.5"
+
+  @behaviour Nostrum.Cache.GuildCache
+
+  alias Nostrum.Cache.GuildCache
+  alias Nostrum.Cache.Mapping.ChannelGuild
+  alias Nostrum.Snowflake
+  alias Nostrum.Struct.Channel
+  alias Nostrum.Struct.Emoji
+  alias Nostrum.Struct.Guild
+  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Struct.Guild.Role
+  alias Nostrum.Struct.Message
+  alias Nostrum.Util
+  import Nostrum.Snowflake, only: [is_snowflake: 1]
+  use Supervisor
+
+  @doc "Start the supervisor."
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @doc "Set up the cache's ETS table."
+  @impl Supervisor
+  def init(_init_arg) do
+    :ets.new(tabname(), [:set, :public, :named_table])
+    Supervisor.init([], strategy: :one_for_one)
+  end
+
+  defguardp is_selector(term) when is_function(term, 1)
+
+  @doc "Retrieve the ETS table name used for the cache."
+  @spec tabname :: atom()
+  def tabname, do: @table_name
+
+  @doc "Retrieve all guilds from the cache."
+  @impl GuildCache
+  @spec all() :: Enum.t()
+  def all do
+    @table_name
+    |> :ets.tab2list()
+    |> Stream.map(&elem(&1, 1))
+  end
+
+  @doc "Retrieve all guilds matching the given selector from the cache."
+  @impl GuildCache
+  @spec select_all(GuildCache.selector()) :: Enum.t()
+  def select_all(selector)
+
+  def select_all(selector) when is_selector(selector) do
+    :ets.foldl(fn {_id, guild}, acc -> [selector.(guild) | acc] end, [], @table_name)
+  end
+
+  @doc "Retrieve a guild from the cache by ID."
+  @impl GuildCache
+  @spec get(Guild.id()) :: {:ok, Guild.t()} | {:error, GuildCache.reason()}
+  def get(id) do
+    select(id, fn guild -> guild end)
+  end
+
+  @doc "Same as `get/1`, but raise if the guild does not exist."
+  @impl GuildCache
+  @spec get!(Guild.id()) :: Guild.t() | no_return
+  def get!(id), do: get(id) |> Util.bangify_find(id, __MODULE__)
+
+  @doc "Get a guild from the cache using the given selectors."
+  @impl GuildCache
+  @spec get_by(GuildCache.clauses()) :: {:ok, Guild.t()} | {:error, GuildCache.reason()}
+  def get_by(clauses) do
+    select_by(clauses, fn guild -> guild end)
+  end
+
+  @doc "Same as `get_by/1`, but raise if no guild was found."
+  @impl GuildCache
+  @spec get_by!(GuildCache.clauses()) :: Guild.t() | no_return
+  def get_by!(clauses), do: get_by(clauses) |> Util.bangify_find(clauses, __MODULE__)
+
+  @doc "Select values from the guild with the matching ID."
+  @impl GuildCache
+  @spec select(Guild.id(), GuildCache.selector()) :: {:ok, any} | {:error, GuildCache.reason()}
+  def select(id, selector) do
+    select_by(%{id: id}, selector)
+  end
+
+  @doc "Same as `select!/1`, but raise if no guild matching `id` is found."
+  @impl GuildCache
+  @spec select!(Guild.id(), GuildCache.selector()) :: any | no_return
+  def select!(id, selector), do: select(id, selector) |> Util.bangify_find(id, __MODULE__)
+
+  @doc "Select values using a `selector` for a guild that matches the given `clauses`."
+  @impl GuildCache
+  @spec select_by(GuildCache.clauses(), GuildCache.selector()) ::
+          {:ok, any} | {:error, GuildCache.reason()}
+  def select_by(clauses, selector)
+
+  def select_by(clauses, selector) when is_list(clauses) and is_selector(selector),
+    do: select_by(Map.new(clauses), selector)
+
+  def select_by(%{id: id}, selector) when is_snowflake(id) and is_selector(selector) do
+    case :ets.lookup(@table_name, id) do
+      [{^id, guild}] ->
+        selection = selector.(guild)
+        {:ok, selection}
+
+      [] ->
+        {:error, :id_not_found_on_guild_lookup}
+    end
+  end
+
+  def select_by(%{channel_id: channel_id}, selector)
+      when is_snowflake(channel_id) and is_selector(selector) do
+    case ChannelGuild.get_guild(channel_id) do
+      {:ok, guild_id} -> select_by(%{id: guild_id}, selector)
+      {:error, _} = error -> error
+    end
+  end
+
+  def select_by(%{message: %Message{channel_id: channel_id}}, selector) do
+    select_by(%{channel_id: channel_id}, selector)
+  end
+
+  @doc "Same as `select_by/2`, but raise if no guild was found."
+  @impl GuildCache
+  @spec select_by!(GuildCache.clauses(), GuildCache.selector()) :: any | no_return
+  def select_by!(clauses, selector),
+    do: select_by(clauses, selector) |> Util.bangify_find(clauses, __MODULE__)
+
+  # IMPLEMENTATION
+  @doc "Create the given guild in the cache."
+  @impl GuildCache
+  @spec create(Guild.t()) :: true
+  def create(guild) do
+    true = :ets.insert_new(@table_name, {guild.id, guild})
+  end
+
+  @doc "Update the given guild in the cache."
+  @impl GuildCache
+  @spec update(map()) :: {Guild.t(), Guild.t()}
+  def update(payload) do
+    [{_id, old_guild}] = :ets.lookup(@table_name, payload.id)
+    casted = Util.cast(payload, {:struct, Guild})
+    new_guild = Guild.merge(old_guild, casted)
+    true = :ets.update_element(@table_name, payload.id, {2, new_guild})
+    {old_guild, new_guild}
+  end
+
+  @doc "Delete the given guild from the cache."
+  @impl GuildCache
+  @spec delete(Guild.id()) :: Guild.t() | nil
+  def delete(guild_id) do
+    # Returns the old guild, if cached
+    case :ets.take(@table_name, guild_id) do
+      [{_id, guild}] -> guild
+      [] -> nil
+    end
+  end
+
+  @doc "Create the given channel for the given guild in the cache."
+  @impl GuildCache
+  @spec channel_create(Guild.id(), map()) :: Channel.t()
+  def channel_create(guild_id, channel) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    new_channel = Util.cast(channel, {:struct, Channel})
+    new_channels = Map.put(guild.channels, channel.id, new_channel)
+    new_guild = %{guild | channels: new_channels}
+    true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+    new_channel
+  end
+
+  @doc "Delete the channel from the given guild in the cache."
+  @impl GuildCache
+  @spec channel_delete(Guild.id(), Channel.id()) :: Channel.t() | :noop
+  def channel_delete(guild_id, channel_id) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    {popped, new_channels} = Map.pop(guild.channels, channel_id)
+    new_guild = %{guild | channels: new_channels}
+    true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+    if popped, do: popped, else: :noop
+  end
+
+  @doc "Update the channel on the given guild in the cache."
+  @impl GuildCache
+  @spec channel_update(Guild.id(), map()) :: {Channel.t(), Channel.t()}
+  def channel_update(guild_id, channel) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    {old, new, new_channels} = upsert(guild.channels, channel.id, channel, Channel)
+    new_guild = %{guild | channels: new_channels}
+    true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+    {old, new}
+  end
+
+  @doc "Update the emoji list for the given guild in the cache."
+  @impl GuildCache
+  @spec emoji_update(Guild.id(), [map()]) :: {[Emoji.t()], [Emoji.t()]}
+  def emoji_update(guild_id, emojis) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    casted = Util.cast(emojis, {:list, {:struct, Emoji}})
+    new = %{guild | emojis: casted}
+    true = :ets.update_element(@table_name, guild_id, {2, new})
+    {guild.emojis, casted}
+  end
+
+  @doc "Add the given member to the given guild in the cache."
+  @impl GuildCache
+  @spec member_add(Guild.id(), map()) :: Member.t()
+  def member_add(guild_id, payload) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    {_old, member, new_members} = upsert(guild.members, payload.user.id, payload, Member)
+    new = %{guild | members: new_members, member_count: guild.member_count + 1}
+    true = :ets.update_element(@table_name, guild_id, {2, new})
+    member
+  end
+
+  @doc "Remove the given member from the given guild in the cache."
+  @impl GuildCache
+  @spec member_remove(Guild.id(), map()) :: {Guild.id(), Member.t()} | :noop
+  def member_remove(guild_id, user) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    {popped, new_members} = Map.pop(guild.members, user.id)
+    new_guild = %{guild | members: new_members, member_count: guild.member_count - 1}
+    true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+    if popped, do: {guild_id, popped}, else: :noop
+  end
+
+  @doc "Update the given member for the given guild in the cache."
+  @impl GuildCache
+  @spec member_update(Guild.id(), map()) :: {Guild.id(), Member.t() | nil, Member.t()}
+  def member_update(guild_id, member) do
+    # We may retrieve a GUILD_MEMBER_UPDATE event for our own user even if we
+    # have the required intents to retrieve it for other members disabled, as
+    # outlined in issue https://github.com/Kraigie/nostrum/issues/293. In
+    # that case, we will not have the guild cached.
+    case :ets.lookup(@table_name, guild_id) do
+      [{_id, guild}] ->
+        {old, new, new_members} = upsert(guild.members, member.user.id, member, Member)
+        new_guild = %{guild | members: new_members}
+        true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+        {guild_id, old, new}
+
+      [] ->
+        new = Util.cast(member, {:struct, Member})
+        {guild_id, nil, new}
+    end
+  end
+
+  @doc "Create a chunk of members for the given guild in the cache."
+  @impl GuildCache
+  def member_chunk(guild_id, member_chunk) do
+    # CHONK like that one cat of craig
+
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+
+    new_members =
+      Enum.reduce(member_chunk, guild.members, fn m, acc ->
+        Map.put(acc, m.user.id, Util.cast(m, {:struct, Member}))
+      end)
+
+    # XXX: do we not need to update member count here?
+    new = %{guild | members: new_members}
+    true = :ets.update_element(@table_name, guild_id, {2, new})
+  end
+
+  @doc "Create the given role in the given guild in the cache."
+  @impl GuildCache
+  @spec role_create(Guild.id(), map()) :: Role.t()
+  def role_create(guild_id, role) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    {_old, new, new_roles} = upsert(guild.roles, role.id, role, Role)
+    new_guild = %{guild | roles: new_roles}
+    true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+    new
+  end
+
+  @doc "Delete the given role from the given guild in the cache."
+  @impl GuildCache
+  @spec role_delete(Guild.id(), Role.id()) :: {Guild.id(), Role.t()} | :noop
+  def role_delete(guild_id, role_id) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    {popped, new_roles} = Map.pop(guild.roles, role_id)
+    new_guild = %{guild | roles: new_roles}
+    true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+    if popped, do: {guild_id, popped}, else: :noop
+  end
+
+  @doc "Update the given role in the given guild in the cache."
+  @impl GuildCache
+  @spec role_update(Guild.id(), map()) :: {Role.t(), Role.t()}
+  def role_update(guild_id, role) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    {old, new_role, new_roles} = upsert(guild.roles, role.id, role, Role)
+    new_guild = %{guild | roles: new_roles}
+    true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+    {old, new_role}
+  end
+
+  @doc "Update guild voice states with the given voice state in the cache."
+  @impl GuildCache
+  @spec voice_state_update(Guild.id(), map()) :: {Guild.id(), [map()]}
+  def voice_state_update(guild_id, payload) do
+    [{_id, guild}] = :ets.lookup(@table_name, guild_id)
+    # Trim the `member` from the update payload.
+    # Remove both `"member"` and `:member` in case of future key changes.
+    trimmed_update = Map.drop(payload, [:member, "member"])
+    state_without_user = Enum.reject(guild.voice_states, &(&1.user_id == trimmed_update.user_id))
+    # If the `channel_id` is nil, then the user is leaving.
+    # Otherwise, the voice state was updated.
+    new_state =
+      if(is_nil(trimmed_update.channel_id),
+        do: state_without_user,
+        else: [trimmed_update | state_without_user]
+      )
+
+    new_guild = %{guild | voice_states: new_state}
+    true = :ets.update_element(@table_name, guild_id, {2, new_guild})
+    {guild_id, new_state}
+  end
+
+  @spec upsert(%{required(Snowflake.t()) => struct}, Snowflake.t(), map, atom) ::
+          {struct | nil, struct, %{required(Snowflake.t()) => struct}}
+  defp upsert(map, key, new, struct) do
+    if Map.has_key?(map, key) do
+      old = Map.get(map, key)
+
+      new =
+        old
+        |> Map.from_struct()
+        |> Map.merge(new)
+        |> Util.cast({:struct, struct})
+
+      new_map = Map.put(map, key, new)
+
+      {old, new, new_map}
+    else
+      new = Util.cast(new, {:struct, struct})
+      {nil, new, Map.put(map, key, new)}
+    end
+  end
+end

--- a/lib/nostrum/cache/user_cache/ets.ex
+++ b/lib/nostrum/cache/user_cache/ets.ex
@@ -7,6 +7,7 @@ defmodule Nostrum.Cache.UserCache.ETS do
   In addition to the cache behaviour implementations provided by this module,
   you can also call regular ETS table methods on it, such as `:ets.info`.
   """
+  @moduledoc since: "0.5"
 
   @behaviour Nostrum.Cache.UserCache
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule Nostrum.Mixfile do
       main: "intro",
       extras: extras(),
       groups_for_modules: groups_for_modules(),
+      groups_for_functions: groups_for_functions(),
       assets: "docs/assets"
     ]
   end
@@ -69,6 +70,11 @@ defmodule Nostrum.Mixfile do
       ]
     ]
   end
+
+  defp groups_for_functions,
+    do: [
+      "Reading the cache": &(&1[:section] == :reading)
+    ]
 
   def aliases do
     [

--- a/test/nostrum/cache/guild_cache_test.exs
+++ b/test/nostrum/cache/guild_cache_test.exs
@@ -1,14 +1,197 @@
 defmodule Nostrum.Cache.GuildCacheTest do
+  alias Nostrum.Struct.Channel
+  alias Nostrum.Struct.Emoji
+  alias Nostrum.Struct.Guild
+  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Struct.Guild.Role
   use ExUnit.Case
 
-  alias Nostrum.Cache.GuildCache
-  alias Nostrum.Struct.Guild
+  @cache_modules [
+    # Implementations
+    Nostrum.Cache.GuildCache.ETS
+  ]
 
-  setup_all do
-    :ets.new(GuildCache.tabname(), [:set, :public, :named_table])
-    assert true = GuildCache.create(%Guild{id: 0})
-    :ok
+  for cache <- @cache_modules do
+    defmodule :"#{cache}Test" do
+      use ExUnit.Case
+      # this is needed because otherwise we cannot access
+      # the cache in the tests
+      @cache cache
+      @test_guild %{
+        id: 1234,
+        name: "joe's jobs",
+        channels: %{},
+        emojis: [],
+        roles: %{},
+        members: %{},
+        member_count: 0
+      }
+      @test_channel %{
+        id: 91231,
+        name: "Joe's Grumblings"
+      }
+      @test_role %{
+        id: 102_512,
+        name: "High Sharders"
+      }
+      @test_member %{
+        roles: [],
+        user: %{
+          id: 120_391,
+          name: "joe"
+        }
+      }
+
+      doctest @cache
+
+      describe "with an empty cache" do
+        setup do
+          [pid: start_supervised!(@cache)]
+        end
+
+        test "all/0 returns empty enum" do
+          assert Enum.to_list(@cache.all) == []
+        end
+
+        test "create/1 returns true" do
+          assert @cache.create(@test_guild) == true
+        end
+      end
+
+      describe "with cached guild" do
+        setup do
+          pid = start_supervised!(@cache)
+          guild = Guild.to_struct(@test_guild)
+          true = @cache.create(guild)
+          [pid: pid]
+        end
+
+        test "all/0 returns guild" do
+          all_list = Enum.to_list(@cache.all())
+          expected = Guild.to_struct(@test_guild)
+          assert [^expected] = all_list
+        end
+
+        test "channel management" do
+          # channel_create/1
+          created = @cache.channel_create(@test_guild.id, @test_channel)
+          expected = Channel.to_struct(@test_channel)
+          assert ^expected = created
+          cached = @cache.get!(@test_guild.id)
+          channels = %{expected.id => expected}
+          assert ^channels = cached.channels
+
+          # channel_update/1
+          updated_channel = Map.put(@test_channel, :name, "Craig's Grumbling")
+          expected = Channel.to_struct(updated_channel)
+          {old, new} = @cache.channel_update(@test_guild.id, updated_channel)
+          old_name = @test_channel.name
+          assert %Channel{name: ^old_name} = old
+          assert ^expected = new
+
+          # channel_delete/1
+          deleted = @cache.channel_delete(@test_guild.id, @test_channel.id)
+          assert ^expected = deleted
+
+          # Double delete!
+          assert :noop = @cache.channel_delete(@test_guild.id, @test_channel.id)
+        end
+
+        test "emoji_update/1" do
+          payload_emoji = %{id: 102_394, name: "joeface3"}
+          emojis = [payload_emoji]
+          expected = [Emoji.to_struct(payload_emoji)]
+          {old, new} = @cache.emoji_update(@test_guild.id, emojis)
+          assert [] = old
+          assert ^expected = new
+        end
+
+        test "member management" do
+          # member_add/2
+          member_id = @test_member.user.id
+          expected = Member.to_struct(@test_member)
+          member = @cache.member_add(@test_guild.id, @test_member)
+          assert ^expected = member
+
+          assert %{^member_id => ^expected} =
+                   @cache.select_by!([id: @test_guild.id], & &1.members)
+
+          # member_update/2
+          payload = put_in(@test_member, [:user, :name], "GrumblerBot3")
+          updated = Member.to_struct(payload)
+          {guild_id, ^expected, ^updated} = @cache.member_update(@test_guild.id, payload)
+          assert guild_id == @test_guild.id
+          assert %{^member_id => ^updated} = @cache.select_by!([id: @test_guild.id], & &1.members)
+
+          # member_remove/2
+          remove_payload = payload.user
+          {^guild_id, ^updated} = @cache.member_remove(@test_guild.id, remove_payload)
+          guild_members = @cache.select_by!([id: @test_guild.id], & &1.members)
+          assert Enum.empty?(guild_members)
+        end
+
+        # Copying the comment from the ETS cache implementation:
+        #   We may retrieve a GUILD_MEMBER_UPDATE event for our own user even if we
+        #   have the required intents to retrieve it for other members disabled, as
+        #   outlined in issue https://github.com/Kraigie/nostrum/issues/293. In
+        #   that case, we will not have the guild cached.
+        # This test verifies that the cache guards against that.
+        test "member_update/2 handles uncached guild" do
+          guild = Map.put(@test_guild, :id, @test_guild.id + 12839)
+          expected = Member.to_struct(@test_member)
+          {_guild_id, nil, ^expected} = @cache.member_update(guild, @test_member)
+        end
+
+        test "member_chunk/2" do
+          second_member = put_in(@test_member, [:user, :id], 19204)
+          chunk = [@test_member, second_member]
+          assert true = @cache.member_chunk(@test_guild.id, chunk)
+          first_id = @test_member.user.id
+          second_id = second_member.user.id
+
+          assert %Guild{members: %{^first_id => _a, ^second_id => _b}} =
+                   @cache.get!(@test_guild.id)
+        end
+
+        test "role management" do
+          # role_create/2
+          expected = Role.to_struct(@test_role)
+          role_id = expected.id
+          assert ^expected = @cache.role_create(@test_guild.id, @test_role)
+          assert %Guild{roles: %{^role_id => ^expected}} = @cache.get!(@test_guild.id)
+
+          # role_update/2
+          updated_payload = Map.put(@test_role, :name, "Higher Sharders")
+          new_role = Role.to_struct(updated_payload)
+          {^expected, ^new_role} = @cache.role_update(@test_guild.id, updated_payload)
+
+          # role_delete/2
+          {_guild_id, ^new_role} = @cache.role_delete(@test_guild.id, @test_role.id)
+          guild = @cache.get!(@test_guild.id)
+          assert guild.roles == %{}
+        end
+      end
+
+      describe "guild" do
+        setup do
+          pid = start_supervised!(@cache)
+          guild = Guild.to_struct(@test_guild)
+          true = @cache.create(guild)
+          [pid: pid]
+        end
+
+        test "update and delete" do
+          # update/1
+          new_guild = %{@test_guild | name: "Merkel's Merkle Trees"}
+          old = Guild.to_struct(@test_guild)
+          new = Guild.to_struct(new_guild)
+          assert {^old, ^new} = @cache.update(new_guild)
+
+          # delete/1
+          assert ^new = @cache.delete(@test_guild.id)
+          assert @cache.delete(@test_guild.id) == nil
+        end
+      end
+    end
   end
-
-  doctest GuildCache
 end


### PR DESCRIPTION
Similar to the pluggable user cache, this allows developers to choose
their own caching mechanism for structures received from Discord.
However, the approach taken here also differs slightly from the user
cache implementation to make improvements aimed at completely decoupling
the chosen cache implementation from nostrum itself. The following base
functionality is provided:

- Cache behaviour and dispatching module `Nostrum.Cache.GuildCache` with
  accompanying documentation.
- Default cache behaviour implementation `Nostrum.Cache.GuildCache.ETS`,
  which is the current ETS-based guild cache implementation.

Two architectural changes are made here in contrast to the user cache:

1. Guild cache implementations are supervisors. This allows any
implementations to completely manage what they do on their own, in a
manner that is managed and supported by OTP. Our ETS-based cache uses
this to set up ETS tables, an Mnesia-backed cache may perform and wait
for table creation, a Redis-backed cache may wait for the backing
connection to Redis to be ready, a "discard" cache may skip doing any
work, any child constellations fitting the OTP mechanisms are supported.

2. `defdelegate` is used instead of manually defining the functions to
dispatch to the backing cache. This reduces the code we need to write on
our end heavily, and prevents duplication of type specifications and
documentation. This applies to functions related to the cache itself and
functions for the `Supervisor`, allowing us to keep the
`CacheSupervisor` simple and not duplicate getting the configured cache.

Both of these changes will be integrated into the current user cache to
ensure that we have a uniform way of using pluggable caches that is
transparent to the user.

Just like with the user cache, a test module is introduced. As more
cache modules get introduced, this can be adapted to test new caching
modules by changing a single line.