### PR TITLE
Threads support

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -3900,6 +3900,7 @@ defmodule Nostrum.Api do
   - `rate_limit_per_user`: Rate limit per user in seconds, can be set to any value in `0..21600`.
 
   """
+  @doc since: "0.5.1"
   @spec start_thread_with_message(
           Channel.id(),
           Message.id(),
@@ -3940,6 +3941,7 @@ defmodule Nostrum.Api do
   - `invitable`: whether non-moderators can add other non-moderators to a thread; only available when creating a private thread defaults to `false`.
   - `rate_limit_per_user`: Rate limit per user in seconds, can be set to any value in `0..21600`.
   """
+  @doc since: "0.5.1"
   @spec start_thread(Channel.id(), thread_without_message_params, AuditLogEntry.reason()) ::
           {:ok, Channel.t()} | error
   def start_thread(channel_id, options, reason \\ nil) do
@@ -3956,6 +3958,7 @@ defmodule Nostrum.Api do
   @doc """
   Returns a thread member object for the specified user if they are a member of the thread
   """
+  @doc since: "0.5.1"
   @spec get_thread_member(Channel.id(), User.id()) :: {:ok, ThreadMember.t()} | error
   def get_thread_member(thread_id, user_id) do
     request(:get, Constants.thread_member(thread_id, user_id))
@@ -3967,6 +3970,7 @@ defmodule Nostrum.Api do
 
   This endpoint is restricted according to whether the `GUILD_MEMBERS` privileged intent is enabled.
   """
+  @doc since: "0.5.1"
   @spec get_thread_members(Channel.id()) :: {:ok, [ThreadMember.t()]} | error
   def get_thread_members(thread_id) do
     request(:get, Constants.thread_members(thread_id))
@@ -3980,6 +3984,7 @@ defmodule Nostrum.Api do
   - `threads`: A list of channel objects.
   - `members`: A list of `ThreadMemer` objects, one for each returned thread the current user has joined.
   """
+  @doc since: "0.5.1"
   @spec list_guild_threads(Guild.id()) ::
           {:ok, %{threads: [Channel.t()], members: [ThreadMember.t()]}} | error
   def list_guild_threads(guild_id) do
@@ -4013,9 +4018,10 @@ defmodule Nostrum.Api do
   - `has_more`: A boolean indicating whether there are more archived threads that can be fetched.
 
   ## Options
-  - `before`: Returns threads before this timestamp, can be either a `DateTime` or (ISO8601 timestamp)[`DateTime.to_iso8601/3`].
+  - `before`: Returns threads before this timestamp, can be either a `DateTime` or [ISO8601 timestamp](`DateTime.to_iso8601/3`).
   - `limit`: Optional maximum number of threads to return.
   """
+  @doc since: "0.5.1"
   @spec list_public_archived_threads(Channel.id(), options) ::
           {:ok, %{threads: [Channel.t()], members: [ThreadMember.t()], has_more: boolean()}}
           | error
@@ -4034,6 +4040,7 @@ defmodule Nostrum.Api do
   @doc """
   Same as `list_public_archived_threads/2`, but for private threads instead of public.
   """
+  @doc since: "0.5.1"
   @spec list_private_archived_threads(Channel.id(), options) ::
           {:ok, %{threads: [Channel.t()], members: [ThreadMember.t()], has_more: boolean()}}
           | error
@@ -4052,6 +4059,7 @@ defmodule Nostrum.Api do
   @doc """
   Same as `list_public_archived_threads/2`, but only returns private threads that the current user has joined.
   """
+  @doc since: "0.5.1"
   @spec list_joined_private_archived_threads(Channel.id(), options) ::
           {:ok, %{threads: [Channel.t()], members: [ThreadMember.t()], has_more: boolean()}}
           | error
@@ -4098,6 +4106,7 @@ defmodule Nostrum.Api do
   @doc """
   Join an existing thread, requires that the thread is not archived.
   """
+  @doc since: "0.5.1"
   @spec join_thread(Channel.id()) :: {:ok} | error
   def join_thread(thread_id) do
     request(:put, Constants.thread_member_me(thread_id))
@@ -4106,6 +4115,7 @@ defmodule Nostrum.Api do
   @doc """
   Add a user to a thread, requires the ability to send messages in the thread.
   """
+  @doc since: "0.5.1"
   def add_thread_member(thread_id, user_id) do
     request(:put, Constants.thread_member(thread_id, user_id))
   end
@@ -4113,6 +4123,7 @@ defmodule Nostrum.Api do
   @doc """
   Leave a thread, requires that the thread is not archived.
   """
+  @doc since: "0.5.1"
   @spec leave_thread(Channel.id()) :: {:ok} | error
   def leave_thread(thread_id) do
     request(:delete, Constants.thread_member_me(thread_id))
@@ -4123,6 +4134,7 @@ defmodule Nostrum.Api do
 
   Also requires the `MANAGE_THREADS` permission, or the creator of the thread if the thread is private.
   """
+  @doc since: "0.5.1"
   @spec remove_thread_member(Channel.id(), User.id()) :: {:ok} | error
   def remove_thread_member(thread_id, user_id) do
     request(:delete, Constants.thread_member(thread_id, user_id))

--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -4101,7 +4101,6 @@ defmodule Nostrum.Api do
   @spec join_thread(Channel.id()) :: {:ok} | error
   def join_thread(thread_id) do
     request(:put, Constants.thread_member_me(thread_id))
-    |> handle_request_with_decode
   end
 
   @doc """
@@ -4109,7 +4108,6 @@ defmodule Nostrum.Api do
   """
   def add_thread_member(thread_id, user_id) do
     request(:put, Constants.thread_member(thread_id, user_id))
-    |> handle_request_with_decode
   end
 
   @doc """
@@ -4118,7 +4116,6 @@ defmodule Nostrum.Api do
   @spec leave_thread(Channel.id()) :: {:ok} | error
   def leave_thread(thread_id) do
     request(:delete, Constants.thread_member_me(thread_id))
-    |> handle_request_with_decode
   end
 
   @doc """
@@ -4129,7 +4126,6 @@ defmodule Nostrum.Api do
   @spec remove_thread_member(Channel.id(), User.id()) :: {:ok} | error
   def remove_thread_member(thread_id, user_id) do
     request(:delete, Constants.thread_member(thread_id, user_id))
-    |> handle_request_with_decode
   end
 
   @spec maybe_add_reason(String.t() | nil) :: list()

--- a/lib/nostrum/constants.ex
+++ b/lib/nostrum/constants.ex
@@ -142,6 +142,26 @@ defmodule Nostrum.Constants do
   def cdn_icon(id, icon, image_format), do: "/icons/#{id}/#{icon}.#{image_format}"
   def cdn_splash(id, splash, image_format), do: "/splashes/#{id}/#{splash}.#{image_format}"
 
+  def thread_with_message(channel_id, message_id),
+    do: "/channels/#{channel_id}/messages/#{message_id}/threads"
+
+  def thread_without_message(channel_id), do: "/channels/#{channel_id}/threads"
+
+  def thread_member_me(thread_id), do: "/channels/#{thread_id}/thread-members/@me"
+
+  def thread_member(thread_id, user_id), do: "/channels/#{thread_id}/thread-members/#{user_id}"
+
+  def thread_members(thread_id), do: "/channels/#{thread_id}/thread-members"
+
+  def guild_active_threads(guild_id), do: "/guilds/#{guild_id}/threads/active"
+
+  def public_archived_threads(channel_id), do: "/channels/#{channel_id}/threads/archived/public"
+
+  def private_archived_threads(channel_id), do: "/channels/#{channel_id}/threads/archived/private"
+
+  def private_joined_archived_threads(channel_id),
+    do: "/channels/#{channel_id}/users/@me/threads/archived/private"
+
   def discord_epoch, do: 1_420_070_400_000
 
   def opcodes do

--- a/lib/nostrum/constants.ex
+++ b/lib/nostrum/constants.ex
@@ -2,7 +2,7 @@ defmodule Nostrum.Constants do
   @moduledoc false
 
   def domain, do: "discord.com"
-  def base_route, do: "/api/v8"
+  def base_route, do: "/api/v9"
   def base_url, do: "https://#{domain()}#{base_route()}"
   def cdn_url, do: "https://cdn.discordapp.com"
   def gateway, do: "/gateway"

--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -21,7 +21,7 @@ defmodule Nostrum.Consumer do
   use ConsumerSupervisor
 
   alias Nostrum.Shard.Stage.Cache
-  alias Nostrum.Struct.{Channel, VoiceWSState, WSState}
+  alias Nostrum.Struct.{Channel, ThreadMember, VoiceWSState, WSState}
 
   alias Nostrum.Struct.Event.{
     ChannelPinsUpdate,
@@ -38,6 +38,8 @@ defmodule Nostrum.Consumer do
     MessageReactionRemoveEmoji,
     Ready,
     SpeakingUpdate,
+    ThreadListSync,
+    ThreadMembersUpdate,
     TypingStart,
     VoiceReady,
     VoiceServerUpdate,
@@ -216,6 +218,27 @@ defmodule Nostrum.Consumer do
   @type voice_server_update :: {:VOICE_SERVER_UPDATE, VoiceServerUpdate.t(), WSState.t()}
   @type webhooks_update :: {:WEBHOOKS_UPDATE, map, WSState.t()}
 
+  @typedoc """
+  Dispatched when a thread is created or when added to a private thread
+  """
+  @type thread_create :: {:THREAD_CREATE, Channel.t(), WSState.t()}
+  @type thread_delete :: {:THREAD_DELETE, Channel.t(), WSState.t()}
+  @type thread_update :: {:THREAD_UPDATE, Channel.t(), WSState.t()}
+
+  @typedoc """
+  Dispatched when gaining access to a channel
+  """
+  @type thread_list_sync :: {:THREAD_LIST_SYNC, ThreadListSync.t(), WSState.t()}
+
+  @typedoc """
+  Dispatched when a `ThreadMember` for the current user is updated
+  """
+  @type thread_member_update :: {:THREAD_MEMBER_UPDATE, ThreadMember.t(), WSState.t()}
+
+  @typedoc """
+  Dispatched when member(s) are added or removed from a thread
+  """
+  @type thread_members_update :: {:THREAD_MEMBERS_UPDATE, ThreadMembersUpdate.t(), WSState.t()}
   @type event ::
           channel_create
           | channel_delete
@@ -249,6 +272,12 @@ defmodule Nostrum.Consumer do
           | presence_update
           | ready
           | resumed
+          | thread_create
+          | thread_delete
+          | thread_update
+          | thread_list_sync
+          | thread_member_update
+          | thread_members_update
           | typing_start
           | user_settings_update
           | user_update

--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -227,7 +227,9 @@ defmodule Nostrum.Consumer do
   Dispatched when a thread is deleted, if the thread was cached, contains the original thread, otherwise contains `:noop`
   """
   @type thread_delete :: {:THREAD_DELETE, Channel.t() | :noop, WSState.t()}
-  @type thread_update :: {:THREAD_UPDATE, {old_thread :: Channel.t() | nil, new_thread :: Channel.t()}, WSState.t()}
+  @type thread_update ::
+          {:THREAD_UPDATE, {old_thread :: Channel.t() | nil, new_thread :: Channel.t()},
+           WSState.t()}
 
   @typedoc """
   Dispatched when gaining access to a channel

--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -222,8 +222,12 @@ defmodule Nostrum.Consumer do
   Dispatched when a thread is created or when added to a private thread
   """
   @type thread_create :: {:THREAD_CREATE, Channel.t(), WSState.t()}
-  @type thread_delete :: {:THREAD_DELETE, Channel.t(), WSState.t()}
-  @type thread_update :: {:THREAD_UPDATE, Channel.t(), WSState.t()}
+
+  @typedoc """
+  Dispatched when a thread is deleted, if the thread was cached, contains the original thread, otherwise contains `:noop`
+  """
+  @type thread_delete :: {:THREAD_DELETE, Channel.t() | :noop, WSState.t()}
+  @type thread_update :: {:THREAD_UPDATE, {old_thread :: Channel.t() | nil, new_thread :: Channel.t()}, WSState.t()}
 
   @typedoc """
   Dispatched when gaining access to a channel

--- a/lib/nostrum/permission.ex
+++ b/lib/nostrum/permission.ex
@@ -56,6 +56,10 @@ defmodule Nostrum.Permission do
           | :read_message_history
           | :mention_everyone
           | :use_external_emojis
+          | :create_public_threads
+          | :create_private_threads
+          | :send_messages_in_threads
+          | :manage_threads
 
   @type voice_permission ::
           :connect
@@ -71,6 +75,7 @@ defmodule Nostrum.Permission do
           | text_permission
           | voice_permission
 
+  # TODO: replace this with bitshifts to match the API docs for readability
   @permission_to_bit_map %{
     create_instant_invite: 0x00000001,
     kick_members: 0x00000002,
@@ -100,7 +105,11 @@ defmodule Nostrum.Permission do
     manage_nicknames: 0x08000000,
     manage_roles: 0x10000000,
     manage_webhooks: 0x20000000,
-    manage_emojis: 0x40000000
+    manage_emojis: 0x40000000,
+    manage_threads: 0x0000000400000000,
+    create_public_threads: 0x0000000800000000,
+    create_private_threads: 0x0000001000000000,
+    send_messages_in_threads: 0x0000004000000000
   }
 
   @bit_to_permission_map Map.new(@permission_to_bit_map, fn {k, v} -> {v, k} end)

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -22,13 +22,15 @@ defmodule Nostrum.Shard.Dispatch do
     MessageReactionRemoveEmoji,
     Ready,
     SpeakingUpdate,
+    ThreadListSync,
+    ThreadMembersUpdate,
     TypingStart,
     VoiceReady,
     VoiceServerUpdate,
     VoiceState
   }
 
-  alias Nostrum.Struct.{Guild, Interaction, Message, User}
+  alias Nostrum.Struct.{Guild, Interaction, Message, ThreadMember, User}
   alias Nostrum.Struct.Guild.{ScheduledEvent, UnavailableGuild}
   alias Nostrum.Util
   alias Nostrum.Voice
@@ -267,6 +269,24 @@ defmodule Nostrum.Shard.Dispatch do
   end
 
   def handle_event(:RESUMED = event, p, state), do: {event, p, state}
+
+  def handle_event(:THREAD_CREATE = event, p, state),
+    do: {event, GuildCache.channel_create(p.guild_id, p), state}
+
+  def handle_event(:THREAD_DELETE = event, p, state),
+    do: {event, GuildCache.channel_delete(p.guild_id, p.channel_id), state}
+
+  def handle_event(:THREAD_UPDATE = event, p, state),
+    do: {event, GuildCache.channel_update(p.guild_id, p), state}
+
+  def handle_event(:THREAD_LIST_SYNC = event, p, state),
+    do: {event, ThreadListSync.to_struct(p), state}
+
+  def handle_event(:THREAD_MEMBER_UPDATE = event, p, state),
+    do: {event, ThreadMember.to_struct(p), state}
+
+  def handle_event(:THREAD_MEMBERS_UPDATE = event, p, state),
+    do: {event, ThreadMembersUpdate.to_struct(p), state}
 
   def handle_event(:TYPING_START = event, p, state) do
     {event, TypingStart.to_struct(p), state}

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -274,7 +274,7 @@ defmodule Nostrum.Shard.Dispatch do
     do: {event, GuildCache.channel_create(p.guild_id, p), state}
 
   def handle_event(:THREAD_DELETE = event, p, state),
-    do: {event, GuildCache.channel_delete(p.guild_id, p.channel_id), state}
+    do: {event, GuildCache.channel_delete(p.guild_id, p.id), state}
 
   def handle_event(:THREAD_UPDATE = event, p, state),
     do: {event, GuildCache.channel_update(p.guild_id, p), state}

--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -9,7 +9,7 @@ defmodule Nostrum.Shard.Session do
 
   use GenServer
 
-  @gateway_qs "/?compress=zlib-stream&encoding=etf&v=8"
+  @gateway_qs "/?compress=zlib-stream&encoding=etf&v=9"
 
   # Maximum time the initial connection may take, in milliseconds.
   @timeout_connect 10_000

--- a/lib/nostrum/struct/channel.ex
+++ b/lib/nostrum/struct/channel.ex
@@ -146,7 +146,8 @@ defmodule Nostrum.Struct.Channel do
     :thread_metadata,
     :member,
     :default_auto_archive_duration,
-    :permissions
+    :permissions,
+    :newly_created
   ]
 
   @typedoc """
@@ -371,6 +372,12 @@ defmodule Nostrum.Struct.Channel do
   @type permissions :: String.t()
 
   @typedoc """
+  Included only in the `THREAD_CREATE` event.
+  """
+  @typedoc since: "0.5.1"
+  @type newly_created :: boolean | nil
+
+  @typedoc """
   Type 0 partial channel object representing a text channel within a guild.
   """
   @type guild_text_channel :: %__MODULE__{
@@ -495,7 +502,8 @@ defmodule Nostrum.Struct.Channel do
           message_count: message_count,
           member_count: member_count,
           rate_limit_per_user: rate_limit_per_user,
-          thread_metadata: thread_metadata
+          thread_metadata: thread_metadata,
+          newly_created: newly_created
         }
 
   @typedoc """
@@ -513,7 +521,8 @@ defmodule Nostrum.Struct.Channel do
           message_count: message_count,
           member_count: member_count,
           rate_limit_per_user: rate_limit_per_user,
-          thread_metadata: thread_metadata
+          thread_metadata: thread_metadata,
+          newly_created: newly_created
         }
 
   @typedoc """
@@ -531,7 +540,8 @@ defmodule Nostrum.Struct.Channel do
           message_count: message_count,
           member_count: member_count,
           rate_limit_per_user: rate_limit_per_user,
-          thread_metadata: thread_metadata
+          thread_metadata: thread_metadata,
+          newly_created: newly_created
         }
 
   @typedoc """

--- a/lib/nostrum/struct/event/thread_list_sync.ex
+++ b/lib/nostrum/struct/event/thread_list_sync.ex
@@ -1,0 +1,63 @@
+defmodule Nostrum.Struct.Event.ThreadListSync do
+  @moduledoc """
+  Struct representing a Thread List Sync event.
+
+  This event is sent when the user gains access to a channel.
+  """
+
+  alias Nostrum.Struct.{Channel, Guild, ThreadMember}
+  alias Nostrum.{Snowflake, Util}
+
+  defstruct [
+    :guild_id,
+    :channel_ids,
+    :threads,
+    :members
+  ]
+
+  @typedoc """
+  The id of the guild.
+  """
+  @typedoc since: "0.5.1"
+  @type guid_id :: Guild.id()
+
+  @typedoc """
+  The parent channel ids whose threads are being synced.
+  If omitted, all threads were synced for the entire guild.
+  """
+  @typedoc since: "0.5.1"
+  @type channel_ids :: [Channel.id()] | nil
+
+  @typedoc """
+  All active threads in the given channels that the user can access.
+  """
+  @typedoc since: "0.5.1"
+  @type threads :: [Channel.t()]
+
+  @typedoc """
+  All thread member objects from the synced threads for the current user,
+  indicating which threads the user has been added to.
+  """
+  @typedoc since: "0.5.1"
+  @type members :: [ThreadMember.t()]
+
+  @type t :: %__MODULE__{
+          guild_id: guid_id,
+          channel_ids: channel_ids,
+          threads: threads,
+          members: members
+        }
+
+  @doc false
+  def to_struct(map) do
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:channel_ids, nil, &Util.cast(&1, {:list, Snowflake}))
+      |> Map.update(:threads, nil, &Util.cast(&1, {:list, {:struct, Channel}}))
+      |> Map.update(:members, nil, &Util.cast(&1, {:list, {:struct, ThreadMember}}))
+
+    struct(__MODULE__, new)
+  end
+end

--- a/lib/nostrum/struct/event/thread_members_update.ex
+++ b/lib/nostrum/struct/event/thread_members_update.ex
@@ -5,7 +5,7 @@ defmodule Nostrum.Struct.Event.ThreadMembersUpdate do
   This event is sent whenever a user is added or removed from a thread.
 
   If the current user does not have the `GUILD_MEMBERS` intent,
-  this event will only be send when the current user is added to or removed from a thread.
+  this event will only be sent when the current user is added to or removed from a thread.
   """
 
   defstruct [

--- a/lib/nostrum/struct/event/thread_members_update.ex
+++ b/lib/nostrum/struct/event/thread_members_update.ex
@@ -1,0 +1,74 @@
+defmodule Nostrum.Struct.Event.ThreadMembersUpdate do
+  @moduledoc """
+  Struct representing a thread members update event.
+
+  This event is sent whenever a user is added or removed from a thread.
+
+  If the current user does not have the `GUILD_MEMBERS` intent,
+  this event will only be send when the current user is added to or removed from a thread.
+  """
+
+  defstruct [
+    :id,
+    :guild_id,
+    :member_count,
+    :added_members,
+    :removed_member_ids
+  ]
+
+  alias Nostrum.Struct.{Channel, Guild, ThreadMember, User}
+  alias Nostrum.{Snowflake, Util}
+
+  @typedoc """
+  The id of the thread.
+  """
+  @typedoc since: "0.5.1"
+  @type id :: Channel.id()
+
+  @typedoc """
+  The id of the guild the thread is in.
+  """
+  @typedoc since: "0.5.1"
+  @type guild_id :: Guild.id()
+
+  @typedoc """
+  The approximate number of members in the thread.
+
+  This number is capped at 50, though there can be more members in the thread.
+  """
+  @typedoc since: "0.5.1"
+  @type member_count :: non_neg_integer()
+
+  @typedoc """
+  The members that were added to the thread.
+  """
+  @typedoc since: "0.5.1"
+  @type added_members :: [ThreadMember.t()] | nil
+
+  @typedoc """
+  The ids of the members that were removed from the thread.
+  """
+  @typedoc since: "0.5.1"
+  @type removed_member_ids :: [User.id()] | nil
+
+  @type t :: %__MODULE__{
+          id: id,
+          guild_id: guild_id,
+          member_count: member_count,
+          added_members: added_members,
+          removed_member_ids: removed_member_ids
+        }
+
+  @doc false
+  def to_struct(map) do
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:added_members, nil, &Util.cast(&1, {:list, {:struct, ThreadMember}}))
+      |> Map.update(:removed_member_ids, nil, &Util.cast(&1, {:list, Snowflake}))
+
+    struct(__MODULE__, new)
+  end
+end

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -8,7 +8,8 @@ defmodule Nostrum.Struct.Guild do
     :voice_states,
     :members,
     :channels,
-    :guild_scheduled_events
+    :guild_scheduled_events,
+    :threads
   ]
 
   @moduledoc """
@@ -49,7 +50,8 @@ defmodule Nostrum.Struct.Guild do
     :members,
     :channels,
     :guild_scheduled_events,
-    :vanity_url_code
+    :vanity_url_code,
+    :threads
   ]
 
   @typedoc "The guild's id"
@@ -160,6 +162,10 @@ defmodule Nostrum.Struct.Guild do
   @typedoc "Guild invite vanity URL"
   @type vanity_url_code :: String.t() | nil
 
+  @typedoc "All active threads in the guild that the current user has permission to view"
+  @typedoc since: "0.5.1"
+  @type threads :: %{required(Channel.id()) => Channel.t()} | nil
+
   @typedoc """
   A `Nostrum.Struct.Guild` that is sent on user-specific rest endpoints.
   """
@@ -192,7 +198,8 @@ defmodule Nostrum.Struct.Guild do
           voice_states: nil,
           members: nil,
           channels: nil,
-          vanity_url_code: nil
+          vanity_url_code: nil,
+          threads: nil
         }
 
   @typedoc """
@@ -228,7 +235,8 @@ defmodule Nostrum.Struct.Guild do
           voice_states: nil,
           members: nil,
           channels: nil,
-          guild_scheduled_events: nil
+          guild_scheduled_events: nil,
+          threads: nil
         }
 
   @typedoc """
@@ -264,7 +272,8 @@ defmodule Nostrum.Struct.Guild do
           members: nil,
           channels: nil,
           guild_scheduled_events: nil,
-          vanity_url_code: nil
+          vanity_url_code: nil,
+          threads: nil
         }
 
   @typedoc """
@@ -300,7 +309,8 @@ defmodule Nostrum.Struct.Guild do
           members: members,
           channels: channels,
           guild_scheduled_events: guild_scheduled_events,
-          vanity_url_code: vanity_url_code
+          vanity_url_code: vanity_url_code,
+          threads: threads
         }
 
   @type t ::
@@ -391,6 +401,7 @@ defmodule Nostrum.Struct.Guild do
         nil,
         &Util.cast(&1, {:list, {:struct, ScheduledEvent}})
       )
+      |> Map.update(:threads, nil, &Util.cast(&1, {:index, [:id], {:struct, Channel}}))
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/struct/message.ex
+++ b/lib/nostrum/struct/message.ex
@@ -178,7 +178,9 @@ defmodule Nostrum.Struct.Message do
   @type member :: Member.t() | nil
 
   @typedoc """
-  Reference data sent with crossposted messages and replies
+  Reference data sent with crossposted messages and replies.
+
+  For `THREAD_STARTER_MESSAGE` messages, this field points to the message that the thread was started from.
   """
   @type message_reference :: Reference.t() | nil
 

--- a/lib/nostrum/struct/thread_member.ex
+++ b/lib/nostrum/struct/thread_member.ex
@@ -2,6 +2,7 @@ defmodule Nostrum.Struct.ThreadMember do
   @moduledoc """
   Struct representing a thread member object
   """
+  @moduledoc since: "0.5.1"
 
   alias Nostrum.Struct.{Guild, User}
   alias Nostrum.{Snowflake, Util}
@@ -17,19 +18,16 @@ defmodule Nostrum.Struct.ThreadMember do
   @typedoc """
   The id of the thread, omitted within `GUILD_CREATE` events
   """
-  @typedoc since: "0.5.1"
   @type id :: Snowflake.t() | nil
 
   @typedoc """
   The id of the user, omitted within `GUILD_CREATE` events
   """
-  @typedoc since: "0.5.1"
   @type user_id :: User.id() | nil
 
   @typedoc """
   The timestamp of when the user last joined the thread
   """
-  @typedoc since: "0.5.1"
   @type join_timestamp :: DateTime.t()
 
   @typedoc """
@@ -42,7 +40,6 @@ defmodule Nostrum.Struct.ThreadMember do
 
   Only present within `THREAD_MEMBER_UPDATE` events
   """
-  @typedoc since: "0.5.1"
   @type guild_id :: Guild.id() | nil
 
   @type t :: %__MODULE__{

--- a/lib/nostrum/struct/thread_member.ex
+++ b/lib/nostrum/struct/thread_member.ex
@@ -1,0 +1,68 @@
+defmodule Nostrum.Struct.ThreadMember do
+  @moduledoc """
+  Struct representing a thread member object
+  """
+
+  alias Nostrum.Struct.{Guild, User}
+  alias Nostrum.{Snowflake, Util}
+
+  defstruct [
+    :id,
+    :user_id,
+    :join_timestamp,
+    :flags,
+    :guild_id
+  ]
+
+  @typedoc """
+  The id of the thread, omitted within `GUILD_CREATE` events
+  """
+  @typedoc since: "0.5.1"
+  @type id :: Snowflake.t() | nil
+
+  @typedoc """
+  The id of the user, omitted within `GUILD_CREATE` events
+  """
+  @typedoc since: "0.5.1"
+  @type user_id :: User.id() | nil
+
+  @typedoc """
+  The timestamp of when the user last joined the thread
+  """
+  @typedoc since: "0.5.1"
+  @type join_timestamp :: DateTime.t()
+
+  @typedoc """
+  Any user-thread settings
+  """
+  @type flags :: non_neg_integer()
+
+  @typedoc """
+  The id of the guild the thread is in.
+
+  Only present within `THREAD_MEMBER_UPDATE` events
+  """
+  @typedoc since: "0.5.1"
+  @type guild_id :: Guild.id() | nil
+
+  @type t :: %__MODULE__{
+          id: id,
+          user_id: user_id,
+          join_timestamp: join_timestamp,
+          flags: flags,
+          guild_id: guild_id
+        }
+
+  @doc false
+  def to_struct(map) do
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:user_id, nil, &Util.cast(&1, Snowflake))
+      |> Map.update(:join_timestamp, nil, &Util.maybe_to_datetime/1)
+      |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
+
+    struct(__MODULE__, new)
+  end
+end


### PR DESCRIPTION
Add support for Threads

- [x] Bump Gateway version to v9
- [x] Add new Thread events
- [x] Add new API routes
- [x] Add thread specific fields to existing structs

Why bump to API v9 in this PR and not skip directly to v10? Because these should be able to be done without it being a breaking change, allowing for one last hex release before v10 and `0.6.0`