### PR TITLE
Fix audit log entries not being saved

### DIFF
--- a/lib/nostrum/struct/guild/audit_log.ex
+++ b/lib/nostrum/struct/guild/audit_log.ex
@@ -29,7 +29,8 @@ defmodule Nostrum.Struct.Guild.AuditLog do
     new =
       map
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
-      |> Map.update(:audit_log_entries, nil, &Util.cast(&1, {:list, {:struct, AuditLogEntry}}))
+      |> Map.put(:entries, Util.cast(map[:audit_log_entries], {:list, {:struct, AuditLogEntry}}))
+      |> Map.delete(:audit_log_entries)
       |> Map.update(:users, nil, &Util.cast(&1, {:list, {:struct, User}}))
       |> Map.update(:webhooks, nil, &Util.cast(&1, {:list, {:struct, Webhook}}))
 


### PR DESCRIPTION
`Nostrum.Struct.Guild.AuditLog` has an `:entries` key, while the API
returns an `:audit_log_entries`. However, when casting the response, the
`:audit_log_entries` field was casted. Since there was no `:entries`
field in the resulting map, when calling `struct/2`, `:entries` was
always `nil`.