### PR TITLE
Use native ports instead of porcelain

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,4 @@ config :nostrum,
 
 config :logger, :console, metadata: [:shard, :guild, :channel]
 
-config :porcelain, :driver, Porcelain.Driver.Basic
-
 if File.exists?("config/secret.exs"), do: import_config("secret.exs")

--- a/lib/nostrum/error/voice_error.ex
+++ b/lib/nostrum/error/voice_error.ex
@@ -2,8 +2,8 @@ defmodule Nostrum.Error.VoiceError do
   @moduledoc """
   Represents an error when playing sound through voice channels.
 
-  This occurs when attempting to play audio and Porcelain can't find either
-  the ffmpeg executable or the youtube-dl executable.
+  This occurs when attempting to play audio and the file can't be found
+  for the ffmpeg, youtube-dl, or streamlink executables.
   """
 
   defexception [:message]

--- a/lib/nostrum/struct/voice_state.ex
+++ b/lib/nostrum/struct/voice_state.ex
@@ -1,8 +1,8 @@
 defmodule Nostrum.Struct.VoiceState do
   @moduledoc false
 
+  alias Nostrum.Voice.Ports
   alias Nostrum.Voice.Session
-  alias Porcelain.Process, as: Proc
 
   defstruct [
     :guild_id,
@@ -63,8 +63,8 @@ defmodule Nostrum.Struct.VoiceState do
     end
 
     unless is_nil(v.ffmpeg_proc) do
-      if Proc.alive?(v.ffmpeg_proc) do
-        Proc.stop(v.ffmpeg_proc)
+      if Process.alive?(v.ffmpeg_proc) do
+        Ports.close(v.ffmpeg_proc)
       end
     end
 

--- a/lib/nostrum/struct/voice_state.ex
+++ b/lib/nostrum/struct/voice_state.ex
@@ -56,27 +56,17 @@ defmodule Nostrum.Struct.VoiceState do
   def playing?(_), do: false
 
   def cleanup(%__MODULE__{} = v) do
-    unless is_nil(v.player_pid) do
-      if Process.alive?(v.player_pid) do
-        Process.exit(v.player_pid, :cleanup)
-      end
-    end
+    if is_pid(v.player_pid),
+      do: Process.exit(v.player_pid, :cleanup)
 
-    unless is_nil(v.ffmpeg_proc) do
-      if Process.alive?(v.ffmpeg_proc) do
-        Ports.close(v.ffmpeg_proc)
-      end
-    end
+    if is_pid(v.ffmpeg_proc),
+      do: Ports.close(v.ffmpeg_proc)
 
-    unless is_nil(v.udp_socket) do
-      :gen_udp.close(v.udp_socket)
-    end
+    if is_port(v.udp_socket),
+      do: :gen_udp.close(v.udp_socket)
 
-    unless is_nil(v.session_pid) do
-      if Process.alive?(v.session_pid) do
-        Session.close_connection(v.session_pid)
-      end
-    end
+    if is_pid(v.session_pid),
+      do: Session.close_connection(v.session_pid)
 
     :ok
   end

--- a/lib/nostrum/voice/ports.ex
+++ b/lib/nostrum/voice/ports.ex
@@ -38,7 +38,7 @@ defmodule Nostrum.Voice.Ports do
         :stream
       ])
 
-    # Spawn process to asyncronously send input to port
+    # Spawn process to asynchronously send input to port
     unless is_nil(input) do
       Task.start(fn -> send_input(port, input) end)
     end
@@ -119,7 +119,7 @@ defmodule Nostrum.Voice.Ports do
   end
 
   def handle_call(:close, _from, %{awaiter: awaiter, port: port, input_pid: input_pid}) do
-    if is_pid(awaiter), do: GenServer.reply(awaiter, nil)
+    unless is_nil(awaiter), do: GenServer.reply(awaiter, nil)
     if is_pid(input_pid), do: close(input_pid)
     Logger.debug("Closing port #{inspect(port)}")
     Port.close(port)

--- a/lib/nostrum/voice/ports.ex
+++ b/lib/nostrum/voice/ports.ex
@@ -1,0 +1,155 @@
+defmodule Nostrum.Voice.Ports do
+  @moduledoc false
+
+  defmodule State do
+    @moduledoc false
+
+    defstruct [
+      :q,
+      :port,
+      :port_done,
+      :awaiter,
+      :input_pid
+    ]
+
+    def new(port, input_pid) do
+      %__MODULE__{
+        q: :queue.new(),
+        port_done: false,
+        port: port,
+        input_pid: input_pid
+      }
+    end
+  end
+
+  alias Nostrum.Voice.Ports.State
+
+  require Logger
+
+  use GenServer
+
+  def init({executable, args, input}) do
+    port =
+      Port.open({:spawn_executable, executable}, [
+        {:args, args},
+        :binary,
+        :exit_status,
+        :use_stdio,
+        :stream
+      ])
+
+    # Spawn process to asyncronously send input to port
+    unless is_nil(input) do
+      Task.start(fn -> send_input(port, input) end)
+    end
+
+    # Store reference if input is another process
+    input_pid = if is_pid(input), do: input, else: nil
+
+    {:ok, State.new(port, input_pid)}
+  end
+
+  @spec execute(String.t(), [String.t()], iodata() | list() | pid() | nil) ::
+          {:ok, pid()} | {:error, String.t()}
+  def execute(executable, args \\ [], input \\ nil) do
+    case System.find_executable(executable) do
+      nil ->
+        {:error, "#{executable} not found"}
+
+      path ->
+        {:ok, _pid} = GenServer.start(__MODULE__, {path, args, input})
+    end
+  end
+
+  def send_input(port, input) do
+    case input do
+      integer when is_integer(integer) ->
+        Port.command(port, [integer])
+
+      binary when is_binary(binary) ->
+        Port.command(port, binary)
+
+      list when is_list(list) ->
+        Enum.each(list, &Port.command(port, &1))
+
+      # Input is another port process
+      source when is_pid(source) ->
+        Enum.each(get_stream(source), &Port.command(port, &1))
+    end
+  catch
+    :error, :badarg -> nil
+  end
+
+  @spec get_stream(pid()) :: Enum.t()
+  def get_stream(pid) do
+    Stream.unfold(pid, fn pid ->
+      case get(pid) do
+        nil -> nil
+        data -> {data, pid}
+      end
+    end)
+  end
+
+  def get(pid) do
+    if Process.alive?(pid),
+      do: GenServer.call(pid, :get, :infinity),
+      else: nil
+  end
+
+  @spec close(pid()) :: no_return()
+  def close(pid) do
+    if Process.alive?(pid),
+      do: GenServer.call(pid, :close)
+  end
+
+  def handle_call(:get, _from, %{q: q, port_done: true} = state) do
+    if :queue.is_empty(q) do
+      {:stop, :shutdown, nil, nil}
+    else
+      {:reply, :queue.head(q), %{state | q: :queue.tail(q)}}
+    end
+  end
+
+  def handle_call(:get, from, %{q: q} = state) do
+    if :queue.is_empty(q) do
+      {:noreply, %{state | awaiter: from}}
+    else
+      {:reply, :queue.head(q), %{state | q: :queue.tail(q)}}
+    end
+  end
+
+  def handle_call(:close, _from, %{awaiter: awaiter, port: port, input_pid: input_pid}) do
+    if is_pid(awaiter), do: GenServer.reply(awaiter, nil)
+    if is_pid(input_pid), do: close(input_pid)
+    Logger.debug("Closing port #{inspect(port)}")
+    Port.close(port)
+    {:stop, :shutdown, nil, nil}
+  end
+
+  def handle_info({_port, {:data, data}}, %{q: q, awaiter: nil} = state) do
+    {:noreply, %{state | q: :queue.in(data, q)}}
+  end
+
+  def handle_info({_port, {:data, data}}, %{awaiter: awaiter} = state) do
+    GenServer.reply(awaiter, data)
+    {:noreply, %{state | awaiter: nil}}
+  end
+
+  def handle_info({_port, {:exit_status, _status}}, %{awaiter: nil} = state) do
+    {:noreply, %{state | port_done: true}}
+  end
+
+  def handle_info({_port, {:exit_status, _status}}, %{q: q, awaiter: awaiter} = state) do
+    if :queue.is_empty(q) do
+      GenServer.reply(awaiter, nil)
+      {:stop, :shutdown, nil}
+    else
+      GenServer.reply(awaiter, :queue.head(q))
+      {:noreply, %{state | port_done: true, awaiter: nil}}
+    end
+  end
+
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -99,7 +99,6 @@ defmodule Nostrum.Mixfile do
       {:gun, "== 2.0.1", hex: :remedy_gun},
       {:certifi, "~> 2.8"},
       {:kcl, "~> 1.4"},
-      {:porcelain, "~> 2.0"},
       {:mime, "~> 1.6"},
       {:ex_doc, "~> 0.15", only: :dev},
       {:credo, "~> 1.4", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -22,7 +22,6 @@
   "mime": {:hex, :mime, "1.6.0", "dabde576a497cef4bbdd60aceee8160e02a6c89250d6c0b29e56c0dfb00db3d2", [:mix], [], "hexpm", "31a1a8613f8321143dde1dafc36006a17d28d02bdfecb9e95a880fa7aabd19a7"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "poly1305": {:hex, :poly1305, "1.0.3", "9ec6b5b3b96d96b15d4f2b8a3629aad2a2f5fe82f4ea0f13e5a3512737af4ee7", [:mix], [{:chacha20, "~> 1.0", [hex: :chacha20, repo: "hexpm", optional: false]}, {:equivalex, "~> 1.0", [hex: :equivalex, repo: "hexpm", optional: false]}], "hexpm", "fbe549d59e74e7cde680e7ae6baf7fe2b5f9053a84c1b5c866f703d0651d6b22"},
-  "porcelain": {:hex, :porcelain, "2.0.3", "2d77b17d1f21fed875b8c5ecba72a01533db2013bd2e5e62c6d286c029150fdc", [:mix], [], "hexpm", "dc996ab8fadbc09912c787c7ab8673065e50ea1a6245177b0c24569013d23620"},
   "recon": {:hex, :recon, "2.5.2", "cba53fa8db83ad968c9a652e09c3ed7ddcc4da434f27c3eaa9ca47ffb2b1ff03", [:mix, :rebar3], [], "hexpm", "2c7523c8dee91dff41f6b3d63cba2bd49eb6d2fe5bf1eec0df7f87eb5e230e1c"},
   "salsa20": {:hex, :salsa20, "1.0.3", "fb900fc9b26b713a98618f3c6d6b6c35a5514477c6047caca8d03f3a70175ab0", [:mix], [], "hexpm", "91cbfa537f369d074a79f926f36a6c2ac24fba12cbadcb23aa04a759282887fe"},
 }


### PR DESCRIPTION
Removing Porcelain as a dependency, which has not had a new release in many years, and using native Erlang ports instead with fewer processes than Porcelain uses.
Also takes care of closing secondary processes piping into ffmpeg when ffmpeg is closed.
Various readability improvements.
Yes it works.