### PR TITLE
fix improper call to `Integration` cast bug

### DIFF
--- a/lib/nostrum/struct/guild/integration.ex
+++ b/lib/nostrum/struct/guild/integration.ex
@@ -72,8 +72,8 @@ defmodule Nostrum.Struct.Guild.Integration do
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
       |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:guild_id, nil, &Util.cast(&1, Snowflake))
-      |> Map.update(:account, nil, &Util.cast(&1, Account))
-      |> Map.update(:application, nil, &Util.cast(&1, IntegrationApplication))
+      |> Map.update(:account, nil, &Util.cast(&1, {:struct, Account}))
+      |> Map.update(:application, nil, &Util.cast(&1, {:struct, IntegrationApplication}))
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/struct/guild/integration/application.ex
+++ b/lib/nostrum/struct/guild/integration/application.ex
@@ -55,7 +55,7 @@ defmodule Nostrum.Struct.Guild.Integration.Application do
       map
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
       |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
-      |> Map.update(:bot, nil, &Util.cast(&1, User))
+      |> Map.update(:bot, nil, &Util.cast(&1, {:struct, User}))
 
     struct(__MODULE__, new)
   end


### PR DESCRIPTION
Improperly wrote the calls to `Util.cast/2`, this fixes that.