### PR TITLE
Fix reconnect requests

### DIFF
--- a/lib/nostrum/shard/event.ex
+++ b/lib/nostrum/shard/event.ex
@@ -63,7 +63,7 @@ defmodule Nostrum.Shard.Event do
 
   def handle(:reconnect, _payload, state) do
     Logger.info("RECONNECT")
-    {state, []}
+    {{state, :reconnect}, []}
   end
 
   def handle(event, _payload, state) do

--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -145,9 +145,9 @@ defmodule Nostrum.Shard.Session do
     {:next_state, :connecting_http, data}
   end
 
-  #def disconnected(_kind, _request, _data) do
+  # def disconnected(_kind, _request, _data) do
   #  {:keep_state_and_data, :postpone}
-  #end
+  # end
 
   # If we've been here before, we want to use the resume gateway URL to connect
   # instead of the regular gateway URL.
@@ -196,9 +196,9 @@ defmodule Nostrum.Shard.Session do
     {:stop, :connect_http_timeout}
   end
 
-  #def connecting_http(_kind, _request, _data) do
+  # def connecting_http(_kind, _request, _data) do
   #  {:keep_state_and_data, :postpone}
-  #end
+  # end
 
   def connecting_ws(:enter, _from, %{conn: conn} = data) do
     Logger.debug("Upgrading connection to websocket")


### PR DESCRIPTION
fix reconnect requests from discord to make it so we resume properly and without an infinite loop.

Was unable to test fully, do not merge until someone has had a chance to.