### PR TITLE
Implement memory optimizations in user struct

### DIFF
--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -31,9 +31,6 @@ defmodule Nostrum.Struct.User do
     :global_name,
     :avatar,
     :bot,
-    :mfa_enabled,
-    :verified,
-    :email,
     :public_flags
   ]
 
@@ -60,15 +57,6 @@ defmodule Nostrum.Struct.User do
   @typedoc "Whether the user is a bot"
   @type bot :: boolean | nil
 
-  @typedoc "Whether the user has two factor enabled"
-  @type mfa_enabled :: boolean | nil
-
-  @typedoc "Whether the email on the account has been verified"
-  @type verified :: boolean | nil
-
-  @typedoc "The user's email"
-  @type email :: String.t() | nil
-
   @typedoc """
   The user's public flags, as a bitset.
 
@@ -83,9 +71,6 @@ defmodule Nostrum.Struct.User do
           global_name: global_name,
           avatar: avatar,
           bot: bot,
-          mfa_enabled: mfa_enabled,
-          verified: verified,
-          email: email,
           public_flags: public_flags
         }
 

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -69,8 +69,12 @@ defmodule Nostrum.Struct.User do
   @typedoc "The user's email"
   @type email :: String.t() | nil
 
-  @typedoc "The user's public flags"
-  @type public_flags :: Flags.t()
+  @typedoc """
+  The user's public flags, as a bitset.
+
+  To parse these, use `Nostrum.Struct.User.Flags.from_integer/1`.
+  """
+  @type public_flags :: Flags.raw_flags()
 
   @type t :: %__MODULE__{
           id: id,
@@ -185,7 +189,6 @@ defmodule Nostrum.Struct.User do
       map
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
       |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
-      |> Map.update(:public_flags, %Flags{}, &Flags.from_integer(&1))
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/struct/user/flags.ex
+++ b/lib/nostrum/struct/user/flags.ex
@@ -102,6 +102,9 @@ defmodule Nostrum.Struct.User.Flags do
 
   @type t :: flags
 
+  @typedoc "Raw user flags as sent by the Discord API"
+  @type raw_flags :: integer()
+
   @flag_values [
     staff: 1 <<< 0,
     partner: 1 <<< 1,
@@ -142,7 +145,7 @@ defmodule Nostrum.Struct.User.Flags do
   }
   ```
   """
-  @spec from_integer(integer()) :: t
+  @spec from_integer(raw_flags()) :: t
   def from_integer(flag_value) do
     boolean_list =
       Enum.map(@flag_values, fn {flag, value} ->
@@ -177,7 +180,7 @@ defmodule Nostrum.Struct.User.Flags do
   131842
   ```
   """
-  @spec to_integer(t) :: integer()
+  @spec to_integer(t) :: raw_flags()
   def to_integer(flag_struct) do
     booleans =
       flag_struct

--- a/test/nostrum/cache/user_cache_meta_test.exs
+++ b/test/nostrum/cache/user_cache_meta_test.exs
@@ -23,9 +23,7 @@ defmodule Nostrum.Cache.UserCacheMetaTest do
         username: "test",
         discriminator: "1234",
         avatar: nil,
-        bot: true,
-        mfa_enabled: nil,
-        verified: nil
+        bot: true
       }
       @test_user_two %{
         id: 54321,
@@ -33,9 +31,7 @@ defmodule Nostrum.Cache.UserCacheMetaTest do
         discriminator: "0",
         global_name: "test_two",
         avatar: nil,
-        bot: true,
-        mfa_enabled: nil,
-        verified: nil
+        bot: true
       }
 
       setup do


### PR DESCRIPTION
- Do not automatically parse user public flags
- Remove OAuth2-only user attributes
