### PR TITLE
Log at INFO level when shard connection is up

### DIFF
--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -240,7 +240,7 @@ defmodule Nostrum.Shard.Session do
         Logger.debug("Consumer up, we are ready to rumble")
 
       _consumers ->
-        Logger.debug("Shard connection up")
+        Logger.info("Shard connection armed and ready")
     end
 
     :ok = ConsumerGroup.demonitor(reference)


### PR DESCRIPTION
Make logs such as this:

    [info] Asked to reconnect with session SESSION
    [info] Re-established websocket connection
    [info] Resuming on shard session SESSION
    [info] Asked to reconnect with session SESSION
    [info] Re-established websocket connection
    [info] Resuming on shard session SESSION

Less confusing by ensuring the user knows we successfully resumed.