### PR TITLE
Fix bug with rogue watchdog timer.

### DIFF
--- a/lib/nostrum/voice/audio.ex
+++ b/lib/nostrum/voice/audio.ex
@@ -308,7 +308,7 @@ defmodule Nostrum.Voice.Audio do
   end
 
   def on_stall(%VoiceState{} = voice) do
-    unless is_nil(voice.ffmpeg_proc) do
+    if VoiceState.playing?(voice) and not is_nil(voice.ffmpeg_proc) do
       Proc.stop(voice.ffmpeg_proc)
     end
   end


### PR DESCRIPTION
Occasionally the watchdog timer responsible for detecting end of input is fired after `pause/1` is called, which causes the sound to abruptly end after `resume/1`. 

Fixes #368 