### PR TITLE
Add `@behaviour`, `@impl` and default `handle_event` to `Nostrum.Consumer`

### DIFF
--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -374,6 +374,8 @@ defmodule Nostrum.Consumer do
     quote location: :keep do
       use GenServer
 
+      @behaviour Nostrum.Consumer
+
       def child_spec(opts) do
         %{
           id: __MODULE__,

--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -21,7 +21,7 @@ defmodule Nostrum.Consumer do
 
       {:noreply, state}
     end
-  ``` 
+  ```
 
   ## Example consumer
 
@@ -389,15 +389,18 @@ defmodule Nostrum.Consumer do
         GenServer.start_link(__MODULE__, [], opts)
       end
 
+      @impl GenServer
       def init([]) do
         {:ok, nil, {:continue, nil}}
       end
 
+      @impl GenServer
       def handle_continue(_args, state) do
         ConsumerGroup.join(self())
         {:noreply, state}
       end
 
+      @impl GenServer
       def handle_info({:event, event}, state) do
         Task.start_link(fn ->
           __MODULE__.handle_event(event)
@@ -406,7 +409,7 @@ defmodule Nostrum.Consumer do
         {:noreply, state}
       end
 
-      defoverridable child_spec: 1, start_link: 1, init: 1, handle_continue: 2, handle_info: 2
+      defoverridable GenServer
     end
   end
 end

--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -376,6 +376,8 @@ defmodule Nostrum.Consumer do
 
       @behaviour Nostrum.Consumer
 
+      @before_compile Nostrum.Consumer
+
       def child_spec(opts) do
         %{
           id: __MODULE__,
@@ -412,6 +414,13 @@ defmodule Nostrum.Consumer do
       end
 
       defoverridable GenServer
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote location: :keep do
+      @impl Nostrum.Consumer
+      def handle_event(_), do: :noop
     end
   end
 end


### PR DESCRIPTION
A couple of additions to `Nostrum.Consumer`:

- Use `@impl` declarations where appropriate.
- Add a `@behaviour Nostrum.Consumer` declaration to `__using__`.
- Add a `__before_compile__` hook to inject a default `:noop` implementation of `handle_event`.