### PR TITLE
Add error message for lacking consumer startup

### DIFF
--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -343,7 +343,14 @@ defmodule Nostrum.Shard.Session do
       {^reference, :join, _group, _who} ->
         :ok
     after
-      timeout -> :timeout
+      timeout ->
+        Logger.error(
+          "No consumers were running nor did any start up in time " <>
+            "for shard session startup. Is a consumer started as " <>
+            "part of your supervision tree?"
+        )
+
+        :timeout
     end
   end
 end


### PR DESCRIPTION
Instead of relying on the user to interpret the existing debug logs and badmatch error, send an explicit error message when no consumer could be found that we can use in the shard connection. See #524.