### PR TITLE
Support emoji role icons

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -1979,6 +1979,7 @@ defmodule Nostrum.Api do
     * `:hoist` (boolean) - whether the role should be displayed separately in the sidebar (default: false)
     * `:mentionable` (boolean) - whether the role should be mentionable (default: false)
     * `:icon` (string) - URL role icon (default: `nil`)
+    * `:unicode_emoji` (string) - standard unicode character emoji role icon (default: `nil`)
 
   ## Examples
 

--- a/lib/nostrum/struct/guild/role.ex
+++ b/lib/nostrum/struct/guild/role.ex
@@ -29,7 +29,8 @@ defmodule Nostrum.Struct.Guild.Role do
     :permissions,
     :managed,
     :mentionable,
-    :icon
+    :icon,
+    :unicode_emoji
   ]
 
   defimpl String.Chars do
@@ -64,6 +65,10 @@ defmodule Nostrum.Struct.Guild.Role do
   @typedoc since: "0.7.0"
   @type icon :: String.t() | nil
 
+  @typedoc "The standard unicode character emoji icon for the role"
+  @typedoc since: "0.7.0"
+  @type unicode_emoji :: String.t() | nil
+
   @type t :: %__MODULE__{
           id: id,
           name: name,
@@ -73,7 +78,8 @@ defmodule Nostrum.Struct.Guild.Role do
           permissions: permissions,
           managed: managed,
           mentionable: mentionable,
-          icon: icon
+          icon: icon,
+          unicode_emoji: unicode_emoji
         }
 
   @doc ~S"""

--- a/test/nostrum/struct/guild/role_test.exs
+++ b/test/nostrum/struct/guild/role_test.exs
@@ -24,7 +24,8 @@ defmodule Nostrum.Struct.Guild.RoleTest do
         "permissions" => "8559918328",
         "managed" => false,
         "mentionable" => true,
-        "icon" => "abc123"
+        "icon" => "abc123",
+        "unicode_emoji" => "🧪"
       }
 
       role = Role.to_struct(etf_role)


### PR DESCRIPTION
Apparently the image icon (from #441) is separate from the emoji icon, so we need this too.