### PR TITLE
Add OTP 27.0-rc3 to our test matrix

### DIFF
--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -48,7 +48,10 @@ jobs:
     strategy:
       matrix:
         elixir-version: ['1.14', '1.15', '1.16']
-        otp-version: ['25', '26']
+        otp-version: ['25', '26', '27.0-rc3']
+        exclude:
+          - elixir-version: '1.14'
+            otp-version: '27.0-rc3'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We can catch any potential snags with Nostrum on OTP 27 here.

I have disabled OTP 27 being used with Elixir v1.14 as that is not going to be a combination we see in production.

If we do have failures on this suite under the OTP release candidate we should investigate it but not make it a required criterion for merges.