### PR TITLE
incorrect typespec for options in ApplicationCommandInteractionData

### DIFF
--- a/lib/nostrum/struct/application_command_interaction_data.ex
+++ b/lib/nostrum/struct/application_command_interaction_data.ex
@@ -34,7 +34,7 @@ defmodule Nostrum.Struct.ApplicationCommandInteractionData do
   @type resolved :: ApplicationCommandInteractionDataResolved.t() | nil
 
   @typedoc "Parameters and values supplied by the user, if applicable"
-  @type options :: ApplicationCommandInteractionDataOption.t() | nil
+  @type options :: [ApplicationCommandInteractionDataOption.t()] | nil
 
   @typedoc "For components, the ``custom_id`` of the component"
   @typedoc since: "0.5.0"


### PR DESCRIPTION
Brought up in issue 434 https://github.com/Kraigie/nostrum/issues/434 
Checked code and seems to fix the dialyzer warning.