### PR TITLE
Fix referenced function in example for `create_global_application_com…

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -3257,7 +3257,7 @@ defmodule Nostrum.Api do
   ## Example
 
   ```elixir
-  Nostrum.Api.create_application_command(
+  Nostrum.Api.create_global_application_command(
     %{name: "edit", description: "ed, man! man, ed", options: []}
   )
   ```


### PR DESCRIPTION
…mand`