### PR TITLE
Persistent playback through channel switches

### DIFF
--- a/lib/nostrum/struct/voice_state.ex
+++ b/lib/nostrum/struct/voice_state.ex
@@ -24,7 +24,9 @@ defmodule Nostrum.Struct.VoiceState do
     :ffmpeg_proc,
     :raw_audio,
     :raw_stateful,
-    :player_pid
+    :player_pid,
+    :persist_source,
+    :persist_playback
   ]
 
   def new, do: %__MODULE__{}


### PR DESCRIPTION
Optionally persist playback when joining a different channel in a guild already playing audio in.
Automatically plays when if audio was playing at time of channel change. Audio is `resume/1`able if audio was `pause/1`d at the time of channel change.

Funcs for testing

```elixir
def join_voice, do: Voice.join_channel(@guild_id, @channel_id)
def join_voice_2, do: Voice.join_channel(@guild_id, @channel_id_2)

def join_voice_no, do: Voice.join_channel(@guild_id, @channel_id, false, false, false)
def join_voice_2_no, do: Voice.join_channel(@guild_id, @channel_id_2, false, false, false)

def play(url \\ "https://www.youtube.com/watch?v=o_hXGZ8NXAA", opts \\ []),
    do: Voice.play(@guild_id, url, :ytdl, opts)

def pause(), do: Voice.pause(@guild_id)
def resume(), do: Voice.resume(@guild_id)
  
###
join_voice()
play() # Verify audio playing
join_voice2() # Verify still playing 
pause()
join_voice() # Verify audio not playing
resume() # Verify audio resumes playing
join_voice_2_no() # Verify audio not playing
resume() # Verify an error is retuned
```