### PR TITLE
     Implement pluggable presence caching.     

### DIFF
--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -30,7 +30,6 @@ defmodule Nostrum.Application do
     :ets.new(:unavailable_guilds, [:set, :public, :named_table])
     :ets.new(:users, [:set, :public, :named_table])
     :ets.new(:channels, [:set, :public, :named_table])
-    :ets.new(:presences, [:set, :public, :named_table])
     :ets.new(:guild_shard_map, [:set, :public, :named_table])
     :ets.new(:channel_guild_map, [:set, :public, :named_table])
   end

--- a/lib/nostrum/cache/cache_supervisor.ex
+++ b/lib/nostrum/cache/cache_supervisor.ex
@@ -20,8 +20,9 @@ defmodule Nostrum.Cache.CacheSupervisor do
   def init([]) do
     children = [
       Nostrum.Cache.Me,
-      # Uses the configured cache implementation.
-      Nostrum.Cache.GuildCache
+      # Uses the configured cache implementations.
+      Nostrum.Cache.GuildCache,
+      Nostrum.Cache.PresenceCache
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/nostrum/cache/presence_cache.ex
+++ b/lib/nostrum/cache/presence_cache.ex
@@ -1,24 +1,63 @@
 defmodule Nostrum.Cache.PresenceCache do
+  @default_cache_implementation Nostrum.Cache.PresenceCache.ETS
   @moduledoc """
-  Cache for presences.
+  Cache behaviour & dispatcher for Discord presences.
 
-  The ETS table name associated with the User Cache is `:presences`. Besides the
-  methods provided below you can call any other ETS methods on the table.
+  By default, `#{@default_cache_implementation}` will be use for caching
+  presences.  You can override this in the `:caches` option of the `nostrum`
+  application by setting the `:presences` fields to a different module
+  implementing the `Nostrum.Cache.PresenceCache` behaviour. Any module below
+  `Nostrum.Cache.PresenceCache` implements this behaviour and can be used as a
+  cache.
 
-  ## Example
-  ```elixir
-  info = :ets.info(:presences)
-  [..., heir: :none, name: :presences, size: 1, ...]
-  size = info[:size]
-  1
-  ```
+  ## Writing your own presence cache
+
+  As with the other caches, the presence cache API consists of two parts:
+
+  - The functions that the user calls, currently only `c:get/2`.
+
+  - The functions that nostrum calls, such as `c:create/1` or `c:update/1`.
+  These **do not create any objects in the Discord API**, they are purely
+  created to update the cached data from data that Discord sends us. If you
+  want to create objects on Discord, use the functions exposed by `Nostrum.Api`
+  instead.
+
+  You need to implement both of them for nostrum to work with your custom
+  cache. **You also need to implement `Supervisor` callbacks**, which will
+  start your cache as a child under `Nostrum.Cache.CacheSupervisor`: As an
+  example, the `Nostrum.Cache.PresenceCache.ETS` implementation uses this to to
+  set up its ETS table it uses for caching. See the callbacks section for every
+  nostrum-related callback you need to implement.
   """
+
+  @moduledoc since: "0.5"
+
+  @configured_cache :nostrum
+                    |> Application.compile_env(:caches, %{})
+                    |> Map.get(:presences, @default_cache_implementation)
 
   alias Nostrum.Struct.{Guild, User}
   alias Nostrum.Util
-
   import Nostrum.Snowflake, only: [is_snowflake: 1]
 
+  ## Supervisor callbacks
+  # These set up the backing cache.
+  @doc false
+  defdelegate init(init_arg), to: @configured_cache
+  @doc false
+  defdelegate start_link(init_arg), to: @configured_cache
+  @doc false
+  defdelegate child_spec(opts), to: @configured_cache
+
+  # Types
+  @typedoc """
+  Represents a presence as received from Discord.
+  See [Presence Update](https://discord.com/developers/docs/topics/gateway#presence-update).
+  """
+  @typedoc since: "0.5"
+  @opaque presence :: map()
+
+  # Callbacks
   @doc ~S"""
   Retreives a presence for a user from the cache by guild and id.
 
@@ -34,54 +73,44 @@ defmodule Nostrum.Cache.PresenceCache do
   end
   ```
   """
-  @spec get(User.id(), Guild.id()) :: {:error, :presence_not_found} | {:ok, map}
-  def get(user_id, guild_id) when is_snowflake(user_id) and is_snowflake(guild_id) do
-    case :ets.lookup(:presences, {user_id, guild_id}) do
-      [] -> {:error, :presence_not_found}
-      [{{^user_id, ^guild_id}, presence}] -> {:ok, presence}
-    end
-  end
+  @callback get(User.id(), Guild.id()) :: {:ok, presence()} | {:error, :presence_not_found}
 
   @doc """
-  Same as `get/1`, but raises `Nostrum.Error.CacheError` in case of a failure.
+  Create a presence in the cache.
   """
-  @spec get!(User.id(), Guild.id()) :: no_return | map
+  @callback create(presence) :: :ok
+
+  @doc """
+  Bulk create multiple presences for the given guild in the cache.
+  """
+  @callback bulk_create(Guild.id(), [presence()]) :: :ok
+
+  @doc """
+  Update the given presence in the cache from upstream data.
+
+  ## Return value
+
+  Return the guild ID along with the old presence (if it was cached, otherwise
+  `nil`) and the updated presence structure. If the `:activities` or `:status`
+  fields of the presence did not change, return `:noop`.
+  """
+  @callback update(map()) ::
+              {Guild.id(), old_presence :: presence() | nil, new_presence :: presence()} | :noop
+
+  # Dispatch
+  @doc section: :reading
+  defdelegate get(user_id, guild_id), to: @configured_cache
+  defdelegate create(presence), to: @configured_cache
+  defdelegate update(presence), to: @configured_cache
+  defdelegate bulk_create(guild_id, presences), to: @configured_cache
+
+  # Dispatch helpers
+  @doc "Same as `get/1`, but raise `Nostrum.Error.CacheError` in case of a failure."
+  @doc section: :reading
+  @spec get!(User.id(), Guild.id()) :: presence() | no_return()
   def get!(user_id, guild_id) when is_snowflake(user_id) and is_snowflake(guild_id) do
-    user_id |> get(guild_id) |> Util.bangify_find({user_id, guild_id}, __MODULE__)
-  end
-
-  @doc false
-  @spec create(map) :: :ok
-  def create(presence) do
-    :ets.insert(:presences, {{presence.user.id, presence.guild_id}, presence})
-    :ok
-  end
-
-  @doc false
-  @spec update(map) :: {Guild.id(), nil | map, map} | :noop
-  def update(presence) do
-    case get(presence.user.id, presence.guild_id) do
-      {:ok, p} ->
-        new_presence = Map.merge(p, presence)
-        create(new_presence)
-
-        if p.activities == new_presence.activities and p.status == new_presence.status,
-          do: :noop,
-          else: {presence.guild_id, p, new_presence}
-
-      {:error, _} ->
-        create(presence)
-        {presence.guild_id, nil, presence}
-    end
-  end
-
-  @doc false
-  @spec bulk_create(Guild.id(), [map]) :: :ok
-  def bulk_create(_, []), do: :ok
-
-  def bulk_create(guild_id, presences) when is_list(presences) do
-    Enum.each(presences, fn p ->
-      :ets.insert(:presences, {{p.user.id, guild_id}, p})
-    end)
+    user_id
+    |> @configured_cache.get(guild_id)
+    |> Util.bangify_find({user_id, guild_id}, @configured_cache)
   end
 end

--- a/lib/nostrum/cache/presence_cache/ets.ex
+++ b/lib/nostrum/cache/presence_cache/ets.ex
@@ -1,0 +1,93 @@
+defmodule Nostrum.Cache.PresenceCache.ETS do
+  @tablename :presences
+  @moduledoc """
+  ETS-based cache for user presences.
+
+  The ETS table name associated with the User Cache is `#{@tablename}`. Besides
+  the methods provided below you can call any other ETS methods on the table.
+  If you need to access the name of the presence cache's table
+  programmatically, use the `tabname/0` function instead of hardcoding it in
+  your application.
+
+  ## Example
+  ```elixir
+  info = :ets.info(#{@tablename})
+  [..., heir: :none, name: #{@tablename}, size: 1, ...]
+  size = info[:size]
+  1
+  ```
+  """
+  @moduledoc since: "0.5"
+
+  @behaviour Nostrum.Cache.PresenceCache
+
+  alias Nostrum.Struct.{Guild, User}
+  import Nostrum.Snowflake, only: [is_snowflake: 1]
+  use Supervisor
+
+  @doc "Start the supervisor."
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @doc "Set up the cache's ETS table."
+  @impl Supervisor
+  def init(_init_arg) do
+    :ets.new(@tablename, [:set, :public, :named_table])
+    Supervisor.init([], strategy: :one_for_one)
+  end
+
+  @doc "Return the ETS table name used for this cache."
+  @spec tabname :: atom()
+  def tabname do
+    @tablename
+  end
+
+  @impl Nostrum.Cache.PresenceCache
+  @doc "Retrieves a presence for a user from the cache by guild and id."
+  @spec get(User.id(), Guild.id()) :: {:error, :presence_not_found} | {:ok, map}
+  def get(user_id, guild_id) when is_snowflake(user_id) and is_snowflake(guild_id) do
+    case :ets.lookup(@tablename, {user_id, guild_id}) do
+      [] -> {:error, :presence_not_found}
+      [{{^user_id, ^guild_id}, presence}] -> {:ok, presence}
+    end
+  end
+
+  @impl Nostrum.Cache.PresenceCache
+  @doc "Add the given presence data to the cache."
+  @spec create(map) :: :ok
+  def create(presence) do
+    :ets.insert(@tablename, {{presence.user.id, presence.guild_id}, presence})
+    :ok
+  end
+
+  @impl Nostrum.Cache.PresenceCache
+  @doc "Update the given presence data in the cache."
+  @spec update(map) :: {Guild.id(), nil | map, map} | :noop
+  def update(presence) do
+    case get(presence.user.id, presence.guild_id) do
+      {:ok, p} ->
+        new_presence = Map.merge(p, presence)
+        create(new_presence)
+
+        if p.activities == new_presence.activities and p.status == new_presence.status,
+          do: :noop,
+          else: {presence.guild_id, p, new_presence}
+
+      {:error, _} ->
+        create(presence)
+        {presence.guild_id, nil, presence}
+    end
+  end
+
+  @impl Nostrum.Cache.PresenceCache
+  @doc "Bulk create multiple presences in the cache."
+  @spec bulk_create(Guild.id(), [map]) :: :ok
+  def bulk_create(_, []), do: :ok
+
+  def bulk_create(guild_id, presences) when is_list(presences) do
+    Enum.each(presences, fn p ->
+      :ets.insert(@tablename, {{p.user.id, guild_id}, p})
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,8 @@ defmodule Nostrum.Mixfile do
       extras: extras(),
       groups_for_modules: groups_for_modules(),
       groups_for_functions: groups_for_functions(),
-      assets: "docs/assets"
+      assets: "docs/assets",
+      nest_modules_by_prefix: [Nostrum.Cache]
     ]
   end
 

--- a/test/nostrum/cache/presence_cache_test.exs
+++ b/test/nostrum/cache/presence_cache_test.exs
@@ -1,0 +1,68 @@
+defmodule Nostrum.Cache.PresenceCacheTest do
+  use ExUnit.Case
+
+  @cache_modules [
+    # Implementations
+    Nostrum.Cache.PresenceCache.ETS
+  ]
+
+  for cache <- @cache_modules do
+    defmodule :"#{cache}Test" do
+      use ExUnit.Case
+      # this is needed because otherwise we cannot access
+      # the cache in the tests
+      @cache cache
+      @test_guild_id 12_039_152
+      @test_presence %{
+        activities: [
+          %{
+            created_at: 1_633_974_786_695,
+            id: "custom",
+            name: "Custom Status",
+            state: "#OpenErlang",
+            type: 4
+          }
+        ],
+        client_status: %{desktop: :online},
+        game: %{
+          created_at: 1_633_974_786_695,
+          id: "custom",
+          name: "Custom Status",
+          state: "#OpenErlang",
+          type: 4
+        },
+        guild_id: @test_guild_id,
+        status: :online,
+        user: %{id: 12_049_182_940}
+      }
+
+      doctest @cache
+
+      describe "empty cache" do
+        setup do
+          [pid: start_supervised!(@cache)]
+        end
+
+        test "lookup of nonexistent user" do
+          assert {:error, :presence_not_found} =
+                   @cache.get(@test_presence.user.id + 1, @test_guild_id)
+        end
+
+        test "create, update, delete" do
+          # Used for pinning.
+          test_presence = @test_presence
+          test_guild_id = @test_guild_id
+
+          assert :ok = @cache.create(@test_presence)
+          assert :noop = @cache.update(@test_presence)
+          assert {:ok, ^test_presence} = @cache.get(@test_presence.user.id, @test_guild_id)
+
+          updated_presence = Map.put(@test_presence, :status, :offline)
+
+          assert {^test_guild_id, ^test_presence, ^updated_presence} =
+                   @cache.update(updated_presence)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
    Based off `pluggable-guild-cache` to prevent merge conflicts.
    
    This uses the same approach as the pluggable guild cache, in that we
    have a base behaviour and dispatcher for the presence cache, and a
    ETS-based implementation chosen by default which uses the current
    implementation. A small test is added to ensure correct cache function.
