### PR TITLE
Prepare for 0.9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ version from Hex:
 
 ```elixir
 def deps do
-  [{:nostrum, "~> 0.8"}]
+  [{:nostrum, "~> 0.9"}]
 end
 ```
 

--- a/appup.ex
+++ b/appup.ex
@@ -1,9 +1,14 @@
 # See the appup cookbook for instructions:
 # https://www.erlang.org/doc/design_principles/appup_cookbook.html
 {
-  ~c"0.9.0-alpha3",
+  ~c"0.9.0",
   [
     # Upgrade instructions
+    {~c"0.9.0-alpha3",
+     [
+       # needed to add back http1.1 support
+       {:restart_application, :nostrum}
+     ]},
     {~c"0.9.0-alpha2", []},
     {~c"0.9.0-alpha1",
      [
@@ -18,6 +23,10 @@
   ],
   [
     # Downgrade instructions
+    {~c"0.9.0-alpha3",
+     [
+       {:restart_application, :nostrum}
+     ]},
     {~c"0.9.0-alpha2", []},
     {~c"0.9.0-alpha1",
      [

--- a/guides/advanced/multi_node.md
+++ b/guides/advanced/multi_node.md
@@ -53,7 +53,7 @@ as command frameworks like `:nosedrum`:
 ```elixir
   defp deps do
     [
-      {:nostrum, "~> 0.8", runtime: false},
+      {:nostrum, "~> 0.9", runtime: false},
       # {:nosedrum, "~> 0.6", runtime: false},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Nostrum.Mixfile do
       app: :nostrum,
       appup: "appup.ex",
       compilers: Mix.compilers() ++ [:appup],
-      version: "0.9.0-alpha3",
+      version: "0.9.0",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
There have been enough changes piling up since the last release and with Discord turning off http2 support for the time-being, its probably time for us to release `0.9.0`.