### PR TITLE
Improve pad_opus, define constants, fix various player bugs, code cleanup, current url feature

### DIFF
--- a/lib/nostrum/struct/event/speaking_update.ex
+++ b/lib/nostrum/struct/event/speaking_update.ex
@@ -9,6 +9,7 @@ defmodule Nostrum.Struct.Event.SpeakingUpdate do
     :channel_id,
     :guild_id,
     :speaking,
+    :current_url,
     :timed_out
   ]
 
@@ -30,6 +31,12 @@ defmodule Nostrum.Struct.Event.SpeakingUpdate do
   @type speaking :: boolean()
 
   @typedoc """
+  Current URL being played if a readable format.
+  """
+  @typedoc since: "0.6.0"
+  @type current_url :: String.t() | nil
+
+  @typedoc """
   Boolean representing if speaking update was caused by an audio timeout.
   """
   @typedoc since: "0.5.0"
@@ -39,6 +46,7 @@ defmodule Nostrum.Struct.Event.SpeakingUpdate do
           channel_id: channel_id,
           guild_id: guild_id,
           speaking: speaking,
+          current_url: current_url,
           timed_out: timed_out
         }
 

--- a/lib/nostrum/struct/voice_state.ex
+++ b/lib/nostrum/struct/voice_state.ex
@@ -24,6 +24,7 @@ defmodule Nostrum.Struct.VoiceState do
     :ffmpeg_proc,
     :raw_audio,
     :raw_stateful,
+    :current_url,
     :player_pid,
     :persist_source,
     :persist_playback

--- a/lib/nostrum/voice.ex
+++ b/lib/nostrum/voice.ex
@@ -92,6 +92,10 @@ defmodule Nostrum.Voice do
   @typedoc since: "0.6.0"
   @type play_input :: String.t() | binary() | Enum.t()
 
+  @raw_types [:raw, :raw_s]
+  @ffm_types [:url, :pipe, :ytdl, :stream]
+  @url_types [:url, :ytdl, :stream]
+
   @doc false
   def start_link(_args) do
     GenServer.start_link(__MODULE__, %{}, name: VoiceStateMap)
@@ -248,25 +252,18 @@ defmodule Nostrum.Voice do
         {:error, "Audio already playing in voice channel."}
 
       true ->
-        unless is_nil(voice.ffmpeg_proc), do: Ports.close(voice.ffmpeg_proc)
-        set_speaking(voice, true)
-
-        {ffmpeg_proc, raw_audio, raw_stateful} =
-          case type do
-            :raw -> {nil, input, false}
-            :raw_s -> {nil, input, true}
-            _ffmpeg -> {Audio.spawn_ffmpeg(input, type, options), nil, false}
-          end
+        if is_pid(voice.ffmpeg_proc), do: Ports.close(voice.ffmpeg_proc)
 
         voice =
           update_voice(guild_id,
-            ffmpeg_proc: ffmpeg_proc,
-            raw_audio: raw_audio,
-            raw_stateful: raw_stateful
+            current_url: if(type in @url_types, do: input),
+            ffmpeg_proc: if(type in @ffm_types, do: Audio.spawn_ffmpeg(input, type, options)),
+            raw_audio: if(type in @raw_types, do: input),
+            raw_stateful: type === :raw_s
           )
 
-        {:ok, pid} = Task.start(fn -> Audio.start_player(voice) end)
-        update_voice(guild_id, player_pid: pid)
+        set_speaking(voice, true)
+        update_voice(guild_id, player_pid: spawn(Audio, :start_player, [voice]))
         :ok
     end
   end
@@ -308,7 +305,7 @@ defmodule Nostrum.Voice do
       true ->
         set_speaking(voice, false)
         Process.exit(voice.player_pid, :stop)
-        unless is_nil(voice.ffmpeg_proc), do: Ports.close(voice.ffmpeg_proc)
+        if is_pid(voice.ffmpeg_proc), do: Ports.close(voice.ffmpeg_proc)
         :ok
     end
   end
@@ -394,8 +391,7 @@ defmodule Nostrum.Voice do
 
       true ->
         set_speaking(voice, true)
-        {:ok, pid} = Task.start(fn -> Audio.resume_player(voice) end)
-        update_voice(guild_id, player_pid: pid)
+        update_voice(guild_id, player_pid: spawn(Audio, :resume_player, [voice]))
         :ok
     end
   end
@@ -483,7 +479,23 @@ defmodule Nostrum.Voice do
   @spec get_channel_id(Guild.id()) :: Channel.id()
   def get_channel_id(guild_id) do
     voice = get_voice(guild_id)
-    if voice, do: voice.channel_id, else: nil
+    if voice, do: voice.channel_id
+  end
+
+  @doc """
+  Gets the current URL being played.
+
+  If `play/4` was invoked with type `:url`, `:ytdl`, or `:stream`, this function will return
+  the URL given as input last time it was called.
+
+  If `play/4` was invoked with type `:pipe`, `:raw`, or `:raw_s`, this will return `nil`
+  as the input is raw audio data, not be a readable URL string.
+  """
+  @doc since: "0.6.0"
+  @spec get_current_url(Guild.id()) :: String.t() | nil
+  def get_current_url(guild_id) do
+    voice = get_voice(guild_id)
+    if voice, do: voice.current_url
   end
 
   @doc """
@@ -792,6 +804,7 @@ defmodule Nostrum.Voice do
       ffmpeg_proc: ffmpeg_proc,
       raw_audio: raw_audio,
       raw_stateful: raw_stateful,
+      current_url: current_url,
       persist_source: persist_source,
       persist_playback: persist_playback
     } = voice
@@ -815,6 +828,7 @@ defmodule Nostrum.Voice do
             ffmpeg_proc: ffmpeg_proc,
             raw_audio: raw_audio,
             raw_stateful: raw_stateful,
+            current_url: current_url,
             persist_playback: persist_playback
           ],
           else: []

--- a/lib/nostrum/voice.ex
+++ b/lib/nostrum/voice.ex
@@ -706,6 +706,11 @@ defmodule Nostrum.Voice do
   RTP packet header contains info on the relative timestamps of incoming packets; the opus
   packets themselves don't contain information relating to timing.
 
+  The Discord client will continue to internally increment the `t:rtp_timestamp()` when the
+  user is not speaking such that the duration of pauses can be determined from the RTP packets.
+  Bots will typically not behave this way, so if you call this function on audio produced by
+  a bot it is very likely that no silence will be inserted.
+
   The use case of this function is as follows:
   Consider a user speaks for two seconds, pauses for ten seconds, then speaks for another two
   seconds. During the pause, no RTP packets will be received, so if you create a bitstream from

--- a/lib/nostrum/voice/audio.ex
+++ b/lib/nostrum/voice/audio.ex
@@ -104,8 +104,8 @@ defmodule Nostrum.Voice.Audio do
   end
 
   def take_nap(diff \\ 0) do
-    ((Opus.usec_per_frame() * frames_per_burst() - diff) / 1000)
-    |> trunc()
+    (Opus.usec_per_frame() * frames_per_burst() - diff)
+    |> div(1_000)
     |> max(0)
     |> Process.sleep()
   end

--- a/lib/nostrum/voice/audio.ex
+++ b/lib/nostrum/voice/audio.ex
@@ -86,21 +86,21 @@ defmodule Nostrum.Voice.Audio do
 
   def start_player(voice) do
     take_nap()
-    player_loop(voice, _init? = true, _source = get_source(voice))
+    player_loop(voice, _init? = true)
   end
 
   def resume_player(voice) do
-    player_loop(voice, _init? = false, _source = get_source(voice))
+    player_loop(voice, _init? = false)
   end
 
-  def player_loop(voice, init?, source) do
+  def player_loop(voice, init?) do
     t1 = Util.usec_now()
-    voice = try_send_data(voice, init?, source)
+    voice = try_send_data(voice, init?, get_source(voice))
     t2 = Util.usec_now()
 
     take_nap(t2 - t1)
 
-    player_loop(voice, false, source)
+    player_loop(voice, false)
   end
 
   def take_nap(diff \\ 0) do

--- a/lib/nostrum/voice/opus.ex
+++ b/lib/nostrum/voice/opus.ex
@@ -104,7 +104,7 @@ defmodule Nostrum.Voice.Opus do
         state = %{
           state
           | page_sequence: state.page_sequence + 1,
-            granule_position: state.granule_position + 960 * length(chunk)
+            granule_position: state.granule_position + @samples_per_frame * length(chunk)
         }
 
         {gen_page(chunk, state), state}

--- a/lib/nostrum/voice/payload.ex
+++ b/lib/nostrum/voice/payload.ex
@@ -67,6 +67,7 @@ defmodule Nostrum.Voice.Payload do
         guild_id: voice.guild_id,
         channel_id: voice.channel_id,
         speaking: voice.speaking,
+        current_url: voice.current_url,
         timed_out: timed_out
       }
     }

--- a/lib/nostrum/voice/ports.ex
+++ b/lib/nostrum/voice/ports.ex
@@ -123,7 +123,14 @@ defmodule Nostrum.Voice.Ports do
     unless is_nil(awaiter), do: GenServer.reply(awaiter, nil)
     if is_pid(input_pid), do: close(input_pid)
     Logger.debug("Closing port #{inspect(port)}")
-    Port.close(port)
+
+    # Safely try to close the port
+    try do
+      Port.close(port)
+    rescue
+      ArgumentError -> :noop
+    end
+
     {:stop, :shutdown, nil, nil}
   end
 


### PR DESCRIPTION
Lots of readability and performance improvements and extra info in docs

A number of things gleaned from niche use cases and edge cases encountered while heavily testing an audio bot:
- a fix to close ports safely
- new feature/fields for last played URL
- fixes for `:raw` type playing
- fix for rogue watchdog canceling subsequent audio if played immediately after stopping previous audio