### PR TITLE
[Experimental] support multiple gun connections in the rate limiter

### DIFF
--- a/guides/intro/intro.md
+++ b/guides/intro/intro.md
@@ -52,6 +52,9 @@ Apart from the `token` field mentioned above, the following fields are also supp
   of members for all guilds at startup. Depending on your [cache
   backend](../advanced/pluggable_caching.md), this may increase startup time
   and memory usage by quite a bit. Defaults to `false`.
+- `maximum_connections` - experimental option to configure the maximum amount of
+  concurrent connections that may be opened to Discord's API at once when using
+  http1.1, ignored when using http2. Defaults to `1`.
 
 
 ### Voice-specific

--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -275,7 +275,7 @@ defmodule Nostrum.Api.Ratelimiter do
   buffer their body until we can send it back to the client.
 
   - `:conn_pool`: A queue of `:gun` connection backing the server. Used for making new
-  requests, and updated as the state changes.
+  requests and updated as the state changes.
 
   - `:pending_conns`: A set of `:gun` connections that will be added to the pool once we receive a `:gun_up` event.
 
@@ -288,8 +288,8 @@ defmodule Nostrum.Api.Ratelimiter do
   this time window. Reset automatically via timeouts.
 
   - `:connection_type`: The type of the most recently opened `:gun` connection. This is used to determine
-  if we need to more connections to handle the number of in-flight requests, as we only have this issue
-  when using http1 connections.
+  if we would benefit from opening more connections to handle the number of requests being issued,
+  with http2 opening more connections is unnecessary.
   """
   @typedoc since: "0.9.0"
   @type state :: %{


### PR DESCRIPTION
Experimental PR to see if we can support multiple gun connections in the ratelimiter at once without too much of a rewrite while we wait for Discord to enable http2 again. Needs extensive testing before it should be considered ready to merge, I've only done a few smoke tests so far.