### PR TITLE
Duplicate guild creates should be a cache replace

### DIFF
--- a/lib/nostrum/cache/guild_cache/ets.ex
+++ b/lib/nostrum/cache/guild_cache/ets.ex
@@ -147,7 +147,8 @@ defmodule Nostrum.Cache.GuildCache.ETS do
   @impl GuildCache
   @spec create(Guild.t()) :: true
   def create(guild) do
-    true = :ets.insert_new(@table_name, {guild.id, guild})
+    # A duplicate guild insert is treated as a replace.
+    true = :ets.insert(@table_name, {guild.id, guild})
   end
 
   @doc "Update the given guild in the cache."


### PR DESCRIPTION
This fixes an issue where if a ready event is re-emitted for any reason a fatal error in the cache would occur due to disallowing duplicate Guild inserts.

Instead they are now treated as replace operations.