### PR TITLE
Version 0.9.1 Preparation

### DIFF
--- a/appup.ex
+++ b/appup.ex
@@ -1,9 +1,10 @@
 # See the appup cookbook for instructions:
 # https://www.erlang.org/doc/design_principles/appup_cookbook.html
 {
-  ~c"0.9.0",
+  ~c"0.9.1",
   [
     # Upgrade instructions
+    {~c"0.9.0", []},
     {~c"0.9.0-rc1", []},
     {~c"0.9.0-alpha3", []},
     {~c"0.9.0-alpha2", []},

--- a/lib/nostrum/struct/guild/member.ex
+++ b/lib/nostrum/struct/guild/member.ex
@@ -102,12 +102,14 @@ defmodule Nostrum.Struct.Guild.Member do
 
   You can use `avatar_url/3` to fetch a full-formed URL of this asset.
   """
+  @typedoc since: "0.9.1"
   @type avatar :: String.t() | nil
 
   @typedoc """
   Current guild member gate status. `false` if user has yet to pass the membership screening
   configuration for the guild, `true` if the member has passed.
   """
+  @typedoc since: "0.9.1"
   @type pending :: boolean | nil
 
   @typedoc """
@@ -115,6 +117,7 @@ defmodule Nostrum.Struct.Guild.Member do
 
   Look at the `Nostrum.Struct.Guild.Member.Flags` module for guidance parsing this value.
   """
+  @typedoc since: "0.9.1"
   @type flags :: pos_integer() | nil
 
   @type t :: %__MODULE__{
@@ -167,6 +170,7 @@ defmodule Nostrum.Struct.Guild.Member do
   "https://cdn.discordapp.com/guilds/1226944827137069107/users/165023948638126080/avatars/4c8319db8ea745275a1399f8f8aa74ab.png"
   ```
   """
+  @doc since: "0.9.1"
   @spec avatar_url(t, Nostrum.Struct.Guild.id()) :: String.t() | nil
   def avatar_url(member, guild_id, image_format \\ "png")
 

--- a/lib/nostrum/struct/guild/member/flags.ex
+++ b/lib/nostrum/struct/guild/member/flags.ex
@@ -2,6 +2,7 @@ defmodule Nostrum.Struct.Guild.Member.Flags do
   @moduledoc """
   Struct representing the flags a guild member can have.
   """
+  @moduledoc since: "0.9.1"
 
   import Bitwise
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Nostrum.Mixfile do
       app: :nostrum,
       appup: "appup.ex",
       compilers: Mix.compilers() ++ [:appup],
-      version: "0.9.0",
+      version: "0.9.1",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
This should be rebased when merged, the last commit on this PR will be the HEAD for 0.9.1.

- Bump version in mix.exs
- Update appup configuration
- Add since tags to new fields from #573