### PR TITLE
change gateway to v8

### DIFF
--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -9,7 +9,7 @@ defmodule Nostrum.Shard.Session do
 
   use GenServer
 
-  @gateway_qs "/?compress=zlib-stream&encoding=etf&v=6"
+  @gateway_qs "/?compress=zlib-stream&encoding=etf&v=8"
 
   # Maximum time the initial connection may take, in milliseconds.
   @timeout_connect 10_000


### PR DESCRIPTION
Like it says on the tin.

This was the only part still using v6, everything should already be v8 ready from when we updated the api version to v8.