### PR TITLE
fix: parse string permissions for overwrites

### DIFF
--- a/lib/nostrum/struct/overwrite.ex
+++ b/lib/nostrum/struct/overwrite.ex
@@ -42,6 +42,14 @@ defmodule Nostrum.Struct.Overwrite do
       map
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
       |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:allow, nil, fn
+        perm when is_binary(perm) -> String.to_integer(perm)
+        x -> x
+      end)
+      |> Map.update(:deny, nil, fn
+        perm when is_binary(perm) -> String.to_integer(perm)
+        x -> x
+      end)
 
     struct(__MODULE__, new)
   end


### PR DESCRIPTION
Related to #362, should've checked if this was occurring elsewhere in that PR, but alas here I am. Looks like the same issue as in that PR occurs with permission overwrites for channels, noticed this when trying to use `Struct.Guild.Member.guild_channel_permissions` and got the same `:erlang.bor` error.

Thanks Discord!