### PR TITLE
Remove obsolete handle_event clause from example consumer

### DIFF
--- a/examples/event_consumer.ex
+++ b/examples/event_consumer.ex
@@ -36,10 +36,4 @@ defmodule ExampleConsumer do
         :ignore
     end
   end
-
-  # Default event handler, if you don't include this, your consumer WILL crash if
-  # you don't have a method definition for each event type.
-  def handle_event(_event) do
-    :noop
-  end
 end


### PR DESCRIPTION
`use Nostrum.Consumer` adds this automatically these days.