### PR TITLE
Improve consistency of `to_struct` fns and remove `?` from field names

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -15,7 +15,7 @@
         {Credo.Check.Consistency.SpaceInParentheses},
         {Credo.Check.Consistency.TabsOrSpaces},
         {Credo.Check.Design.AliasUsage, priority: :low},
-        {Credo.Check.Design.DuplicatedCode, excluded_macros: [], mass_threshold: 50},
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: [], mass_threshold: 65},
         {Credo.Check.Design.TagTODO, exit_status: 0},
         {Credo.Check.Design.TagFIXME},
         {Credo.Check.Readability.FunctionNames},

--- a/lib/nostrum/struct/application_command_interaction_data.ex
+++ b/lib/nostrum/struct/application_command_interaction_data.ex
@@ -83,17 +83,22 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @doc false
   @spec to_struct(map()) :: __MODULE__.t()
   def to_struct(map) do
-    %__MODULE__{
-      id: map[:id],
-      name: map[:name],
-      type: map[:type],
-      resolved: Util.cast(map[:resolved], {:struct, ApplicationCommandInteractionDataResolved}),
-      options:
-        Util.cast(map[:options], {:list, {:struct, ApplicationCommandInteractionDataOption}}),
-      custom_id: map[:custom_id],
-      component_type: map[:component_type],
-      values: map[:values],
-      target_id: map[:target_id]
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:target_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(
+        :resolved,
+        nil,
+        &Util.cast(&1, {:struct, ApplicationCommandInteractionDataResolved})
+      )
+      |> Map.update(
+        :options,
+        nil,
+        &Util.cast(&1, {:list, {:struct, ApplicationCommandInteractionDataOption}})
+      )
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/application_command_interaction_data_option.ex
+++ b/lib/nostrum/struct/application_command_interaction_data_option.ex
@@ -85,12 +85,12 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionDataOption do
   @doc false
   @spec to_struct(map()) :: __MODULE__.t()
   def to_struct(map) do
-    %__MODULE__{
-      name: map.name,
-      type: map.type,
-      value: parse_value(map.type, map[:value]),
-      options: Util.cast(map[:options], {:list, {:struct, __MODULE__}}),
-      focused: map[:focused]
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:options, nil, &Util.cast(&1, {:list, {:struct, __MODULE__}}))
+      |> Map.update(:value, nil, &parse_value(map.type, &1))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/component/option.ex
+++ b/lib/nostrum/struct/component/option.ex
@@ -28,14 +28,18 @@ defmodule Nostrum.Struct.Component.Option do
           value: value
         }
 
+  @doc false
   @spec to_struct(nil | maybe_improper_list | map) :: Nostrum.Struct.Component.Option.t()
+  def to_struct(nil) do
+    nil
+  end
+
   def to_struct(map) do
-    %__MODULE__{
-      label: map[:label],
-      value: map[:value],
-      description: map[:description],
-      emoji: Util.cast(map[:emoji], {:struct, Emoji}),
-      default: map[:default]
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:emoji, nil, &Util.cast(&1, {:struct, Emoji}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/guild_ban_add.ex
+++ b/lib/nostrum/struct/event/guild_ban_add.ex
@@ -22,9 +22,12 @@ defmodule Nostrum.Struct.Event.GuildBanAdd do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      guild_id: map.guild_id,
-      user: Util.cast(map.user, {:struct, User})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/guild_ban_remove.ex
+++ b/lib/nostrum/struct/event/guild_ban_remove.ex
@@ -22,9 +22,12 @@ defmodule Nostrum.Struct.Event.GuildBanRemove do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      guild_id: map.guild_id,
-      user: Util.cast(map.user, {:struct, User})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/guild_integrations_update.ex
+++ b/lib/nostrum/struct/event/guild_integrations_update.ex
@@ -3,6 +3,7 @@ defmodule Nostrum.Struct.Event.GuildIntegrationsUpdate do
   @moduledoc since: "0.5.0"
 
   alias Nostrum.Struct.Guild
+  alias Nostrum.Util
 
   defstruct [:guild_id]
 
@@ -16,6 +17,11 @@ defmodule Nostrum.Struct.Event.GuildIntegrationsUpdate do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{guild_id: map.guild_id}
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/message_delete.ex
+++ b/lib/nostrum/struct/event/message_delete.ex
@@ -4,6 +4,7 @@ defmodule Nostrum.Struct.Event.MessageDelete do
   """
 
   alias Nostrum.Struct.{Channel, Guild, Message}
+  alias Nostrum.{Snowflake, Util}
 
   defstruct [
     :id,
@@ -32,11 +33,13 @@ defmodule Nostrum.Struct.Event.MessageDelete do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      id: map.id,
-      channel_id: map.channel_id,
-      # https://github.com/discord/discord-api-docs/issues/296
-      guild_id: map[:guild_id]
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/message_reaction_add.ex
+++ b/lib/nostrum/struct/event/message_reaction_add.ex
@@ -38,13 +38,16 @@ defmodule Nostrum.Struct.Event.MessageReactionAdd do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      user_id: map.user_id,
-      channel_id: map.channel_id,
-      message_id: map.message_id,
-      guild_id: map[:guild_id],
-      member: Util.cast(map[:member], {:struct, Member}),
-      emoji: Util.cast(map.emoji, {:struct, Emoji})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:user_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:message_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:member, nil, &Util.cast(&1, {:struct, Member}))
+      |> Map.update(:emoji, nil, &Util.cast(&1, {:struct, Emoji}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/message_reaction_remove.ex
+++ b/lib/nostrum/struct/event/message_reaction_remove.ex
@@ -34,12 +34,15 @@ defmodule Nostrum.Struct.Event.MessageReactionRemove do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      user_id: map.user_id,
-      channel_id: map.channel_id,
-      message_id: map.message_id,
-      guild_id: map[:guild_id],
-      emoji: Util.cast(map.emoji, {:struct, Emoji})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:user_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:message_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:emoji, nil, &Util.cast(&1, {:struct, Emoji}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/message_reaction_remove_all.ex
+++ b/lib/nostrum/struct/event/message_reaction_remove_all.ex
@@ -3,6 +3,7 @@ defmodule Nostrum.Struct.Event.MessageReactionRemoveAll do
   @moduledoc since: "0.5.0"
 
   alias Nostrum.Struct.{Channel, Guild, Message}
+  alias Nostrum.Util
 
   defstruct [:channel_id, :message_id, :guild_id]
 
@@ -24,10 +25,13 @@ defmodule Nostrum.Struct.Event.MessageReactionRemoveAll do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      channel_id: map.channel_id,
-      message_id: map.message_id,
-      guild_id: map[:guild_id]
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:message_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/message_reaction_remove_emoji.ex
+++ b/lib/nostrum/struct/event/message_reaction_remove_emoji.ex
@@ -29,11 +29,14 @@ defmodule Nostrum.Struct.Event.MessageReactionRemoveEmoji do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      channel_id: map.channel_id,
-      guild_id: map[:guild_id],
-      message_id: map.message_id,
-      emoji: Util.cast(map.emoji, {:struct, Emoji})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:message_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:emoji, nil, &Util.cast(&1, {:struct, Emoji}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/partial_application.ex
+++ b/lib/nostrum/struct/event/partial_application.ex
@@ -2,7 +2,7 @@ defmodule Nostrum.Struct.Event.PartialApplication do
   @moduledoc "Sent on `READY`"
   @moduledoc since: "0.5.0"
 
-  alias Nostrum.Snowflake
+  alias Nostrum.{Snowflake, Util}
 
   defstruct [:id, :flags]
 
@@ -24,12 +24,11 @@ defmodule Nostrum.Struct.Event.PartialApplication do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      id: map.id,
-      # This is documented as optional in Discord's Gateway documentation,
-      # but unlike our other struct fields, we assume it to be present in
-      # ready.
-      flags: map.flags
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/ready.ex
+++ b/lib/nostrum/struct/event/ready.ex
@@ -52,12 +52,14 @@ defmodule Nostrum.Struct.Event.Ready do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      v: map.v,
-      user: Util.cast(map.user, {:struct, User}),
-      guilds: Util.cast(map.guilds, {:list, {:struct, UnavailableGuild}}),
-      shard: :erlang.list_to_tuple(map.shard),
-      application: Util.cast(map.application, {:struct, PartialApplication})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
+      |> Map.update(:guilds, nil, &Util.cast(&1, {:list, {:struct, UnavailableGuild}}))
+      |> Map.update(:application, nil, &Util.cast(&1, {:struct, PartialApplication}))
+      |> Map.update(:shard, nil, &:erlang.list_to_tuple/1)
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/typing_start.ex
+++ b/lib/nostrum/struct/event/typing_start.ex
@@ -6,7 +6,7 @@ defmodule Nostrum.Struct.Event.TypingStart do
   alias Nostrum.Struct.Guild
   alias Nostrum.Struct.Guild.Member
   alias Nostrum.Struct.User
-  alias Nostrum.Util
+  alias Nostrum.{Snowflake, Util}
 
   defstruct [:channel_id, :guild_id, :user_id, :timestamp, :member]
 
@@ -36,12 +36,14 @@ defmodule Nostrum.Struct.Event.TypingStart do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      channel_id: map.channel_id,
-      guild_id: map[:guild_id],
-      user_id: map.user_id,
-      timestamp: map.timestamp,
-      member: Util.cast(map[:member], {:struct, Member})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:user_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:member, nil, &Util.cast(&1, {:struct, Member}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/voice_state.ex
+++ b/lib/nostrum/struct/event/voice_state.ex
@@ -6,7 +6,7 @@ defmodule Nostrum.Struct.Event.VoiceState do
   alias Nostrum.Struct.Guild
   alias Nostrum.Struct.Guild.Member
   alias Nostrum.Struct.User
-  alias Nostrum.Util
+  alias Nostrum.{Snowflake, Util}
 
   defstruct [
     :guild_id,
@@ -82,20 +82,16 @@ defmodule Nostrum.Struct.Event.VoiceState do
 
   @doc false
   def to_struct(map) do
-    %__MODULE__{
-      guild_id: map.guild_id,
-      channel_id: map.channel_id,
-      user_id: map.user_id,
-      member: Util.cast(map[:member], {:struct, Member}),
-      session_id: map.session_id,
-      deaf: map.deaf,
-      mute: map.mute,
-      self_deaf: map.self_deaf,
-      self_mute: map.self_mute,
-      self_stream: map[:self_stream] || false,
-      self_video: map.self_video,
-      suppress: map.suppress,
-      request_to_speak_timestamp: Util.maybe_to_datetime(map.request_to_speak_timestamp)
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.put_new(:self_stream, false)
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:user_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:member, nil, &Util.cast(&1, {:struct, Member}))
+      |> Map.update(:request_to_speak_timestamp, nil, &Util.maybe_to_datetime/1)
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/event/voice_state.ex
+++ b/lib/nostrum/struct/event/voice_state.ex
@@ -14,13 +14,13 @@ defmodule Nostrum.Struct.Event.VoiceState do
     :user_id,
     :member,
     :session_id,
-    :deaf?,
-    :mute?,
-    :self_deaf?,
-    :self_mute?,
-    :self_stream?,
-    :self_video?,
-    :suppress?,
+    :deaf,
+    :mute,
+    :self_deaf,
+    :self_mute,
+    :self_stream,
+    :self_video,
+    :suppress,
     :request_to_speak_timestamp
   ]
 
@@ -40,25 +40,25 @@ defmodule Nostrum.Struct.Event.VoiceState do
   @type session_id :: String.t()
 
   @typedoc "Whether this user is deafened by the server"
-  @type deaf? :: boolean
+  @type deaf :: boolean
 
   @typedoc "Whether this user is muteened by the server"
-  @type mute? :: boolean
+  @type mute :: boolean
 
   @typedoc "Whether this user is locally deafened"
-  @type self_deaf? :: boolean
+  @type self_deaf :: boolean
 
   @typedoc "Whether this user is locally muted"
-  @type self_mute? :: boolean
+  @type self_mute :: boolean
 
   @typedoc "Whether the user is streaming using \"Go Live\""
-  @type self_stream? :: boolean
+  @type self_stream :: boolean
 
   @typedoc "Whether this user's camera is enabled"
-  @type self_video? :: boolean
+  @type self_video :: boolean
 
   @typedoc "Whether this user is muted by the current user"
-  @type suppress? :: boolean
+  @type suppress :: boolean
 
   @typedoc "Time at which the user requested to speak, if applicable"
   @type request_to_speak_timestamp :: DateTime.t() | nil
@@ -70,13 +70,13 @@ defmodule Nostrum.Struct.Event.VoiceState do
           user_id: user_id,
           member: member,
           session_id: session_id,
-          deaf?: deaf?,
-          mute?: mute?,
-          self_deaf?: self_deaf?,
-          self_mute?: self_mute?,
-          self_stream?: self_stream?,
-          self_video?: self_video?,
-          suppress?: suppress?,
+          deaf: deaf,
+          mute: mute,
+          self_deaf: self_deaf,
+          self_mute: self_mute,
+          self_stream: self_stream,
+          self_video: self_video,
+          suppress: suppress,
           request_to_speak_timestamp: request_to_speak_timestamp
         }
 
@@ -88,13 +88,13 @@ defmodule Nostrum.Struct.Event.VoiceState do
       user_id: map.user_id,
       member: Util.cast(map[:member], {:struct, Member}),
       session_id: map.session_id,
-      deaf?: map.deaf,
-      mute?: map.mute,
-      self_deaf?: map.self_deaf,
-      self_mute?: map.self_mute,
-      self_stream?: map[:self_stream] || false,
-      self_video?: map.self_video,
-      suppress?: map.suppress,
+      deaf: map.deaf,
+      mute: map.mute,
+      self_deaf: map.self_deaf,
+      self_mute: map.self_mute,
+      self_stream: map[:self_stream] || false,
+      self_video: map.self_video,
+      suppress: map.suppress,
       request_to_speak_timestamp: Util.maybe_to_datetime(map.request_to_speak_timestamp)
     }
   end

--- a/lib/nostrum/struct/guild/integration.ex
+++ b/lib/nostrum/struct/guild/integration.ex
@@ -12,7 +12,7 @@ defmodule Nostrum.Struct.Guild.Integration do
   """
   @moduledoc since: "0.5.0"
 
-  alias Nostrum.Snowflake
+  alias Nostrum.{Snowflake, Util}
 
   defstruct [:id, :name, :type, :enabled]
 
@@ -39,11 +39,11 @@ defmodule Nostrum.Struct.Guild.Integration do
   @doc false
   @spec to_struct(map()) :: __MODULE__.t()
   def to_struct(map) do
-    %__MODULE__{
-      id: map.id,
-      name: map.name,
-      type: map.type,
-      enabled: map.enabled
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/interaction.ex
+++ b/lib/nostrum/struct/interaction.ex
@@ -105,18 +105,19 @@ defmodule Nostrum.Struct.Interaction do
   @doc false
   @spec to_struct(map()) :: __MODULE__.t()
   def to_struct(map) do
-    %__MODULE__{
-      id: map.id,
-      application_id: map[:application_id],
-      type: map.type,
-      data: Util.cast(map[:data], {:struct, ApplicationCommandInteractionData}),
-      guild_id: map[:guild_id],
-      channel_id: map[:channel_id],
-      member: Util.cast(map[:member], {:struct, Member}),
-      user: Util.cast(map[:user] || map[:member][:user], {:struct, User}),
-      token: map[:token],
-      version: map[:version],
-      message: Util.cast(map[:message], {:struct, Message})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:application_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:channel_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:data, nil, &Util.cast(&1, {:struct, ApplicationCommandInteractionData}))
+      |> Map.update(:member, nil, &Util.cast(&1, {:struct, Guild.Member}))
+      |> Map.put_new(:user, map[:member][:user])
+      |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
+      |> Map.update(:message, nil, &Util.cast(&1, {:struct, Message}))
+
+    struct(__MODULE__, new)
   end
 end

--- a/lib/nostrum/struct/message/component.ex
+++ b/lib/nostrum/struct/message/component.ex
@@ -161,36 +161,29 @@ defmodule Nostrum.Struct.Message.Component do
 
   @typedoc "Represents a message component."
   @type t :: %__MODULE__{
-          type: type(),
-          custom_id: custom_id(),
-          disabled: disabled(),
-          style: style(),
-          label: label(),
-          emoji: emoji(),
-          url: url(),
-          options: options(),
-          placeholder: placeholder(),
-          min_values: min_values(),
-          max_values: max_values(),
-          components: components()
+          type: type,
+          custom_id: custom_id,
+          disabled: disabled,
+          style: style,
+          label: label,
+          emoji: emoji,
+          url: url,
+          options: options,
+          placeholder: placeholder,
+          min_values: min_values,
+          max_values: max_values,
+          components: components
         }
 
   @doc false
   @spec to_struct(map()) :: t()
   def to_struct(map) do
-    %__MODULE__{
-      type: map.type,
-      custom_id: map[:custom_id],
-      disabled: map[:disabled],
-      style: map[:style],
-      label: map[:label],
-      emoji: Util.cast(map[:emoji], {:struct, Emoji}),
-      url: map[:url],
-      options: map[:options],
-      placeholder: map[:placeholder],
-      min_values: map[:min_values],
-      max_values: map[:max_values],
-      components: Util.cast(map[:components], {:list, {:struct, __MODULE__}})
-    }
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:emoji, nil, &Util.cast(&1, {:struct, Emoji}))
+      |> Map.update(:components, nil, &Util.cast(&1, {:list, {:struct, __MODULE__}}))
+
+    struct(__MODULE__, new)
   end
 end


### PR DESCRIPTION
Now all the `to_struct/1` functions should follow the same pattern.

And from `VoiceState` I removed the `?` from field names to maintain consistency across the rest of the library and the 1:1 field mapping with the API.

While writing this PR, I noticed that I missed a couple places when replacing ISO8601 strings with the `DateTime` struct as well as a couple Unix Timestamp fields. I'll open a PR for those after this gets merged.