### PR TITLE
Added `premium_since` field to Guild Member

### DIFF
--- a/lib/nostrum/struct/guild/member.ex
+++ b/lib/nostrum/struct/guild/member.ex
@@ -33,7 +33,8 @@ defmodule Nostrum.Struct.Guild.Member do
     :joined_at,
     :deaf,
     :mute,
-    :communication_disabled_until
+    :communication_disabled_until,
+    :premium_since
   ]
 
   defimpl String.Chars do
@@ -75,6 +76,11 @@ defmodule Nostrum.Struct.Guild.Member do
   """
   @type communication_disabled_until :: DateTime.t() | nil
 
+  @typedoc """
+  Current guild booster status of the user. If user is currently boosting a guild this will be a `t:DateTime.t/0` since the start of the boosting, it will be `nil` if the user is not currently boosting the guild.
+  """
+  @type premium_since :: DateTime.t() | nil
+
   @type t :: %__MODULE__{
           user: user,
           nick: nick,
@@ -82,7 +88,8 @@ defmodule Nostrum.Struct.Guild.Member do
           joined_at: joined_at,
           deaf: deaf,
           mute: mute,
-          communication_disabled_until: communication_disabled_until
+          communication_disabled_until: communication_disabled_until,
+          premium_since: premium_since
         }
 
   @doc ~S"""
@@ -225,6 +232,7 @@ defmodule Nostrum.Struct.Guild.Member do
       |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
       |> Map.update(:roles, nil, &Util.cast(&1, {:list, Snowflake}))
       |> Map.update(:communication_disabled_until, nil, &Util.maybe_to_datetime/1)
+      |> Map.update(:premium_since, nil, &Util.maybe_to_datetime/1)
 
     struct(__MODULE__, new)
   end


### PR DESCRIPTION
Added the `premium_since` field to the Guild Member struct for use in determining if a user is actively boosting a guild.

Reference Documentation:
[Guild Member Object (Discord API)](https://discord.com/developers/docs/resources/guild#guild-member-object)


Sample Guild Member:
```
  %Nostrum.Struct.Guild.Member{
    communication_disabled_until: nil,
    deaf: false,
    joined_at: "2020-12-29T17:18:07.964000+00:00",
    mute: false,
    nick: nil,
    premium_since: ~U[2022-02-08 23:57:37.225000Z],
    roles: [111111111111111111],
    user: %Nostrum.Struct.User{
      avatar: "f2464bd69e949680135b0eeb99c7a2fa",
      bot: nil,
      discriminator: "0001",
      email: nil,
      id: 222222222222222222,
      mfa_enabled: nil,
      public_flags: %Nostrum.Struct.User.Flags{
        bug_hunter_level_1: false,
        bug_hunter_level_2: false,
        early_supporter: false,
        hypesquad_balance: true,
        hypesquad_bravery: false,
        hypesquad_brilliance: false,
        hypesquad_events: false,
        partner: false,
        staff: false,
        system: false,
        team_user: false,
        verified_bot: false,
        verified_developer: false
      },
      username: "directionalpad",
      verified: nil
    }
```
