### PR TITLE
Fix the error caused by trying to cast a datetime to datetime

### DIFF
--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -209,11 +209,17 @@ defmodule Nostrum.Util do
   end
 
   @doc """
-  Converts possibly nil ISO8601 timestamp to a `DateTime`
+  Converts possibly nil ISO8601 timestamp to a `DateTime`.
+
+  If a `DateTime` is provided, return it as-is.
   """
-  @spec maybe_to_datetime(String.t() | nil) :: DateTime.t() | nil
+  @spec maybe_to_datetime(String.t() | nil | DateTime.t()) :: DateTime.t() | nil
   def maybe_to_datetime(nil) do
     nil
+  end
+
+  def maybe_to_datetime(%DateTime{} = dt) do
+    dt
   end
 
   def maybe_to_datetime(stamp) do


### PR DESCRIPTION
Users have reported a state machine error caused by what looks to be the
guild upsert process calling the `Nostrum.Util.maybe_to_datetime`
function on a value that is already a datetime.

We can resolve this by just returning datetimes as is from that function
if we are passed one as an argument.