### PR TITLE
Move ChannelCache to DMChannelCache

### DIFF
--- a/examples/cache.ex
+++ b/examples/cache.ex
@@ -32,7 +32,7 @@ defmodule ExampleCommands do
   import Nostrum.Snowflake, only: [is_snowflake: 1]
 
   alias Nostrum.Api
-  alias Nostrum.Cache.{ChannelCache, GuildCache, UserCache}
+  alias Nostrum.Cache.{DMChannelCache, GuildCache, UserCache}
   alias Nostrum.Struct.User
 
   # Fetch the defined prefix from our config, however,
@@ -67,7 +67,7 @@ defmodule ExampleCommands do
          {:ok, user} <-
            get_cached_with_fallback(user_id, &UserCache.get/1, &Api.get_user/1),
          {:ok, %{name: channel_name}} <-
-           get_cached_with_fallback(channel_id, &ChannelCache.get/1, &Api.get_channel/1),
+           get_cached_with_fallback(channel_id, &DMChannelCache.get/1, &Api.get_channel/1),
          {:ok, %{name: guild_name}} <-
            get_cached_with_fallback(guild_id, &GuildCache.get/1, &Api.get_guild/1) do
       Api.create_message(

--- a/lib/nostrum/cache/cache_supervisor.ex
+++ b/lib/nostrum/cache/cache_supervisor.ex
@@ -4,7 +4,7 @@ defmodule Nostrum.Cache.CacheSupervisor do
 
   See the documentation for the relevant submodules for details:
 
-  - `Nostrum.Cache.ChannelCache`
+  - `Nostrum.Cache.DMChannelCache`
   - `Nostrum.Cache.GuildCache`
   - `Nostrum.Cache.Me`
   - `Nostrum.Cache.PresenceCache`
@@ -25,7 +25,7 @@ defmodule Nostrum.Cache.CacheSupervisor do
       Nostrum.Cache.GuildCache,
       Nostrum.Cache.MemberCache,
       Nostrum.Cache.UserCache,
-      Nostrum.Cache.ChannelCache,
+      Nostrum.Cache.DMChannelCache,
       Nostrum.Cache.PresenceCache
     ]
 

--- a/lib/nostrum/cache/dmchannel_cache/ets.ex
+++ b/lib/nostrum/cache/dmchannel_cache/ets.ex
@@ -1,4 +1,4 @@
-defmodule Nostrum.Cache.ChannelCache.ETS do
+defmodule Nostrum.Cache.DMChannelCache.ETS do
   @moduledoc """
   An ETS-based cache for channels outside of guilds.
 
@@ -10,16 +10,16 @@ defmodule Nostrum.Cache.ChannelCache.ETS do
 
   Note that users should not call the functions not related to this specific
   implementation of the cache directly. Instead, call the functions of
-  `Nostrum.Cache.ChannelCache` directly, which will dispatch to the configured
+  `Nostrum.Cache.DMChannelCache` directly, which will dispatch to the configured
   cache.
   """
   @moduledoc since: "0.5.0"
 
-  @behaviour Nostrum.Cache.ChannelCache
+  @behaviour Nostrum.Cache.DMChannelCache
 
   @table_name :nostrum_channels
 
-  alias Nostrum.Cache.ChannelCache
+  alias Nostrum.Cache.DMChannelCache
   alias Nostrum.Struct.Channel
   use Supervisor
 
@@ -41,7 +41,7 @@ defmodule Nostrum.Cache.ChannelCache.ETS do
   def table, do: @table_name
 
   @doc "Converts and creates the given map as a channel in the cache."
-  @impl ChannelCache
+  @impl DMChannelCache
   @spec create(map) :: Channel.t()
   def create(channel) do
     parsed = convert(channel)
@@ -50,7 +50,7 @@ defmodule Nostrum.Cache.ChannelCache.ETS do
   end
 
   @doc "Update the given channel in the cache."
-  @impl ChannelCache
+  @impl DMChannelCache
   @spec update(Channel.t()) :: {Channel.t() | nil, Channel.t()}
   def update(channel) do
     parsed = convert(channel)
@@ -66,7 +66,7 @@ defmodule Nostrum.Cache.ChannelCache.ETS do
   end
 
   @doc "Delete the channel from the cache by ID."
-  @impl ChannelCache
+  @impl DMChannelCache
   @spec delete(Channel.id()) :: :noop | Channel.t()
   def delete(id) do
     case :ets.lookup(@table_name, id) do
@@ -79,7 +79,7 @@ defmodule Nostrum.Cache.ChannelCache.ETS do
     end
   end
 
-  @impl ChannelCache
+  @impl DMChannelCache
   @doc "Retrieve a query handle for usage with QLC."
   @doc since: "0.8.0"
   @spec query_handle() :: :qlc.query_handle()

--- a/lib/nostrum/cache/dmchannel_cache/ets.ex
+++ b/lib/nostrum/cache/dmchannel_cache/ets.ex
@@ -17,7 +17,7 @@ defmodule Nostrum.Cache.DMChannelCache.ETS do
 
   @behaviour Nostrum.Cache.DMChannelCache
 
-  @table_name :nostrum_channels
+  @table_name :nostrum_dm_channels
 
   alias Nostrum.Cache.DMChannelCache
   alias Nostrum.Struct.Channel

--- a/lib/nostrum/cache/dmchannel_cache/mnesia.ex
+++ b/lib/nostrum/cache/dmchannel_cache/mnesia.ex
@@ -1,5 +1,5 @@
 if Code.ensure_loaded?(:mnesia) do
-  defmodule Nostrum.Cache.ChannelCache.Mnesia do
+  defmodule Nostrum.Cache.DMChannelCache.Mnesia do
     @moduledoc """
     An Mnesia-based cache for channels outside of guilds.
 
@@ -10,9 +10,9 @@ if Code.ensure_loaded?(:mnesia) do
     @table_name :nostrum_channels
     @record_name @table_name
 
-    @behaviour Nostrum.Cache.ChannelCache
+    @behaviour Nostrum.Cache.DMChannelCache
 
-    alias Nostrum.Cache.ChannelCache
+    alias Nostrum.Cache.DMChannelCache
     alias Nostrum.Struct.Channel
     use Supervisor
 
@@ -46,7 +46,7 @@ if Code.ensure_loaded?(:mnesia) do
       Supervisor.init([], strategy: :one_for_one)
     end
 
-    @impl ChannelCache
+    @impl DMChannelCache
     @doc "Creates the given channel in the cache."
     @spec create(map) :: Channel.t()
     def create(channel) do
@@ -56,7 +56,7 @@ if Code.ensure_loaded?(:mnesia) do
       parsed
     end
 
-    @impl ChannelCache
+    @impl DMChannelCache
     @doc "Update the given channel in the cache."
     @spec update(Channel.t()) :: {Channel.t() | nil, Channel.t()}
     def update(channel) do
@@ -74,7 +74,7 @@ if Code.ensure_loaded?(:mnesia) do
       end)
     end
 
-    @impl ChannelCache
+    @impl DMChannelCache
     @doc "Delete the channel from the cache by ID."
     @spec delete(Channel.id()) :: :noop | Channel.t()
     def delete(id) do
@@ -90,7 +90,7 @@ if Code.ensure_loaded?(:mnesia) do
       end)
     end
 
-    @impl ChannelCache
+    @impl DMChannelCache
     @doc "Retrieve a QLC query handle for the channel cache."
     @doc since: "0.8.0"
     @spec query_handle :: :qlc.query_handle()
@@ -99,7 +99,7 @@ if Code.ensure_loaded?(:mnesia) do
       :mnesia.table(@table_name, {:traverse, {:select, ms}})
     end
 
-    @impl ChannelCache
+    @impl DMChannelCache
     @doc "Wrap QLC operations in a transaction."
     @doc since: "0.8.0"
     def wrap_qlc(fun) do

--- a/lib/nostrum/cache/dmchannel_cache/mnesia.ex
+++ b/lib/nostrum/cache/dmchannel_cache/mnesia.ex
@@ -7,7 +7,7 @@ if Code.ensure_loaded?(:mnesia) do
     """
     @moduledoc since: "0.8.0"
 
-    @table_name :nostrum_channels
+    @table_name :nostrum_dm_channels
     @record_name @table_name
 
     @behaviour Nostrum.Cache.DMChannelCache

--- a/lib/nostrum/cache/dmchannel_cache/noop.ex
+++ b/lib/nostrum/cache/dmchannel_cache/noop.ex
@@ -1,14 +1,14 @@
-defmodule Nostrum.Cache.ChannelCache.NoOp do
+defmodule Nostrum.Cache.DMChannelCache.NoOp do
   @moduledoc """
-  A NoOp implementation for the ChannelCache
+  A NoOp implementation for the DMChannelCache
 
-  This cache does nothing, enable it if you dont need to cache channels
+  This cache does nothing, enable it if you dont need to cache DM channels
   """
   @moduledoc since: "0.9.0"
 
-  @behaviour Nostrum.Cache.ChannelCache
+  @behaviour Nostrum.Cache.DMChannelCache
 
-  alias Nostrum.Cache.ChannelCache
+  alias Nostrum.Cache.DMChannelCache
   alias Nostrum.Struct.Channel
   use Supervisor
 
@@ -22,16 +22,16 @@ defmodule Nostrum.Cache.ChannelCache.NoOp do
     Supervisor.init([], strategy: :one_for_one)
   end
 
-  @impl ChannelCache
+  @impl DMChannelCache
   def create(channel), do: convert(channel)
 
-  @impl ChannelCache
+  @impl DMChannelCache
   def update(channel), do: {nil, convert(channel)}
 
-  @impl ChannelCache
+  @impl DMChannelCache
   def delete(_id), do: :noop
 
-  @impl ChannelCache
+  @impl DMChannelCache
   def query_handle, do: :qlc.string_to_handle(~c"[].")
 
   defp convert(%{__struct__: _} = struct), do: struct

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -2,8 +2,8 @@ defmodule Nostrum.Shard.Dispatch do
   @moduledoc false
 
   alias Nostrum.Cache.{
-    ChannelCache,
     ChannelGuildMapping,
+    DMChannelCache,
     GuildCache,
     MemberCache,
     PresenceCache,
@@ -91,7 +91,7 @@ defmodule Nostrum.Shard.Dispatch do
     do: {event, AutoModerationRuleExecute.to_struct(p), state}
 
   def handle_event(:CHANNEL_CREATE = event, %{type: 1} = p, state) do
-    {event, ChannelCache.create(p), state}
+    {event, DMChannelCache.create(p), state}
   end
 
   def handle_event(:CHANNEL_CREATE = event, %{type: t} = p, state) when t in [0, 2] do
@@ -105,7 +105,7 @@ defmodule Nostrum.Shard.Dispatch do
   end
 
   def handle_event(:CHANNEL_DELETE = event, %{type: 1} = p, state) do
-    {event, ChannelCache.delete(p.id), state}
+    {event, DMChannelCache.delete(p.id), state}
   end
 
   def handle_event(:CHANNEL_DELETE = event, %{type: t} = p, state) when t in [0, 2] do
@@ -295,7 +295,7 @@ defmodule Nostrum.Shard.Dispatch do
 
   def handle_event(:READY = event, p, state) do
     p.private_channels
-    |> Enum.each(fn dm_channel -> ChannelCache.create(dm_channel) end)
+    |> Enum.each(fn dm_channel -> DMChannelCache.create(dm_channel) end)
 
     ready_guilds =
       p.guilds

--- a/lib/nostrum/struct/channel.ex
+++ b/lib/nostrum/struct/channel.ex
@@ -19,7 +19,7 @@ defmodule Nostrum.Struct.Channel do
     permission_overwrites: [],
     position: 1,
     type: 5,
-  }
+  }x
   ```
 
   The channel struct implements `String.Chars` protocol through the `mention/1` function. This example uses our channel from the previous code block.

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Nostrum.Mixfile do
       assets: "guides/assets",
       nest_modules_by_prefix: [
         Nostrum.Cache,
-        Nostrum.Cache.ChannelCache,
+        Nostrum.Cache.DMChannelCache,
         Nostrum.Cache.ChannelGuildMapping,
         Nostrum.Cache.GuildCache,
         Nostrum.Cache.MemberCache,

--- a/src/nostrum_dmchannel_cache_qlc.erl
+++ b/src/nostrum_dmchannel_cache_qlc.erl
@@ -1,9 +1,9 @@
--module(nostrum_channel_cache_qlc).
+-module(nostrum_dmchannel_cache_qlc).
 -export([get/2]).
 
 -include_lib("stdlib/include/qlc.hrl").
 
-% Optimized channel cache QLC queries.
+% Optimized DM channel cache QLC queries.
 
 get(RequestedChannelId, Cache) ->
     qlc:q([{ChannelId, Channel} || {ChannelId, Channel} <- Cache:query_handle(),

--- a/test/nostrum/cache/dmchannel_cache_meta_test.exs
+++ b/test/nostrum/cache/dmchannel_cache_meta_test.exs
@@ -1,14 +1,14 @@
-defmodule Nostrum.Cache.ChannelCacheMetaTest do
-  alias Nostrum.Cache.ChannelCache
+defmodule Nostrum.Cache.DMChannelCacheMetaTest do
+  alias Nostrum.Cache.DMChannelCache
   alias Nostrum.Struct.Channel
   use ExUnit.Case, async: true
 
   @cache_modules [
     # Dispatchers
-    ChannelCache,
+    DMChannelCache,
     # Implementations
-    ChannelCache.ETS,
-    ChannelCache.Mnesia
+    DMChannelCache.ETS,
+    DMChannelCache.Mnesia
   ]
 
   for cache <- @cache_modules do
@@ -34,7 +34,7 @@ defmodule Nostrum.Cache.ChannelCacheMetaTest do
         end
 
         test "get/1 returns channel not found" do
-          assert {:error, :not_found} = ChannelCache.get(123, @cache)
+          assert {:error, :not_found} = DMChannelCache.get(123, @cache)
         end
 
         test "create/1 returns channel" do
@@ -63,7 +63,7 @@ defmodule Nostrum.Cache.ChannelCacheMetaTest do
 
         test "get/1 returns channel" do
           expected = Channel.to_struct(@test_channel)
-          assert {:ok, ^expected} = ChannelCache.get(@test_channel.id, @cache)
+          assert {:ok, ^expected} = DMChannelCache.get(@test_channel.id, @cache)
         end
 
         test "update/1 updates a channel" do
@@ -81,7 +81,7 @@ defmodule Nostrum.Cache.ChannelCacheMetaTest do
           deleted = @cache.delete(@test_channel.id)
           expected = Channel.to_struct(@test_channel)
           assert deleted == expected
-          assert {:error, :not_found} = ChannelCache.get(@test_channel.id, @cache)
+          assert {:error, :not_found} = DMChannelCache.get(@test_channel.id, @cache)
 
           # double delete:
           assert :noop == @cache.delete(@test_channel.id)


### PR DESCRIPTION
Since we modified the behaviour of the DMChannelCache to only cache DM Channels it is a good idea to amend the naming of the cache itself to avoid confusion, as well as fleshing out the documentation to further make it clear how caches are expected to operate.

Closes #537