### PR TITLE
Fix button status

### DIFF
--- a/lib/nostrum/struct/component/button.ex
+++ b/lib/nostrum/struct/component/button.ex
@@ -105,31 +105,18 @@ defmodule Nostrum.Struct.Component.Button do
   """
   def toggle(%{type: 2, disabled: button_state} = button) do
     button
-    |> struct({:disabled, !button_state})
+    |> struct([{:disabled, !button_state}])
   end
 
   def toggle(_), do: buttons_only()
 
   @doc """
-  Disables the button.
+  Enables the button when `enabled` is true. Disables it otherwise.
   """
-
-  def disable(%{type: 2} = button) do
+  def enable(%{type: 2} = button, enabled) do
     button
-    |> update({:disabled, true})
+    |> update([{:disabled, !enabled}])
   end
-
-  def disable(_), do: buttons_only()
-
-  @doc """
-  Enables the button.
-  """
-  def enable(%{type: 2} = button) do
-    button
-    |> update({:disabled, false})
-  end
-
-  def enable(_), do: buttons_only()
 
   @doc """
   Changes the style of the button.

--- a/lib/nostrum/struct/component/button.ex
+++ b/lib/nostrum/struct/component/button.ex
@@ -111,11 +111,11 @@ defmodule Nostrum.Struct.Component.Button do
   def toggle(_), do: buttons_only()
 
   @doc """
-  Enables the button when `enabled` is true. Disables it otherwise.
+  Disables the button when `disabled` is true. Enables it otherwise.
   """
-  def enable(%{type: 2} = button, enabled) do
+  def disable(%{type: 2} = button, disabled) do
     button
-    |> update([{:disabled, !enabled}])
+    |> update([{:disabled, disabled}])
   end
 
   @doc """


### PR DESCRIPTION
Replaces the functions `enable/1` and `disable/1` from `Nostrum.Struct.Component.Button` with the function `enable/2` and fixes a crash in `toggle/1`