### PR TITLE
Minor voice refactors and improve get reactions api call

### DIFF
--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -357,7 +357,7 @@ defmodule Nostrum.Shard.Dispatch do
 
           # Already in this channel:
           true ->
-            Voice.update_voice(p.guild_id)
+            :noop
         end
       else
         # Leaving Channel:

--- a/lib/nostrum/shard/supervisor.ex
+++ b/lib/nostrum/shard/supervisor.ex
@@ -56,16 +56,10 @@ defmodule Nostrum.Shard.Supervisor do
 
   def update_voice_state(guild_id, channel_id, self_mute, self_deaf) do
     case GuildShard.get_shard(guild_id) do
-      {:ok, shard_id} ->
-        ShardSupervisor
+      {:ok, shard_num} ->
+        :"Shard-#{shard_num}"
         |> Supervisor.which_children()
-        |> Enum.filter(fn {id, _pid, _type, [modules]} ->
-          modules == Nostrum.Shard and id == shard_id
-        end)
-        |> Enum.map(fn {_id, pid, _type, _modules} -> Supervisor.which_children(pid) end)
-        |> List.flatten()
-        |> Enum.filter(fn {_id, _pid, _type, [modules]} -> modules == Nostrum.Shard.Session end)
-        |> List.first()
+        |> Enum.find(fn {id, _pid, _type, _modules} -> id == Nostrum.Shard.Session end)
         |> elem(1)
         |> Session.update_voice_state(guild_id, channel_id, self_mute, self_deaf)
 

--- a/lib/nostrum/struct/voice_state.ex
+++ b/lib/nostrum/struct/voice_state.ex
@@ -3,7 +3,6 @@ defmodule Nostrum.Struct.VoiceState do
 
   alias Nostrum.Voice.Ports
   alias Nostrum.Voice.Session
-  alias Nostrum.Voice.Supervisor, as: VoiceSupervisor
 
   defstruct [
     :guild_id,
@@ -69,25 +68,11 @@ defmodule Nostrum.Struct.VoiceState do
     if is_port(v.udp_socket),
       do: :gen_udp.close(v.udp_socket)
 
-    if is_pid(v.session_pid) do
-      Session.close_connection(v.session_pid)
-      delete_session_async(v)
-    else
-      VoiceSupervisor.delete_session(v.guild_id)
-    end
+    if is_pid(v.session_pid),
+      do: Session.close_connection(v.session_pid)
 
     :ok
   end
 
   def cleanup(_), do: :ok
-
-  defp delete_session_async(%__MODULE__{session_pid: pid, guild_id: guild_id}) do
-    spawn(fn ->
-      Process.monitor(pid)
-
-      receive do
-        _ -> VoiceSupervisor.delete_session(guild_id)
-      end
-    end)
-  end
 end

--- a/lib/nostrum/voice.ex
+++ b/lib/nostrum/voice.ex
@@ -118,7 +118,7 @@ defmodule Nostrum.Voice do
 
   @doc false
   def remove_voice(guild_id) do
-    GenServer.call(VoiceStateMap, {:remove, guild_id})
+    GenServer.cast(VoiceStateMap, {:remove, guild_id})
   end
 
   @doc """
@@ -762,11 +762,9 @@ defmodule Nostrum.Voice do
   end
 
   @doc false
-  def handle_call({:remove, guild_id}, _from, state) do
-    state[guild_id] |> VoiceState.cleanup()
-    VoiceSupervisor.end_session(guild_id)
-
-    {:reply, true, Map.delete(state, guild_id)}
+  def handle_cast({:remove, guild_id}, state) do
+    VoiceState.cleanup(state[guild_id])
+    {:noreply, Map.delete(state, guild_id)}
   end
 
   @doc false

--- a/lib/nostrum/voice/ports.ex
+++ b/lib/nostrum/voice/ports.ex
@@ -100,7 +100,7 @@ defmodule Nostrum.Voice.Ports do
   @spec close(pid()) :: no_return()
   def close(pid) do
     if Process.alive?(pid),
-      do: GenServer.call(pid, :close)
+      do: GenServer.cast(pid, :close)
   end
 
   def handle_call(:get, _from, %{q: q, port_done: true} = state) do
@@ -119,7 +119,7 @@ defmodule Nostrum.Voice.Ports do
     end
   end
 
-  def handle_call(:close, _from, %{awaiter: awaiter, port: port, input_pid: input_pid}) do
+  def handle_cast(:close, %{awaiter: awaiter, port: port, input_pid: input_pid}) do
     unless is_nil(awaiter), do: GenServer.reply(awaiter, nil)
     if is_pid(input_pid), do: close(input_pid)
     Logger.debug("Closing port #{inspect(port)}")
@@ -131,7 +131,7 @@ defmodule Nostrum.Voice.Ports do
       ArgumentError -> :noop
     end
 
-    {:stop, :shutdown, nil, nil}
+    {:stop, :shutdown, nil}
   end
 
   def handle_info({_port, {:data, data}}, %{q: q, awaiter: nil} = state) do

--- a/lib/nostrum/voice/supervisor.ex
+++ b/lib/nostrum/voice/supervisor.ex
@@ -14,6 +14,7 @@ defmodule Nostrum.Voice.Supervisor do
 
   def init(_opts) do
     children = [
+      {DynamicSupervisor, strategy: :one_for_one, name: VoiceSessionSupervisor},
       Nostrum.Voice
     ]
 
@@ -31,10 +32,6 @@ defmodule Nostrum.Voice.Supervisor do
       restart: :transient
     }
 
-    Supervisor.start_child(VoiceSupervisor, child)
-  end
-
-  def delete_session(guild_id) do
-    VoiceSupervisor |> Supervisor.delete_child(guild_id)
+    DynamicSupervisor.start_child(VoiceSessionSupervisor, child)
   end
 end

--- a/lib/nostrum/voice/supervisor.ex
+++ b/lib/nostrum/voice/supervisor.ex
@@ -27,14 +27,14 @@ defmodule Nostrum.Voice.Supervisor do
   def create_session(%VoiceState{} = voice) do
     child = %{
       id: voice.guild_id,
-      start: {Session, :start_link, [voice]}
+      start: {Session, :start_link, [voice]},
+      restart: :transient
     }
 
     Supervisor.start_child(VoiceSupervisor, child)
   end
 
-  def end_session(guild_id) do
-    VoiceSupervisor |> Supervisor.terminate_child(guild_id)
+  def delete_session(guild_id) do
     VoiceSupervisor |> Supervisor.delete_child(guild_id)
   end
 end


### PR DESCRIPTION
I had noticed my bot hell looping trying to reconnect after getting a voice ws error 4006 so I'm leaving less to chance when sequencing events for reconnecting. Using cast in some places to reduce blocking processes. The get reactions api changes are unrelated because I forgot I had those unstaged changes in my branch.