### PR TITLE
Fix bug where voice player stalls on initial timeout

### DIFF
--- a/lib/nostrum/voice/audio.ex
+++ b/lib/nostrum/voice/audio.ex
@@ -312,6 +312,9 @@ defmodule Nostrum.Voice.Audio do
   end
 
   def on_stall(%VoiceState{} = voice) do
+    # Refresh voice state before running checks
+    voice = Voice.get_voice(voice.guild_id)
+
     if VoiceState.playing?(voice) and not is_nil(voice.ffmpeg_proc) do
       Proc.stop(voice.ffmpeg_proc)
     end


### PR DESCRIPTION
`player_pid` isn't current on the first iteration of `player_loop` so the `on_stall` check fails and causes the player to stall if the audio source times out or fails before producing any audio.