### PR TITLE
Support role icons

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1959,6 +1959,7 @@ defmodule Nostrum.Api do
     * `:color` (integer) - RGB color value (default: 0)
     * `:hoist` (boolean) - whether the role should be displayed separately in the sidebar (default: false)
     * `:mentionable` (boolean) - whether the role should be mentionable (default: false)
+    * `:icon` (string) - URL role icon (default: `nil`)
 
   ## Examples
 

--- a/lib/nostrum/struct/guild/role.ex
+++ b/lib/nostrum/struct/guild/role.ex
@@ -61,7 +61,7 @@ defmodule Nostrum.Struct.Guild.Role do
   @type mentionable :: boolean
 
   @typedoc "The hash of the role icon"
-  @type icon :: String.t()
+  @type icon :: String.t() | nil
 
   @type t :: %__MODULE__{
           id: id,

--- a/lib/nostrum/struct/guild/role.ex
+++ b/lib/nostrum/struct/guild/role.ex
@@ -28,7 +28,8 @@ defmodule Nostrum.Struct.Guild.Role do
     :position,
     :permissions,
     :managed,
-    :mentionable
+    :mentionable,
+    :icon
   ]
 
   defimpl String.Chars do
@@ -59,6 +60,9 @@ defmodule Nostrum.Struct.Guild.Role do
   @typedoc "Whether the role is mentionable"
   @type mentionable :: boolean
 
+  @typedoc "The hash of the role icon"
+  @type icon :: String.t()
+
   @type t :: %__MODULE__{
           id: id,
           name: name,
@@ -67,7 +71,8 @@ defmodule Nostrum.Struct.Guild.Role do
           position: position,
           permissions: permissions,
           managed: managed,
-          mentionable: mentionable
+          mentionable: mentionable,
+          icon: icon
         }
 
   @doc ~S"""

--- a/test/nostrum/struct/guild/role_test.exs
+++ b/test/nostrum/struct/guild/role_test.exs
@@ -23,7 +23,8 @@ defmodule Nostrum.Struct.Guild.RoleTest do
         "position" => 1,
         "permissions" => "8559918328",
         "managed" => false,
-        "mentionable" => true
+        "mentionable" => true,
+        "icon" => "abc123"
       }
 
       role = Role.to_struct(etf_role)


### PR DESCRIPTION
Tested this with a local copy and it seems to properly populate the `:icon` field into the struct from the API response.