### PR TITLE
Add state machine report translator

### DIFF
--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -22,6 +22,7 @@ defmodule Nostrum.Application do
   def start(_type, _args) do
     Token.check_token!()
     check_executables()
+    Logger.add_translator({Nostrum.StateMachineTranslator, :translate})
 
     children = [
       Nostrum.Store.Supervisor,

--- a/lib/nostrum/state_machine_translator.ex
+++ b/lib/nostrum/state_machine_translator.ex
@@ -1,0 +1,35 @@
+defmodule Nostrum.StateMachineTranslator do
+  @moduledoc """
+  Translate error reports for `:gen_statem` modules in Elixir.
+
+  By default, Elixir will ignore these messages altogether, see [this
+  ElixirForum
+  post](https://elixirforum.com/t/why-does-logger-translator-ignore-gen-statem-reports/37418).
+  A possible workaround seems to be using the `gen_state_machine` library, but
+  pulling in a library purely to have error reporting for something built-in to
+  OTP seems pretty strange to me.
+  """
+  @moduledoc since: "0.9.0"
+
+  # https://github.com/elixir-lang/elixir/blob/d30c5c0185607f08797441ab8af12636ad8dbd7e/lib/logger/lib/logger/translator.ex#L39
+  def translate(min_level, :error, :report, {:logger, %{label: label} = report}) do
+    case label do
+      {:gen_statem, :terminate} ->
+        report_gen_statem_terminate(min_level, report)
+
+      _ ->
+        :none
+    end
+  end
+
+  def translate(_min_level, _level, _kind, _data) do
+    :none
+  end
+
+  defp report_gen_statem_terminate(_min_level, report) do
+    # raw erlang format. you know it, you love it.
+    # thanks to OTP for exposing this in the first place.
+    log = :gen_statem.format_log(report, %{})
+    {:ok, log, []}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -98,7 +98,8 @@ defmodule Nostrum.Mixfile do
         ~r/Nostrum.Constants/
       ],
       Utilities: [
-        ~r/Nostrum.(Snowflake|Token|Util)/
+        ~r/Nostrum.(Snowflake|Token|Util)/,
+        ~r/^Nostrum\.StateMachineTranslator$/
       ],
       Stores: [
         ~r/Nostrum.Store.\w+$/


### PR DESCRIPTION
Elixir will, by default, not output `:gen_statem` errors, which is ... suboptimal. We add a new logger translator to deal with these errors and report them.