### PR TITLE
support non padded base64 userid in the discord bot tokens

### DIFF
--- a/lib/nostrum/token.ex
+++ b/lib/nostrum/token.ex
@@ -50,8 +50,8 @@ defmodule Nostrum.Token do
   defp decode_user_id!(user_id) do
     _user_id =
       user_id
-      |> :base64.decode_to_string()
-      |> :erlang.list_to_integer()
+      |> Base.decode64!(padding: false)
+      |> String.to_integer()
 
     :ok
   rescue


### PR DESCRIPTION
i was running into problems starting the bot and noticed my userid in the discord token was not a multiple of 4 and also not padded. using elixir modules for base64 seems to solve this by passing the padding: false option. not sure if there's a reason to stick with erlang modules though.