### PR TITLE
Ogg encoding and rtp ext fixes

### DIFF
--- a/lib/nostrum/voice/opus.ex
+++ b/lib/nostrum/voice/opus.ex
@@ -19,7 +19,7 @@ defmodule Nostrum.Voice.Opus do
   discord.js appears to be the only other library that officially implements receiving
   audio as a part of their voice modules, and in their stripping of the RTP header
   extension they account for an extra "Discord byte" but it looks like they are actually
-  misinterpreting the 16-bit extension lenth as the number of extension elements, then
+  misinterpreting the 16-bit extension length as the number of extension elements, then
   iterating through each one-byte header and variable-length element but incorrectly
   incrementing the offset by an extra 1, which causes them to land on an extra 1 byte,
   instead a full extension (1 byte header with 1 byte extension).

--- a/lib/nostrum/voice/opus.ex
+++ b/lib/nostrum/voice/opus.ex
@@ -132,7 +132,7 @@ defmodule Nostrum.Voice.Opus do
       when is_list(body) do
     segment_table_raw =
       body
-      |> Enum.map(&byte_size(&1))
+      |> Enum.map(&byte_size/1)
       |> encode_ogg_segment_table()
 
     %{
@@ -142,9 +142,9 @@ defmodule Nostrum.Voice.Opus do
       bitstream_serial: bitstream_serial,
       page_sequence: page_sequence,
       crc_checksum: 0,
-      page_segments: segment_table_raw |> byte_size(),
+      page_segments: byte_size(segment_table_raw),
       segment_table_raw: segment_table_raw,
-      body: body |> :binary.list_to_bin()
+      body: :binary.list_to_bin(body)
     }
     |> encode_with_crc()
   end

--- a/lib/nostrum/voice/opus.ex
+++ b/lib/nostrum/voice/opus.ex
@@ -4,58 +4,41 @@ defmodule Nostrum.Voice.Opus do
   use Bitwise
 
   @doc """
-  Strips the RTP extensions from an RTP payload.
+  Strips the RTP header extension from an RTP payload.
 
   The encrypted portion of the RTP packets that we receive from Discord
-  isn't raw opus packets; it's actually opus prepended by RTP header extensions.
+  isn't raw opus packets; it's actually opus prepended by an RTP header extension.
   Looking at the unencrypted fixed-length RTP header, the extension bit is, in
   fact, set to 1.
 
-  Discord seems to have misinterpreted the RTP header extension RFC and
-  thought that for one-byte header extensions that the two-byte integer
-  length following the constant 0xBEDE pattern is equivalent to the number
-  of header extensions - 1 (where ext length 0 would represent 1 extension),
-  but this is only the case for the 4-bit integer that describes each
-  one-byte header extension.
+  RFC 8285 describes the format of RTP header extensions. Discord uses RTP
+  extensions with the one-byte header format that begins with a 0xBEDE pattern
+  followed by a 16 bit extension length. This extension length represents the length
+  of the following extension in 32-bit words.
 
-  discord.js is the only other library that implements receiving audio, and
-  in their stripping of the RTP header extensions they account for an extra
-  "Discord byte" but it looks like they are actually incorrectly incrementing
-  the offset by an extra 1, which causes them to land on an extra 1 byte,
+  discord.js appears to be the only other library that officially implements receiving
+  audio as a part of their voice modules, and in their stripping of the RTP header
+  extension they account for an extra "Discord byte" but it looks like they are actually
+  misinterpreting the 16-bit extension lenth as the number of extension elements, then
+  iterating through each header extension and variable-length element but incorrectly
+  incrementing the offset by an extra 1, which causes them to land on an extra 1 byte,
   instead a full extension (1 byte header with 1 byte extension).
+
+  Because the RTP header extension elements don't necessarily mean anything to the client
+  and Discord does not document what their extension element ids and corresponding values
+  mean, they can easily be skipped over since the total extension length is provided at
+  the beginning of the extension.
   """
-  def strip_rtp_ext(packet) do
-    <<
-      0xBE,
-      0xDE,
-      ext_len::integer-16,
-      rest::binary
-    >> = packet
-
-    # Actual number of extensions is 1 + given ext_len (Discord bug)
-    ext_len = ext_len + 1
-
-    rtp_ext_step(rest, ext_len)
-  end
-
-  defp rtp_ext_step(rest, 0) do
-    # RTP header extensions fully stripped, leaving pure opus
-    rest
-  end
-
-  defp rtp_ext_step(<<0::8, rest::binary>>, len) do
-    # One-byte headers of 0 is padding
-    rtp_ext_step(rest, len)
-  end
-
-  defp rtp_ext_step(rest, len) do
-    <<_id::4, l::integer-size(4), rest::binary>> = rest
-
-    # This is correct: for one-byte headers, length is 4-bit int + 1
-    l = l + 1
-    <<_ext::binary-size(l), rest::binary>> = rest
-    rtp_ext_step(rest, len - 1)
-  end
+  def strip_rtp_ext(
+        <<
+          0xBE,
+          0xDE,
+          ext_len::integer-16,
+          _exts::unit(32)-size(ext_len),
+          rest::binary
+        >> = _packet
+      ),
+      do: rest
 
   def parse_ogg(<<>>), do: []
 
@@ -147,6 +130,12 @@ defmodule Nostrum.Voice.Opus do
         } = _state
       )
       when is_list(body) do
+
+    segment_table_raw =
+      body
+      |> Enum.map(&byte_size(&1))
+      |> encode_ogg_segment_table()
+
     %{
       version: 0,
       header_type: header_type,
@@ -154,28 +143,25 @@ defmodule Nostrum.Voice.Opus do
       bitstream_serial: bitstream_serial,
       page_sequence: page_sequence,
       crc_checksum: 0,
-      page_segments: body |> Enum.count(),
-      segment_table_raw:
-        body
-        |> Enum.map(&byte_size(&1))
-        |> encode_ogg_segment_table(),
+      page_segments: segment_table_raw |> byte_size(),
+      segment_table_raw: segment_table_raw,
       body: body |> :binary.list_to_bin()
     }
     |> encode_with_crc()
   end
 
-  def parse_opus_head(binary) do
-    <<
-      "OpusHead",
-      version::integer-8,
-      channel_count::integer-8,
-      pre_skip::little-integer-16,
-      input_sample_rate::little-integer-32,
-      output_gain::little-integer-16,
-      mapping_family::integer-8,
-      rest::binary
-    >> = binary
-
+  def parse_opus_head(
+        <<
+          "OpusHead",
+          version::integer-8,
+          channel_count::integer-8,
+          pre_skip::little-integer-16,
+          input_sample_rate::little-integer-32,
+          output_gain::little-integer-16,
+          mapping_family::integer-8,
+          rest::binary
+        >> = _binary
+      ) do
     %{
       version: version,
       channel_count: channel_count,
@@ -208,15 +194,15 @@ defmodule Nostrum.Voice.Opus do
     >>
   end
 
-  def parse_opus_tags(binary) do
-    <<
-      "OpusTags",
-      vendor_string_length::little-integer-32,
-      vendor_string::binary-size(vendor_string_length),
-      user_comment_list_length::little-integer-32,
-      rest::binary
-    >> = binary
-
+  def parse_opus_tags(
+        <<
+          "OpusTags",
+          vendor_string_length::little-integer-32,
+          vendor_string::binary-size(vendor_string_length),
+          user_comment_list_length::little-integer-32,
+          rest::binary
+        >> = _binary
+      ) do
     {rest, comments} =
       if user_comment_list_length > 0 do
         Enum.reduce(1..user_comment_list_length, {rest, []}, fn _, {rest, list} ->
@@ -262,20 +248,20 @@ defmodule Nostrum.Voice.Opus do
     >>
   end
 
-  def parse_ogg_page(binary) do
-    <<
-      "OggS",
-      version::integer-8,
-      header_type::integer-8,
-      granule_position::little-integer-64,
-      bitstream_serial::little-integer-32,
-      page_sequence::little-integer-32,
-      crc_checksum::little-integer-32,
-      page_segments::integer-8,
-      segment_table_raw::binary-size(page_segments),
-      rest::binary
-    >> = binary
-
+  def parse_ogg_page(
+        <<
+          "OggS",
+          version::integer-8,
+          header_type::integer-8,
+          granule_position::little-integer-64,
+          bitstream_serial::little-integer-32,
+          page_sequence::little-integer-32,
+          crc_checksum::little-integer-32,
+          page_segments::integer-8,
+          segment_table_raw::binary-size(page_segments),
+          rest::binary
+        >> = _binary
+      ) do
     segment_table = parse_ogg_segment_table(segment_table_raw)
 
     body_len = segment_table |> Enum.sum()

--- a/lib/nostrum/voice/opus.ex
+++ b/lib/nostrum/voice/opus.ex
@@ -20,7 +20,7 @@ defmodule Nostrum.Voice.Opus do
   audio as a part of their voice modules, and in their stripping of the RTP header
   extension they account for an extra "Discord byte" but it looks like they are actually
   misinterpreting the 16-bit extension lenth as the number of extension elements, then
-  iterating through each header extension and variable-length element but incorrectly
+  iterating through each one-byte header and variable-length element but incorrectly
   incrementing the offset by an extra 1, which causes them to land on an extra 1 byte,
   instead a full extension (1 byte header with 1 byte extension).
 
@@ -130,7 +130,6 @@ defmodule Nostrum.Voice.Opus do
         } = _state
       )
       when is_list(body) do
-
     segment_table_raw =
       body
       |> Enum.map(&byte_size(&1))

--- a/lib/nostrum/voice/opus.ex
+++ b/lib/nostrum/voice/opus.ex
@@ -16,14 +16,6 @@ defmodule Nostrum.Voice.Opus do
   followed by a 16 bit extension length. This extension length represents the length
   of the following extension in 32-bit words.
 
-  discord.js appears to be the only other library that officially implements receiving
-  audio as a part of their voice modules, and in their stripping of the RTP header
-  extension they account for an extra "Discord byte" but it looks like they are actually
-  misinterpreting the 16-bit extension length as the number of extension elements, then
-  iterating through each one-byte header and variable-length element but incorrectly
-  incrementing the offset by an extra 1, which causes them to land on an extra 1 byte,
-  instead a full extension (1 byte header with 1 byte extension).
-
   Because the RTP header extension elements don't necessarily mean anything to the client
   and Discord does not document what their extension element ids and corresponding values
   mean, they can easily be skipped over since the total extension length is provided at


### PR DESCRIPTION
Three main things

1. **Fix bug with generating ogg pages with incorrect page_segments value.** - _page_segments is the byte length of the segment_table, and when segments exceed 254 bytes they take up multiple bytes in the segment table. This was leading to some encoding errors when some opus packets were 255 bytes in length or greater._
2. **Properly skip over rtp header extension.** - _the ext_length is actually the number of 32 bit words of the extension, not the number of extension elements to iterate through. Thanks to @imayhaveborkedit for pointing me to the first paragraph of the rfc 🤡_ 
3. **Place binary pattern matches in function headers versus body.** - _good practice_
