### PR TITLE
Fix cast call in thread list API call

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -4024,8 +4024,8 @@ defmodule Nostrum.Api do
     case res do
       {:ok, %{threads: channels, members: thread_members, has_more: has_more}} ->
         map = %{
-          threads: Util.cast({:list, {:struct, Channel}}, channels),
-          members: Util.cast({:list, {:struct, ThreadMember}}, thread_members),
+          threads: Util.cast(channels, {:list, {:struct, Channel}}),
+          members: Util.cast(thread_members, {:list, {:struct, ThreadMember}}),
           has_more: has_more
         }
 


### PR DESCRIPTION
This fixes a bug where `Util.cast` was being called incorrectly, where the arguments were swapped. 

See discussion on Discord here: https://canary.discord.com/channels/81384788765712384/381889573426429952/1048980360949661736