### PR TITLE
Prevent crash with retry_after

### DIFF
--- a/lib/nostrum/error/api_error.ex
+++ b/lib/nostrum/error/api_error.ex
@@ -3,7 +3,7 @@ defmodule Nostrum.Error.ApiError do
   Represents a failed response from the API.
 
   This occurs when `:gun` fails, or when the API doesn't respond with `200` or `204`.
-  This should only occur when using the banged API methods.
+  This should only be raised explicitly when using the banged API methods.
   """
 
   defexception [

--- a/lib/nostrum/store/ratelimit_bucket.ex
+++ b/lib/nostrum/store/ratelimit_bucket.ex
@@ -134,7 +134,7 @@ defmodule Nostrum.Store.RatelimitBucket do
         # know what I'm doing anymore?
 
         case reset_time - Util.now() + latency do
-          time when time < 0 -> :now
+          time when time <= 0 -> :now
           time -> time
         end
 


### PR DESCRIPTION
First off, a retry_after time of exactly `0` is also a "you can go now": even if it represents some minimal value like 0.001, the network latency will eat that up anyways. Next up, if the ratelimiter asks us to retry and we do, handle the case where another process managed to race us and we need to sit it out again, with up to three retries.

Closes #493.