### PR TITLE
Prevent crashing guild cache without guilds intent

### DIFF
--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -152,6 +152,15 @@ defmodule Nostrum.Consumer do
           {:GUILD_MEMBER_ADD,
            {guild_id :: integer, new_member :: Nostrum.Struct.Guild.Member.t()}, WSState.t()}
   @type guild_members_chunk :: {:GUILD_MEMBERS_CHUNK, map, WSState.t()}
+  @typedoc """
+  Dispatched when somebody leaves a guild.
+
+  In case the guild member intent is enabled but not the guild intent,
+  nostrum may not cache the actual guild, and thus be unable to provide
+  full information about members leaving guilds. In that case, this event
+  receives the guild ID and a partial member object with the leaving user as
+  provided by Discord, but no information about the user's state on the guild.
+  """
   @type guild_member_remove ::
           {:GUILD_MEMBER_REMOVE,
            {guild_id :: integer, old_member :: Nostrum.Struct.Guild.Member.t()}, WSState.t()}


### PR DESCRIPTION
Issue #452 outlines a problem where if the guild member intent is enabled but the guild intent is not, Nostrum will crash upon trying to look up the guild in the guild cache table. Instead of doing a hard match here, cross-check it in a `case` and if we do not have it cached, simply fan out the guild ID and the partial member object to the consumer.

Closes #452.