### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ config :nostrum,
   token: "666" # The token of your bot as a string
 ```
 
-Note that due to Discord API changes, in order to receive message content (e.g.
+> **Note:** Due to Discord API changes, _in order to receive message content_ (e.g.
 for non-slash commands or moderation tools), you need to have the "Message
 Content Intent" enabled on your [Bot's application
 settings](https://discord.com/developers/applications/), and the


### PR DESCRIPTION
Emphasize message content intent warning

### Why
This change adds highlighting and italics to a section which, if missed, can create confusion on why a bot cannot reply to user input despite receiving the message.

E.g., the `msg` struct will have `''` in the `content` field, which fails the `case` statement.
![Screen Shot 2022-08-06 at 11 51 34 AM](https://user-images.githubusercontent.com/8475488/183262287-1b7fe7cd-3c51-45ac-b3d7-a8df7ca23ecd.png)

