### PR TITLE
Handle nil member count in guild caches

### DIFF
--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -971,7 +971,7 @@ defmodule Nostrum.Api.Ratelimiter do
   # defp parse_headers({:error, _reason} = result), do: result
 
   # credo:disable-for-next-line
-  defp parse_headers({:ok, {status, headers, body}}) do
+  defp parse_headers({:ok, {_status, headers, _body}}) do
     limit_scope = header_value(headers, "x-ratelimit-scope")
     remaining = header_value(headers, "x-ratelimit-remaining")
     remaining = unless is_nil(remaining), do: String.to_integer(remaining)
@@ -983,10 +983,6 @@ defmodule Nostrum.Api.Ratelimiter do
 
     cond do
       is_nil(remaining) and is_nil(reset_after) ->
-        Logger.warning(
-          "Congrats, you killed upstream? (#{status}) #{inspect(headers)} #{inspect(body)}"
-        )
-
         :congratulations_you_killed_upstream
 
       limit_scope == "user" and remaining == 0 ->

--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -162,7 +162,7 @@ defmodule Nostrum.Api.Ratelimiter do
   `0.8`, nostrum used to use a `GenServer` that would call out to ETS tables to
   look up ratelimiting buckets for requests. If it needed to sleep before
   issuing a request due to the bucket being exhausted, it would do so in the
-  server process and block other callers. 
+  server process and block other callers.
 
   In nostrum 0.8, the existing ratelimiter bucket storage architecture was
   refactored to be based around the [pluggable caching
@@ -971,7 +971,7 @@ defmodule Nostrum.Api.Ratelimiter do
   # defp parse_headers({:error, _reason} = result), do: result
 
   # credo:disable-for-next-line
-  defp parse_headers({:ok, {_status, headers, _body}}) do
+  defp parse_headers({:ok, {status, headers, body}}) do
     limit_scope = header_value(headers, "x-ratelimit-scope")
     remaining = header_value(headers, "x-ratelimit-remaining")
     remaining = unless is_nil(remaining), do: String.to_integer(remaining)
@@ -983,6 +983,10 @@ defmodule Nostrum.Api.Ratelimiter do
 
     cond do
       is_nil(remaining) and is_nil(reset_after) ->
+        Logger.warning(
+          "Congrats, you killed upstream? (#{status}) #{inspect(headers)} #{inspect(body)}"
+        )
+
         :congratulations_you_killed_upstream
 
       limit_scope == "user" and remaining == 0 ->

--- a/lib/nostrum/cache/guild_cache/ets.ex
+++ b/lib/nostrum/cache/guild_cache/ets.ex
@@ -27,6 +27,8 @@ defmodule Nostrum.Cache.GuildCache.ETS do
   alias Nostrum.Util
   use Supervisor
 
+  require Logger
+
   @doc "Start the supervisor."
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
@@ -185,6 +187,11 @@ defmodule Nostrum.Cache.GuildCache.ETS do
   @spec member_count_up(Guild.id()) :: true
   def member_count_up(guild_id) do
     case :ets.lookup(@table_name, guild_id) do
+      [{^guild_id, %{member_count: nil}}] ->
+        # no-op if member_count is nil
+        Logger.warning("Unexpected nil member_count for guild #{guild_id} when incrementing")
+        true
+
       [{^guild_id, guild}] ->
         :ets.insert(@table_name, {guild_id, %{guild | member_count: guild.member_count + 1}})
 
@@ -200,6 +207,11 @@ defmodule Nostrum.Cache.GuildCache.ETS do
   @spec member_count_down(Guild.id()) :: true
   def member_count_down(guild_id) do
     case :ets.lookup(@table_name, guild_id) do
+      [{^guild_id, %{member_count: nil}}] ->
+        # no-op if member_count is nil
+        Logger.warning("Unexpected nil member_count for guild #{guild_id} when decrementing")
+        true
+
       [{^guild_id, guild}] ->
         :ets.insert(@table_name, {guild_id, %{guild | member_count: guild.member_count - 1}})
 

--- a/lib/nostrum/cache/guild_cache/mnesia.ex
+++ b/lib/nostrum/cache/guild_cache/mnesia.ex
@@ -81,7 +81,9 @@ if Code.ensure_loaded?(:mnesia) do
         :mnesia.activity(:sync_transaction, fn ->
           case :mnesia.read(@table_name, new_guild.id, :write) do
             [{_tag, _id, old_guild} = entry] ->
-              :mnesia.write(put_elem(entry, 2, new_guild))
+              updated_guild = Guild.merge(old_guild, new_guild)
+
+              :mnesia.write(put_elem(entry, 2, updated_guild))
               old_guild
 
             [] ->

--- a/lib/nostrum/cache/guild_cache/mnesia.ex
+++ b/lib/nostrum/cache/guild_cache/mnesia.ex
@@ -20,6 +20,8 @@ if Code.ensure_loaded?(:mnesia) do
     alias Nostrum.Util
     use Supervisor
 
+    require Logger
+
     @doc "Start the supervisor."
     def start_link(init_arg) do
       Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
@@ -222,7 +224,12 @@ if Code.ensure_loaded?(:mnesia) do
     def member_count_up(guild_id) do
       # May not be `update_guild!` for the case where guild intent is off.
       update_guild(guild_id, fn guild ->
-        {%{guild | member_count: guild.member_count + 1}, true}
+        if is_nil(guild.member_count) do
+          Logger.warning("Unexpected nil member_count for guild #{guild_id} when incrementing")
+          {guild, true}
+        else
+          {%{guild | member_count: guild.member_count + 1}, true}
+        end
       end)
 
       true
@@ -235,7 +242,12 @@ if Code.ensure_loaded?(:mnesia) do
     def member_count_down(guild_id) do
       # May not be `update_guild!` for the case where guild intent is off.
       update_guild(guild_id, fn guild ->
-        {%{guild | member_count: guild.member_count - 1}, true}
+        if is_nil(guild.member_count) do
+          Logger.warning("Unexpected nil member_count for guild #{guild_id} when decrementing")
+          {guild, true}
+        else
+          {%{guild | member_count: guild.member_count - 1}, true}
+        end
       end)
 
       true


### PR DESCRIPTION
Makes it so that member_count being `nil` in the guild cache won't cause a crash on a member leaving/joining.

Ideally this shouldn't happen but 🤷‍♂️

Also, ignore the commit before this, I was debugging a separate issue and removed all changes from it.