### PR TITLE
Add information to Api Rest only section

### DIFF
--- a/docs/static/API.md
+++ b/docs/static/API.md
@@ -59,5 +59,8 @@ The ratelimiter at a high level works something like this:
 ## Rest Only
 If you only want to use the REST portion of the provided API, the only process
 needed is the ratelimiter. This can be manually started by calling
-`Nostrum.Api.Ratelimiter.start_link/1`. If you don't want to start Nostrum you
-can add `runtime: false` to the dependency options.
+`Nostrum.Api.Ratelimiter.start_link/1`. 
+If you don't want to start Nostrum you can add `runtime: false` to the dependency
+options. If you're using `mix release`, all `runtime: false` deps will be exluded
+from build, so you'll also need to add `:nostrum` app to `mix.exs`
+in `:included_applications` application option or in `releases` project option.


### PR DESCRIPTION
While using Nostrum with Rest Only approach, an error occurred in runtime of build (released with mix release):
```
[info] Application example exited: exited in: Example.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (ArgumentError) The module Nostrum.Api.Ratelimiter was given as a child to a supervisor but it does not exist.
            (elixir 1.12.2) lib/supervisor.ex:631: Supervisor.init_child/1
```

The cause of it related to all `runtime: false` deps are not included into build, while building with `mix release`. 
I decided to add this info to docs as a time saver for devs, who will meet this non-obvious problem only in production.