### PR TITLE
Fix Util.get_all_shard_latencies

### DIFF
--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -287,7 +287,7 @@ defmodule Nostrum.Util do
     |> Enum.map(fn {_id, pid, _type, _modules} -> Supervisor.which_children(pid) end)
     |> List.flatten()
     |> Enum.map(fn {_id, pid, _type, _modules} -> Session.get_ws_state(pid) end)
-    |> Enum.reduce(%{}, fn s, m -> Map.put(m, s.shard_num, get_shard_latency(s)) end)
+    |> Enum.reduce(%{}, fn {_, s}, m -> Map.put(m, s.shard_num, get_shard_latency(s)) end)
   end
 
   @doc """


### PR DESCRIPTION
`Session.get_ws_state` now returns the tuple `{:connected, %WSState{}}`, it was causing KeyNotFound errors to be raised.