### PR TITLE
Fix Doc Arg Mismatch: Rename "options" to "response"

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -3702,11 +3702,11 @@ defmodule Nostrum.Api do
   directly. See `create_interaction_response/2`.
   """
   @spec create_interaction_response(Interaction.id(), Interaction.token(), map()) :: {:ok} | error
-  def create_interaction_response(id, token, options) do
+  def create_interaction_response(id, token, response) do
     request(
       :post,
       Constants.interaction_callback(id, token),
-      combine_embeds(options) |> combine_files()
+      combine_embeds(response) |> combine_files()
     )
   end
 


### PR DESCRIPTION
This PR renames the `options` arg in `create_interaction_response()/3` to `response` to match the docs and other `create_interaction_response` functions.

Right now, the docs read:

<img width="1030" alt="Screenshot 2024-05-08 at 11 59 29 AM" src="https://github.com/Kraigie/nostrum/assets/3742496/b0725928-5ef0-4e79-b56a-c5f3bf2d93c1">

This threw me off at first as a Discord API noob.

Nostrum rules, thank you for the great software!