### PR TITLE
Update GitHub Action versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,12 +7,12 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '26'
           elixir-version: '1.16'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -12,14 +12,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:
           otp-version: 26
           elixir-version: 1.16
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         env:
           base-key: 26-1.16
         with:
@@ -53,14 +53,14 @@ jobs:
           - elixir-version: '1.14'
             otp-version: '27.0-rc3'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp-version }}
           elixir-version: ${{ matrix.elixir-version }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: _build
           # Generate a hash of the OTP version and Elixir version


### PR DESCRIPTION
Updates GitHub Action versions to latest versions of available actions.

Prevents a spam of 15+ warnings in CI about deprecated node.js versions.