### PR TITLE
Accept RTP packet without header

### DIFF
--- a/lib/nostrum/voice/opus.ex
+++ b/lib/nostrum/voice/opus.ex
@@ -42,6 +42,8 @@ defmodule Nostrum.Voice.Opus do
       ),
       do: rest
 
+  def strip_rtp_ext(packet), do: packet
+
   def parse_ogg(<<>>), do: []
 
   def parse_ogg(binary) do


### PR DESCRIPTION
Discord sometimes sends us RTP packets without headers, which make nostrum crash with the following error:
```
20:52:08.330 [error] GenServer #PID<0.765.0> terminating
** (FunctionClauseError) no function clause matching in Nostrum.Voice.Opus.strip_rtp_ext/1
    (nostrum 0.6.1) lib/nostrum/voice/opus.ex:34: Nostrum.Voice.Opus.strip_rtp_ext(<<252, 255, 254>>)
    (nostrum 0.6.1) lib/nostrum/voice/session.ex:154: Nostrum.Voice.Session.handle_info/2
    (stdlib 4.0.1) gen_server.erl:1120: :gen_server.try_dispatch/4
    (stdlib 4.0.1) gen_server.erl:1197: :gen_server.handle_msg/6
    (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```
This patch fixes this problem. I believe discord.js processes RTP packets in the same way as this patch ([here](https://github.com/discordjs/discord.js/blob/d8e774138d5ab0333a767599e5470b4ea3f35ba5/packages/voice/src/receive/VoiceReceiver.ts#L120-L126)).