### PR TITLE
Fix `check_token/1` for variable length tokens

### DIFF
--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -34,8 +34,7 @@ defmodule Nostrum.Application do
 
   defp check_token, do: check_token(Application.get_env(:nostrum, :token))
   defp check_token(nil), do: raise("Please supply a token")
-  defp check_token(<<_::192, 46, _::48, 46, _::216>>), do: :ok
-  defp check_token(<<_::192, 46, _::48, 46, _::304>>), do: :ok
+  defp check_token(<<_::192, 46, _::48, 46, _rest::binary>>), do: :ok
 
   defp check_token(_invalid_format),
     do: raise("Invalid token format, copy it again from the `Bot` tab of your Application")

--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -3,11 +3,13 @@ defmodule Nostrum.Application do
 
   use Application
 
+  alias Nostrum.Token
+
   require Logger
 
   @doc false
   def start(_type, _args) do
-    Nostrum.Token.check_token!()
+    Token.check_token!()
     check_executables()
     setup_ets_tables()
 

--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -35,6 +35,7 @@ defmodule Nostrum.Application do
   defp check_token, do: check_token(Application.get_env(:nostrum, :token))
   defp check_token(nil), do: raise("Please supply a token")
   defp check_token(<<_::192, 46, _::48, 46, _::216>>), do: :ok
+  defp check_token(<<_::192, 46, _::48, 46, _::304>>), do: :ok
 
   defp check_token(_invalid_format),
     do: raise("Invalid token format, copy it again from the `Bot` tab of your Application")

--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -7,7 +7,7 @@ defmodule Nostrum.Application do
 
   @doc false
   def start(_type, _args) do
-    check_token()
+    Nostrum.Token.check_token!()
     check_executables()
     setup_ets_tables()
 
@@ -31,16 +31,6 @@ defmodule Nostrum.Application do
     :ets.new(:guild_shard_map, [:set, :public, :named_table])
     :ets.new(:channel_guild_map, [:set, :public, :named_table])
   end
-
-  defp check_token, do: check_token(Application.get_env(:nostrum, :token))
-  defp check_token(nil), do: raise("Please supply a token")
-
-  defp check_token(<<_user_id::binary-size(24), 46, _ts::binary-size(6), 46, _hmac_auth::binary>>) do
-    :ok
-  end
-
-  defp check_token(_invalid_format),
-    do: raise("Invalid token format, copy it again from the `Bot` tab of your Application")
 
   defp check_executables do
     ff = Application.get_env(:nostrum, :ffmpeg)

--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -34,7 +34,10 @@ defmodule Nostrum.Application do
 
   defp check_token, do: check_token(Application.get_env(:nostrum, :token))
   defp check_token(nil), do: raise("Please supply a token")
-  defp check_token(<<_::192, 46, _::48, 46, _rest::binary>>), do: :ok
+
+  defp check_token(<<_user_id::binary-size(24), 46, _ts::binary-size(6), 46, _hmac_auth::binary>>) do
+    :ok
+  end
 
   defp check_token(_invalid_format),
     do: raise("Invalid token format, copy it again from the `Bot` tab of your Application")

--- a/lib/nostrum/token.ex
+++ b/lib/nostrum/token.ex
@@ -48,14 +48,13 @@ defmodule Nostrum.Token do
   end
 
   defp decode_user_id!(user_id) do
-    try do
+    _user_id =
       user_id
       |> :base64.decode_to_string()
       |> :erlang.list_to_integer()
 
-      :ok
-    rescue
-      _ -> raise(@invalid_token_error_message)
-    end
+    :ok
+  rescue
+    _ -> raise(@invalid_token_error_message)
   end
 end

--- a/lib/nostrum/token.ex
+++ b/lib/nostrum/token.ex
@@ -55,6 +55,11 @@ defmodule Nostrum.Token do
 
     :ok
   rescue
-    _ -> raise(@invalid_token_error_message)
+    exception ->
+      reraise(
+        RuntimeError,
+        [message: @invalid_token_error_message, exception: exception],
+        __STACKTRACE__
+      )
   end
 end

--- a/lib/nostrum/token.ex
+++ b/lib/nostrum/token.ex
@@ -1,0 +1,61 @@
+defmodule Nostrum.Token do
+  @moduledoc """
+  A helper module for verifying the Discord bot token.
+
+  The token can be generated in the "Bot" tab of your Application the [Discord Developer Portal](https://discord.com/developers/applications) and
+  can be configured in your config file.
+
+  ```elixir
+  config :nostrum,
+    token: "666" # The token of your bot as a string
+  ```
+  """
+
+  @invalid_token_error_message ~S[Invalid token format. Copy it again from the "Bot" tab of your Application in the Discord Developer Portal.]
+  @no_token_error_message "A bot token needs to be supplied in your config file"
+
+  @doc """
+  Checks if the Discord bot token has the correct format.
+
+  We check if the token is a binary followed by splitting it into 3 parts separated by a dot `"."`.
+  The first part is the Base64 encoded user_id which we decode and parse into as integer.
+  The second part is an encoded timestamp, and the last part an arbitrary cryptographic signature.
+
+  Raises on failure.
+
+  ## Examples
+
+      iex> token = "OTY4NTU2MzQ4MzkwMzkxODU5.G49NjP.pD8PLpKp-Xx8sr-8m1DCxSPTJZdcpcJZOExc1c"
+      iex> Nostrum.Token.check_token!(token)
+      :ok
+
+      iex> token = "ODY4MDcxODUzMDMyMzU3OTc4.YPqU6Q.jNJcq1daGG3otexX3c1LcxCpgpQ"
+      iex> Nostrum.Token.check_token!(token)
+      :ok
+  """
+  def check_token!, do: check_token!(Application.get_env(:nostrum, :token))
+  def check_token!(nil), do: raise(@no_token_error_message)
+
+  def check_token!(<<user_id::binary-size(24), 46, _ts::binary-size(6), 46, _hmac_auth::binary>>) do
+    decode_user_id!(user_id)
+  end
+
+  def check_token!(token) when is_binary(token) do
+    case String.split(token, ".") do
+      [user_id, _timestamp, _hmac_auth] -> decode_user_id!(user_id)
+      _ -> raise(@invalid_token_error_message)
+    end
+  end
+
+  defp decode_user_id!(user_id) do
+    try do
+      user_id
+      |> :base64.decode_to_string()
+      |> :erlang.list_to_integer()
+
+      :ok
+    rescue
+      _ -> raise(@invalid_token_error_message)
+    end
+  end
+end

--- a/test/nostrum/token_test.exs
+++ b/test/nostrum/token_test.exs
@@ -1,0 +1,23 @@
+defmodule Nostrum.TokenTest do
+  use ExUnit.Case, async: true
+
+  alias Nostrum.Token
+
+  doctest Token
+
+  describe "check_token!/1" do
+    test "raises on non set token" do
+      assert_raise RuntimeError, "A bot token needs to be supplied in your config file", fn ->
+        Token.check_token!(nil)
+      end
+    end
+
+    test "raises on wrong token format" do
+      assert_raise RuntimeError,
+                   ~S[Invalid token format. Copy it again from the "Bot" tab of your Application in the Discord Developer Portal.],
+                   fn ->
+                     Token.check_token!("666")
+                   end
+    end
+  end
+end


### PR DESCRIPTION
Generating a Discord Bot Token will sometimes return a longer token format than what the `check_token/1` function is checking for.

This will currently throw the following error:

```elixir
** (Mix) Could not start application nostrum: exited in: Nostrum.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (RuntimeError) Invalid token format, copy it again from the `Bot` tab of your Application
            (nostrum 0.5.1) lib/nostrum/application.ex:40: Nostrum.Application.check_token/1
            (nostrum 0.5.1) lib/nostrum/application.ex:10: Nostrum.Application.start/2
            (kernel 8.2) application_master.erl:293: :application_master.start_it_old/4
```

I wasn't able to reliably find a triggering setting but this is an example token (Already resetted, so it's unusable)

`OTY4NTU2MzQ4MzkwMzkxODU5.G49NjP.pD8PLpKp-Xx8sr-8m1DCxSPTJZdcpcJZOExc1c`

This PR replaces the `Nostrum.Application.check_token/1` function with the `Nostrum.Token.check_token!` function.

It pattern matches on a variable hash for the last part of the binary token and additionally tries to decode the `user_id` which is the first part of the binary token.