### PR TITLE
Managed application commands

### DIFF
--- a/docs/static/Application Commands.md
+++ b/docs/static/Application Commands.md
@@ -112,10 +112,12 @@ option list to a map.
 
 Did you notice the ``:ignore`` at the end of our function clauses? It's telling
 Nostrum to not send anything back to the user. Although our command performs
-its job, the lack of a response forces Discord to display "The application did
-not respond" to the user.
+its job, the lack of a response forces Discord to display "YourBot is thinking"
+to the user for 15 minutes until eventually giving up and switching that to
+"The application did not respond".
 
-To respond with something meaningful, simply return a map like the following:
+To respond with something more meaningful, simply return a map like the
+following:
 
 ```elixir
 def handle(interaction, %{"action" => "assign", "name" => role_id}) do

--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -21,9 +21,15 @@ defmodule Nostrum.Application do
       Nostrum.Voice.Supervisor
     ]
 
-    if Application.get_env(:nostrum, :dev),
-      do: Supervisor.start_link(children ++ [DummySupervisor], strategy: :one_for_one),
-      else: Supervisor.start_link(children, strategy: :one_for_one)
+    children = if Application.get_env(:nostrum, :managed_commands) do
+      children ++ [Nostrum.Command]
+    else children end
+
+    children = if Application.get_env(:nostrum, :dev) do
+      children ++ [DummySupervisor]
+    else children end
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: Nostrum.Supervisor)
   end
 
   @doc false

--- a/lib/nostrum/command.ex
+++ b/lib/nostrum/command.ex
@@ -1,0 +1,171 @@
+defmodule Nostrum.Command do
+  alias Nostrum.{Api, Consumer, Struct.Interaction}
+  use Consumer
+  require Logger
+
+  @moduledoc ~S"""
+  Reduces boilerplate when implementing application commands.
+
+  Here's an example module that responds with "pong!" to /ping:
+  ```Elixir
+  defmodule MyBot.PingCommand do
+    use Nostrum.Command, %Nostrum.Command.Spec{
+      name: "ping",
+      desc: "sends back pong"
+    }
+
+    def handle(interaction, _options) do
+      %{content: "pong!"}
+    end
+  end
+  ```
+
+  This one calculates the sum of two integers:
+  ```Elixir
+  defmodule MyBot.SumCommand do
+    use Nostrum.Command, %Nostrum.Command.Spec{
+      name: "sum",
+      desc: "adds two integers together",
+      options: [
+        %Nostrum.Command.Spec.Option{
+          name: "a",
+          desc: "first number",
+          type: :integer
+        },
+        %Nostrum.Command.Spec.Option{
+          name: "b",
+          desc: "second number",
+          type: :integer
+        }
+      ]
+    }
+
+    def handle(_interaction, options = %{"a" => a, "b" => b}) do
+      %{content: "The sum of #{a} and #{b} is #{a + b}"}
+    end
+  end
+  ```
+
+  And this one evaluates an Elixir expression (WARNING: very unsafe):
+  ```Elixir
+  defmodule MyBot.EvalCommand do
+    use Nostrum.Command, %Nostrum.Command.Spec{
+      name: "eval",
+      desc: "evaluates an Elixir expression",
+      options: [
+        %Nostrum.Command.Spec.Option{
+          name: "expression",
+          desc: "expression to evaluate",
+          type: :string
+        }
+      ]
+    }
+
+    def handle(_interaction, options = %{"expression" => expr}) do
+      {result, _} = Code.eval_string(expr)
+      %{content: "`#{inspect(result)}`"}
+    end
+  end
+  ```
+
+  Note that in order for these commands to work, you should tell Nostrum about
+  them:
+  ```Elixir
+  config :nostrum,
+    managed_commands: [
+      MyBot.PingCommand,
+      MyBot.SumCommand,
+      MyBot.EvalCommand
+    ]
+  ```
+  """
+
+  defmacro __using__(specification) do
+    quote do
+      @behaviour Nostrum.Command
+      def spec, do: unquote(specification)
+    end
+  end
+
+  @doc """
+  Should return the specification of the command as a `Nostrum.Command.Spec`
+  struct
+  """
+  @callback spec() :: __MODULE__.Spec.t
+
+  @doc """
+  Gets called when the command is invoked. If `mode` in the spec is set to
+  `:unmanaged`, the return value is ignored. Other values for this setting
+  (`:managed` and `:ephemeral`) do consider the return value:
+    - `:ignore` does nothing. The user will continue to see the "Your Bot is
+    thinking" message for the next 15 minutes, after which it will be replaced
+    with "The application did not respond"
+    - `:delete` deletes the "Your Bot is thinking" message
+    - `{:post, :delete, post}` deletes the "Your Bot is thinking" message and
+    invokes `module.post_handle(post)` ignoring its return values
+    - `{:post, data, post}` edits the response to `data` and invokes
+    `module.post_handle(post)` ignoring its return values
+    - `data` edits the response to `data`
+  """
+  @callback handle(Interaction.t, %{String.t => String.t | number()}) ::
+    :ignore | :delete | map() | {:post, map() | :delete, term()}
+
+  @doc """
+  Gets called with the argument `post` after calling `handle` if it returned
+  `{:post, _, post}` in `:managed` or `:ephemeral` mode
+  """
+  @callback post_handle(term()) :: term()
+
+  # TODO: autocomplete
+  @callback handle_autocomplete(term()) :: term()
+  @optional_callbacks post_handle: 1, handle_autocomplete: 1
+
+  def start_link(), do: Consumer.start_link(__MODULE__)
+
+  def handle_event({:READY, _, _}) do
+    Logger.debug("command consumer started")
+    {:ok, _} = Supervisor.start_child(Nostrum.Supervisor, __MODULE__.Holder)
+  end
+
+  def handle_event({:INTERACTION_CREATE, %Interaction{data: %{name: command}} = interaction, _}) when command != nil do
+    Logger.debug("received /#{command} invocation")
+
+    case __MODULE__.Holder.get_command(command) do
+      {:ok, {module, mode}} ->
+        defer = mode == :managed || mode == :ephemeral
+        if defer do
+          flags = if mode == :ephemeral do 64 else 0 end
+          Api.create_interaction_response!(interaction, %{type: 5, data: %{flags: flags}})
+        end
+
+        options = if interaction.data.options do
+          Enum.map(interaction.data.options, fn %{name: name, value: value} -> {name, value} end)
+          |> Enum.into(%{})
+        else [] end
+
+        case module.handle(interaction, options) do
+          _ when not defer -> :ok
+          :ignore -> :ok
+
+          :delete ->
+            Api.delete_interaction_response!(interaction)
+
+          data when is_map(data) ->
+            Api.edit_interaction_response!(interaction, data)
+
+          {:post, :delete, post} ->
+            Api.delete_interaction_response!(interaction)
+            module.post_handle(post)
+
+          {:post, data, post} ->
+            Api.edit_interaction_response!(interaction, data)
+            module.post_handle(post)
+        end
+
+      {:error, :unknown} ->
+        Logger.warning("unknown command /#{command} invoked. is it listed under :managed_commands?")
+    end
+  end
+
+  def handle_event(_), do: :ok
+end

--- a/lib/nostrum/command/holder.ex
+++ b/lib/nostrum/command/holder.ex
@@ -1,0 +1,38 @@
+defmodule Nostrum.Command.Holder do
+  use GenServer
+  require Logger
+
+  @moduledoc """
+  Loads and registers managed slash commands
+  """
+
+  def start_link(args), do: GenServer.start_link(__MODULE__, args, name: __MODULE__)
+
+  def init(_args) do
+    table = :ets.new(Nostrum.ManagedCommands, [:named_table, :public, :set])
+
+    modules = Application.get_env(:nostrum, :managed_commands)
+
+    commands = for module <- modules do
+      spec = module.spec()
+      name = case spec.name do
+        {fb, _} -> fb
+        name -> name
+      end
+      :ets.insert(table, {name, module, spec.mode})
+      Nostrum.Command.Spec.to_application_command_struct(spec)
+    end
+
+    {:ok, _} = Nostrum.Api.bulk_overwrite_global_application_commands(commands)
+    Logger.info("loaded #{length(commands)} application commands")
+
+    {:ok, table}
+  end
+
+  def get_command(name) do
+    case :ets.lookup(Nostrum.ManagedCommands, name) do
+      [] -> {:error, :unknown}
+      [{^name, module, mode}] -> {:ok, {module, mode}}
+    end
+  end
+end

--- a/lib/nostrum/command/spec.ex
+++ b/lib/nostrum/command/spec.ex
@@ -1,0 +1,217 @@
+defmodule Nostrum.Command.Spec do
+  @moduledoc """
+  Specifies the application command:
+    - `name`: localizable (see below) name of the command
+    - `desc`: localizable description of the command
+    - `default_perms`: default permissions of the command as a bit set (set to
+    "0" to restrict the command as admin-only by default)
+    - `type`: one of `:chat_input` (slash command), `{:context, :user}` (user
+    context menu) or `{:context, :message}` (message context menu)
+    - `options`: list of options (see `Nostrum.Command.Spec.Option`)
+    - `nsfw`: `true` if age-restricted (`false` by default),
+    - `dm`: `true` if can be executed in DMs (`true` by default)
+    - `mode`:
+      - `:unmanaged` just invokes your handler. You are responsible for replying
+      to the interaction. The return value of the handler is ignored.
+      - `:managed` invokes your handler and replies to the interaction based on
+      what it returns
+      - `:ephemeral` acts like `:managed`, but makes the response ephemeral
+
+  "Localizable" fields (`name` and `desc`, along with some others in the `Option`
+  struct) are either:
+    - `"plain strings"` (no localization is done)
+    - `{"fallback string", %{"la-NG" => "trąnśłatioń"}}`
+  """
+
+  @type localizable() :: String.t | {fallback :: String.t, %{locale :: String.t() => translation :: String.t}}
+
+  @enforce_keys [:name, :desc]
+  defstruct [
+    :name,
+    :desc,
+    :default_perms,
+    type: :chat_input,
+    options: [],
+    nsfw: false,
+    dm: true,
+    mode: :managed
+  ]
+  @type t :: %__MODULE__{
+    name: localizable(),
+    desc: localizable(),
+    default_perms: String.t,
+    type: :chat_input | {:context, :user | :message},
+    options: [__MODULE__.Option.t],
+    nsfw: boolean(),
+    dm: boolean(),
+    mode: :unmanaged | :managed | :ephemeral
+  }
+
+  defmodule Option do
+    @moduledoc """
+    Specifies an option of an application command:
+      - `name`: localizable (see `Nostrum.Command.Spec`) name of the option
+      - `desc`: localizable description of the option
+      - `type`: one of `:subcmd` (subcommand), `:subcmd_group` (subcommand
+      group), `:string`, `:integer` (-2^53 to 2^53), `:bool`, `:user`,
+      `:channel`, `:role`, `:mentionable`, `:double` (same range as `:integer`) or
+      `:attachment`
+      - `choices`: list of:
+        - `name`: localizable name of the option choice
+        - `value`: value of the option choice
+      - `options`: list of options if the `type` is `:subcmd` or `:subcmd_group`
+      - `channel_types`: list of `:text`, `:dm`, `:voice`, `:group`, `:category`,
+      `:announcement`, `{:thread, :announcement}`, `{:thread, :public}`,
+      `{:thread, :private}`, `:stage`, `:guild_directory` or `:forum` if the
+      `type` is `:channel`
+      - `value_range`: range of permissible values if the `type` is `:integer`
+      or `:double`
+      - `length_range`: range of permissible lengths if the `type` is `:string`
+      - `autocomplete`: whether the option supports autocompletion
+      (`choices` can't be set if this is true)
+      - `required`: whether this option is required (true by default)
+
+    Note that for `value_range` and `length_range` either of the ends can be
+    set to `Option.ignore_end` to tell Discord to not enforce that end of the
+    range
+    """
+
+    @enforce_keys [:name, :desc, :type]
+    defstruct [
+      :name,
+      :desc,
+      :type,
+      choices: nil,
+      options: [],
+      channel_types: [],
+      value_range: nil,
+      length_range: nil,
+      autocomplete: false,
+      required: true,
+    ]
+    @type t :: %__MODULE__{
+      name: Nostrum.Command.Spec.localizable,
+      desc: Nostrum.Command.Spec.localizable,
+      type: :subcmd | :subcmd_group | :string | :integer | :bool | :user
+          | :channel | :role | :mentionable | :double | :attachment,
+      choices: [%{
+        name: Nostrum.Command.Spec.localizable,
+        value: String.t | number()
+      }],
+      options: [__MODULE__.t],
+      channel_types: [:text | :dm | :voice | :group | :category | :announcement
+                    | {:thread, :announcement | :public | :private}
+                    | :stage | :guild_directory | :forum],
+      value_range: Range.t,
+      length_range: Range.t,
+      autocomplete: boolean()
+    }
+
+    @doc """
+    Use this value in place of either end of `value_range` and `length_range`
+    to tell Discord that this end should not be enforced:
+    ```elixir
+    alias Nostrum.Command.Spec.Option
+    Option.ignore_end..10
+    10..Option.ignore_end
+    ```
+    """
+    def ignore_end, do: 2 ** 54
+
+    def to_app_cmd_struct_option(%__MODULE__{} = spec) do
+      struct = %{
+        type: Map.get(%{
+          subcmd: 1,
+          subcmd_group: 2,
+          string: 3,
+          integer: 4,
+          bool: 5,
+          user: 6,
+          channel: 7,
+          role: 8,
+          mentionable: 9,
+          double: 10,
+          attachment: 11
+        }, spec.type),
+        required: spec.required,
+        autocomplete: spec.autocomplete
+      }
+      |> Nostrum.Command.Spec.add_localizable(spec.name, :name, :name_localizations)
+      |> Nostrum.Command.Spec.add_localizable(spec.desc, :description, :description_localizations)
+      |> add_range(spec.value_range, :min_value, :max_value)
+      |> add_range(spec.length_range, :min_length, :max_length)
+
+      struct = if spec.options do
+        options = Enum.map(spec.options, &to_app_cmd_struct_option/1)
+        Map.put(struct, :options, options)
+      else struct end
+
+      struct = if spec.channel_types do
+        channel_types = Enum.map(spec.channel_types, fn type ->
+          Map.get(%{
+            :text => 0,
+            :dm => 1,
+            :voice => 2,
+            :group => 3,
+            :category => 4,
+            :announcement => 5,
+            {:thread, :announcement} => 10,
+            {:thread, :public} => 11,
+            {:thread, :private} => 12,
+            :stage => 13,
+            :guild_directory => 14,
+            :forum => 15
+          }, type)
+        end)
+        Map.put(struct, :channel_types, channel_types)
+      else struct end
+
+      if spec.choices do
+        choices = Enum.map(spec.choices, fn %{name: name, value: value} ->
+          %{value: value}
+          |> Nostrum.Command.Spec.add_localizable(name, :name, :name_localizations)
+        end)
+        Map.put(struct, :choices, choices)
+      else struct end
+    end
+
+    defp add_range(map, nil, _, _), do: map
+    defp add_range(map, left..right, key_left, key_right) do
+      map = if left != ignore_end() do
+        Map.put(map, key_left, left)
+      else map end
+      if right != ignore_end() do
+        Map.put(map, key_right, right)
+      else map end
+    end
+  end
+
+  @doc """
+  Converts the `spec` to a `Nostrum.Struct.ApplicationCommand` struct
+  """
+  def to_application_command_struct(%__MODULE__{} = spec) do
+    %{
+      default_perms: spec.default_perms,
+      type: Map.get(%{
+        :chat_input => 1,
+        {:context, :user} => 2,
+        {:context, :message} => 3
+      }, spec.type),
+      nsfw: spec.nsfw,
+      dm_permission: spec.dm,
+      options: Enum.map(spec.options, &__MODULE__.Option.to_app_cmd_struct_option/1)
+    }
+    |> add_localizable(spec.name, :name, :name_localizations)
+    |> add_localizable(spec.desc, :description, :description_localizations)
+  end
+
+  def add_localizable(map, <<data::binary>>, key_main, _key_loc) do
+    map
+    |> Map.put(key_main, data)
+  end
+  def add_localizable(map, {fallback, loc}, key_main, key_loc) do
+    map
+    |> Map.put(key_main, fallback)
+    |> Map.put(key_loc, loc)
+  end
+end


### PR DESCRIPTION
This pull request is intended to reduce boilerplate in projects that use application commands. Instead of requiring library users to implement a `Consumer` and manually handle `INTERACTION_CREATE` events, this pull requests enables them to define a separate module per command containing the command specification and its handling function.

As a bonus, it removes magic numbers in command specs, instead opting in for atoms, and merges some spec fields into one field (for example, `name` and `name_localizations` are represented as a tuple and `value_min` and `value_max` as a range)