### PR TITLE
bump minimum elixir version and test matrix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: '25'
-          elixir-version: '1.14'
+          otp-version: '26'
+          elixir-version: '1.15'
       - uses: actions/cache@v2
         with:
           path: deps

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -16,12 +16,12 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 25
-          elixir-version: 1.14
+          otp-version: 26
+          elixir-version: 1.15
 
       - uses: actions/cache@v3
         env:
-          base-key: 25-1.14
+          base-key: 26-1.15
         with:
           path: |
             _build
@@ -47,13 +47,11 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        elixir-version: ['1.12', '1.13', '1.14']
-        otp-version: ['23', '24', '25']
+        elixir-version: ['1.13', '1.14', '1.15']
+        otp-version: ['25', '26']
         exclude:
-          - elixir-version: '1.12'
-            otp-version: '25'
-          - elixir-version: '1.14'
-            otp-version: '22'
+          - elixir-version: '1.13'
+            otp-version: '26'
     steps:
       - uses: actions/checkout@v2
 

--- a/appup.ex
+++ b/appup.ex
@@ -1,29 +1,29 @@
 # See the appup cookbook for instructions:
 # https://www.erlang.org/doc/design_principles/appup_cookbook.html
 {
-  '0.9.0-alpha3',
+  ~c"0.9.0-alpha3",
   [
     # Upgrade instructions
-    {'0.9.0-alpha2', []},
-    {'0.9.0-alpha1',
+    {~c"0.9.0-alpha2", []},
+    {~c"0.9.0-alpha1",
      [
        # Top shard supervisor was not registered, so could not restart shard
        # supervisor to load new gateway logic
        {:restart_application, :nostrum}
      ]},
-    {'0.8.0',
+    {~c"0.8.0",
      [
        {:restart_application, :nostrum}
      ]}
   ],
   [
     # Downgrade instructions
-    {'0.9.0-alpha2', []},
-    {'0.9.0-alpha1',
+    {~c"0.9.0-alpha2", []},
+    {~c"0.9.0-alpha1",
      [
        {:restart_application, :nostrum}
      ]},
-    {'0.8.0',
+    {~c"0.8.0",
      [
        {:restart_application, :nostrum}
      ]}

--- a/benchmarks/qlc_bench.exs
+++ b/benchmarks/qlc_bench.exs
@@ -53,25 +53,25 @@ qhtraverse = :ets.table(tab, traverse: {:select, ms})
 
 # Elixir queries
 qh0 =
-  :qlc.string_to_handle('[{Id, Id, Value} || {Id, Value} <- Handle, Id =:= RequestedId].', [],
+  :qlc.string_to_handle(~c"[{Id, Id, Value} || {Id, Value} <- Handle, Id =:= RequestedId].", [],
     Handle: qh,
     RequestedId: 500_000
   )
 
 qh1a =
-  :qlc.string_to_handle('[{Id, Id, Value} || {Id, Value} <- Handle].', [],
+  :qlc.string_to_handle(~c"[{Id, Id, Value} || {Id, Value} <- Handle].", [],
     Handle: qh,
     RequestedId: 500_000
   )
 
 qh1b =
-  :qlc.string_to_handle('[Value || {Id, _, Value} <- Handle, Id =:= RequestedId].', [],
+  :qlc.string_to_handle(~c"[Value || {Id, _, Value} <- Handle, Id =:= RequestedId].", [],
     Handle: qh1a,
     RequestedId: 500_000
   )
 
 qh2a =
-  :qlc.string_to_handle('[{Id, Id, Value} || {Id, Value} <- Handle, Id =:= RequestedId].', [],
+  :qlc.string_to_handle(~c"[{Id, Id, Value} || {Id, Value} <- Handle, Id =:= RequestedId].", [],
     Handle: qhtraverse,
     RequestedId: 500_000
   )

--- a/lib/nostrum/cache/channel_cache.ex
+++ b/lib/nostrum/cache/channel_cache.ex
@@ -102,7 +102,7 @@ defmodule Nostrum.Cache.ChannelCache do
   If your cache does not need any wrapping, you can omit this.
   """
   @doc since: "0.8.0"
-  @callback wrap_qlc((() -> result)) :: result when result: term()
+  @callback wrap_qlc((-> result)) :: result when result: term()
   @optional_callbacks wrap_qlc: 1
 
   @doc """
@@ -155,7 +155,7 @@ defmodule Nostrum.Cache.ChannelCache do
   @doc since: "0.8.0"
   defdelegate query_handle(), to: @configured_cache
 
-  @spec wrap_qlc(module(), (() -> result)) :: result when result: term()
+  @spec wrap_qlc(module(), (-> result)) :: result when result: term()
   defp wrap_qlc(cache, fun) do
     if function_exported?(cache, :wrap_qlc, 1) do
       cache.wrap_qlc(fun)

--- a/lib/nostrum/cache/channel_cache/noop.ex
+++ b/lib/nostrum/cache/channel_cache/noop.ex
@@ -32,7 +32,7 @@ defmodule Nostrum.Cache.ChannelCache.NoOp do
   def delete(_id), do: :noop
 
   @impl ChannelCache
-  def query_handle, do: :qlc.string_to_handle('[].')
+  def query_handle, do: :qlc.string_to_handle(~c"[].")
 
   defp convert(%{__struct__: _} = struct), do: struct
   defp convert(map), do: Channel.to_struct(map)

--- a/lib/nostrum/cache/guild_cache.ex
+++ b/lib/nostrum/cache/guild_cache.ex
@@ -224,7 +224,7 @@ defmodule Nostrum.Cache.GuildCache do
   If your cache does not need any wrapping, you can omit this.
   """
   @doc since: "0.8.0"
-  @callback wrap_qlc((() -> result)) :: result when result: term()
+  @callback wrap_qlc((-> result)) :: result when result: term()
   @optional_callbacks wrap_qlc: 1
 
   @doc """
@@ -278,8 +278,8 @@ defmodule Nostrum.Cache.GuildCache do
   If no cache is given, calls out to the default cache.
   """
   @doc since: "0.8.0"
-  @spec wrap_qlc((() -> result)) :: result when result: term()
-  @spec wrap_qlc(module(), (() -> result)) :: result when result: term()
+  @spec wrap_qlc((-> result)) :: result when result: term()
+  @spec wrap_qlc(module(), (-> result)) :: result when result: term()
   def wrap_qlc(cache \\ @configured_cache, fun) do
     if function_exported?(cache, :wrap_qlc, 1) do
       cache.wrap_qlc(fun)

--- a/lib/nostrum/cache/guild_cache/noop.ex
+++ b/lib/nostrum/cache/guild_cache/noop.ex
@@ -75,5 +75,5 @@ defmodule Nostrum.Cache.GuildCache.NoOp do
   def member_count_down(_guild_id), do: true
 
   @impl GuildCache
-  def query_handle, do: :qlc.string_to_handle('[].')
+  def query_handle, do: :qlc.string_to_handle(~c"[].")
 end

--- a/lib/nostrum/cache/member_cache.ex
+++ b/lib/nostrum/cache/member_cache.ex
@@ -105,7 +105,7 @@ defmodule Nostrum.Cache.MemberCache do
   If your cache does not need any wrapping, you can omit this.
   """
   @doc since: "0.8.0"
-  @callback wrap_qlc((() -> result)) :: result when result: term()
+  @callback wrap_qlc((-> result)) :: result when result: term()
   @optional_callbacks wrap_qlc: 1
 
   # User-facing
@@ -238,8 +238,8 @@ defmodule Nostrum.Cache.MemberCache do
   If no cache is given, calls out to the default cache.
   """
   @doc since: "0.8.0"
-  @spec wrap_qlc((() -> result)) :: result when result: term()
-  @spec wrap_qlc(module(), (() -> result)) :: result when result: term()
+  @spec wrap_qlc((-> result)) :: result when result: term()
+  @spec wrap_qlc(module(), (-> result)) :: result when result: term()
   def wrap_qlc(cache \\ @configured_cache, fun) do
     if function_exported?(cache, :wrap_qlc, 1) do
       cache.wrap_qlc(fun)

--- a/lib/nostrum/cache/member_cache/ets.ex
+++ b/lib/nostrum/cache/member_cache/ets.ex
@@ -52,7 +52,7 @@ defmodule Nostrum.Cache.MemberCache.ETS do
   """
   @doc since: "0.8.0"
   @impl MemberCache
-  @spec wrap_qlc((() -> qlc_result)) :: qlc_result when qlc_result: term()
+  @spec wrap_qlc((-> qlc_result)) :: qlc_result when qlc_result: term()
   def wrap_qlc(fun) do
     :ets.safe_fixtable(@table_name, true)
     fun.()

--- a/lib/nostrum/cache/member_cache/noop.ex
+++ b/lib/nostrum/cache/member_cache/noop.ex
@@ -35,5 +35,5 @@ defmodule Nostrum.Cache.MemberCache.NoOp do
   def bulk_create(_guild_id, _members), do: true
 
   @impl MemberCache
-  def query_handle, do: :qlc.string_to_handle('[].')
+  def query_handle, do: :qlc.string_to_handle(~c"[].")
 end

--- a/lib/nostrum/cache/presence_cache.ex
+++ b/lib/nostrum/cache/presence_cache.ex
@@ -138,7 +138,7 @@ defmodule Nostrum.Cache.PresenceCache do
   If your cache does not need any wrapping, you can omit this.
   """
   @doc since: "0.8.0"
-  @callback wrap_qlc((() -> result)) :: result when result: term()
+  @callback wrap_qlc((-> result)) :: result when result: term()
   @optional_callbacks wrap_qlc: 1
 
   # Dispatch
@@ -168,8 +168,8 @@ defmodule Nostrum.Cache.PresenceCache do
   If no cache is given, calls out to the default cache.
   """
   @doc since: "0.8.0"
-  @spec wrap_qlc((() -> result)) :: result when result: term()
-  @spec wrap_qlc(module(), (() -> result)) :: result when result: term()
+  @spec wrap_qlc((-> result)) :: result when result: term()
+  @spec wrap_qlc(module(), (-> result)) :: result when result: term()
   def wrap_qlc(cache \\ @configured_cache, fun) do
     if function_exported?(cache, :wrap_qlc, 1) do
       cache.wrap_qlc(fun)

--- a/lib/nostrum/cache/presence_cache/noop.ex
+++ b/lib/nostrum/cache/presence_cache/noop.ex
@@ -35,5 +35,5 @@ defmodule Nostrum.Cache.PresenceCache.NoOp do
   def bulk_create(_guild_id, _presences), do: :ok
 
   @impl PresenceCache
-  def query_handle, do: :qlc.string_to_handle('[].')
+  def query_handle, do: :qlc.string_to_handle(~c"[].")
 end

--- a/lib/nostrum/cache/user_cache.ex
+++ b/lib/nostrum/cache/user_cache.ex
@@ -114,7 +114,7 @@ defmodule Nostrum.Cache.UserCache do
   If your cache does not need any wrapping, you can omit this.
   """
   @doc since: "0.8.0"
-  @callback wrap_qlc((() -> result)) :: result when result: term()
+  @callback wrap_qlc((-> result)) :: result when result: term()
   @optional_callbacks wrap_qlc: 1
 
   @doc """
@@ -139,8 +139,8 @@ defmodule Nostrum.Cache.UserCache do
   If no cache is given, calls out to the default cache.
   """
   @doc since: "0.8.0"
-  @spec wrap_qlc((() -> result)) :: result when result: term()
-  @spec wrap_qlc(module(), (() -> result)) :: result when result: term()
+  @spec wrap_qlc((-> result)) :: result when result: term()
+  @spec wrap_qlc(module(), (-> result)) :: result when result: term()
   def wrap_qlc(cache \\ @configured_cache, fun) do
     if function_exported?(cache, :wrap_qlc, 1) do
       cache.wrap_qlc(fun)

--- a/lib/nostrum/cache/user_cache/noop.ex
+++ b/lib/nostrum/cache/user_cache/noop.ex
@@ -33,5 +33,5 @@ defmodule Nostrum.Cache.UserCache.NoOp do
   def delete(_id), do: :noop
 
   @impl Nostrum.Cache.UserCache
-  def query_handle, do: :qlc.string_to_handle('[].')
+  def query_handle, do: :qlc.string_to_handle(~c"[].")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Nostrum.Mixfile do
       appup: "appup.ex",
       compilers: Mix.compilers() ++ [:appup],
       version: "0.9.0-alpha3",
-      elixir: "~> 1.11",
+      elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Since we use `:pg.monitor/2` within Nostrum and it was introduced in OTP 25.1, this bumps the Elixir version mentioned in our `mix.exs` to the earliest version of Elixir which officially supports OTP 25. Also updates CI to include the latest versions of OTP and Elixir while dropping unsupported versions.