### PR TITLE
Only attempt resume if the gateway says we can

### DIFF
--- a/lib/nostrum/shard/event.ex
+++ b/lib/nostrum/shard/event.ex
@@ -56,9 +56,14 @@ defmodule Nostrum.Shard.Event do
     end
   end
 
-  def handle(:invalid_session, _payload, state) do
-    Logger.info("INVALID_SESSION")
-    {{state, Payload.identity_payload(state)}, []}
+  def handle(:invalid_session, %{d: _can_resume? = true}, state) do
+    Logger.info("Invalid but resumable session. Attempting to resume at #{state.session}")
+    {{state, Payload.resume_payload(state)}, []}
+  end
+
+  def handle(:invalid_session, %{d: _can_resume? = false}, state) do
+    Logger.info("Invalid and un-resumable session at #{state.session}. Events may be lost.")
+    {{state, :reconnect}, []}
   end
 
   def handle(:reconnect, _payload, state) do


### PR DESCRIPTION
Per [1] and [2], if the `d` field is set to `true` we may attempt to
resume again with the same session, otherwise we should not. nostrum
would previously loop on trying to resume on the same session after an
invalid session was sent, and the behaviour of simply sending an
identify payload did not work as expected. When the session that we try
to resume with is invalid, perform a reconnect and do the whole
handshake, greeting and meeting the parents thing all over again.

[1]: https://discord.com/developers/docs/topics/gateway-events#invalid-session
[2]: https://discord.com/developers/docs/topics/gateway#resuming
