### PR TITLE
Fix crash when trying to connect when session pid isn't alive

### DIFF
--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -358,6 +358,18 @@ defmodule Nostrum.Shard.Dispatch do
           voice.channel_id != p.channel_id and is_pid(voice.session_pid) ->
             Voice.on_channel_join_change(p, voice)
 
+          # Already in this channel but connection died:
+          is_pid(voice.session_pid) and not Process.alive?(voice.session_pid) ->
+            Voice.leave_channel(p.guild_id)
+
+            Voice.join_channel(
+              p.guild_id,
+              p.channel_id,
+              p.self_mute,
+              p.self_deaf,
+              voice.persist_source
+            )
+
           # Already in this channel:
           true ->
             :noop

--- a/lib/nostrum/voice/session.ex
+++ b/lib/nostrum/voice/session.ex
@@ -216,13 +216,13 @@ defmodule Nostrum.Voice.Session do
     spawn(fn ->
       Process.monitor(state.conn_pid)
 
-      %VoiceState{channel_id: chan, self_mute: mute, self_deaf: deaf} =
+      %VoiceState{channel_id: chan, self_mute: mute, self_deaf: deaf, persist_source: persist} =
         Voice.get_voice(state.guild_id)
 
       receive do
         _ ->
           Voice.leave_channel(state.guild_id)
-          Voice.join_channel(state.guild_id, chan, mute, deaf)
+          Voice.join_channel(state.guild_id, chan, mute, deaf, persist)
       end
     end)
   end


### PR DESCRIPTION
Fix bug where when session_pid was dead, joining a voice channel would make a gen server call to the dead session and would end up crashing a cache.
This situation shouldn't occur since the session processes are supervised and they should be alive for the duration that the bot is connected to a voice channel, but I've seen it occur a couple times and it ended up crashing the bot. I suspect it may be due to gun2.0 or due to other recent async voice reconnect changes, but this change covers that case now.
Simplify `on_channel_join_change` as voice events always come in in guaranteed order so calling the session gen server isn't necessary so we can further reduce number of gen server calls.