### PR TITLE
Add "--no-warnings" to ytdl command-line options

### DIFF
--- a/lib/nostrum/voice/audio.ex
+++ b/lib/nostrum/voice/audio.ex
@@ -171,6 +171,7 @@ defmodule Nostrum.Voice.Audio do
           ["-f", "bestaudio"],
           ["-o", "-"],
           ["-q"],
+          ["--no-warnings"],
           [url]
         ]
         |> List.flatten()


### PR DESCRIPTION
Fixes a bug where certain videos wouldn't play.

Example video that Nostrum won't play: https://www.youtube.com/watch?v=NjgFKUooYHY

In more detail, the bug occurs when yt-dlp/youtube-dl prints a warning to stderr. Since stderr is redirected to stdout, the warning text will be present at the top or near the start of the output which is sent to ffmpeg, which obviously causes issues when ffmpeg tries to transcode the audio.

The following warning is printed out by yt-dlp (dunno how it is for youtube-dl) when trying to download the video above: `WARNING: [youtube] nsig extraction failed: You may experience throttling for some formats
n = Y4TUHHipURV8t0Kjw4 ; player = https://www.youtube.com/s/player/4c3f79c5/player_ias.vflset/en_US/base.js`

Adding "--no-warnings" to the command-line options causes that warning to be suppressed and fixes the issue where that video (and most certainly more) simply wouldn't play.