### PR TITLE
Check for youtube-dl version on application startup

### DIFF
--- a/lib/nostrum/application.ex
+++ b/lib/nostrum/application.ex
@@ -24,12 +24,6 @@ defmodule Nostrum.Application do
   def start(_type, _args) do
     Token.check_token!()
     check_executables()
-
-    unless Application.get_env(:nostrum, :suppress_youtubedl_version) do
-      if String.contains?(Application.get_env(:nostrum, :youtubedl, "youtube-dl"), "youtube-dl"),
-        do: check_youtubedl()
-    end
-
     check_otp_version()
     Logger.add_translator({Nostrum.StateMachineTranslator, :translate})
 
@@ -74,39 +68,6 @@ defmodule Nostrum.Application do
 
       true ->
         :ok
-    end
-  end
-
-  # youtube-dl has not received active maintenance in the form of a new release
-  # since 2021, as a result of this it no longer works with youtube (though it
-  # DOES work with some other services)
-  #
-  # We opt here to give users the choice on what library to use, and allow for
-  # suppresssion of this warning, but we advise that using the default
-  # youtube-dl install may not work with YouTube.
-  defp check_youtubedl do
-    with bin when is_binary(bin) <-
-           System.find_executable(Application.get_env(:nostrum, :youtubedl, "youtube-dl")),
-         {version, 0} <- System.cmd(bin, ["--version"], stderr_to_stdout: true),
-         {:ok, version_year} when version_year <= @outdated_youtubedl_version <-
-           get_youtubedl_version_year(version) do
-      Logger.warning("""
-      Located youtube-dl installation at '#{bin}' is version #{version |> String.trim_trailing()}.
-
-      This version is known to not support recent YouTube updates preventing it from being able to stream content.
-
-      It is advised to move to a maintained fork such as yt-dlp and configure :nostrum, :youtubedl to point to this version.
-
-      If you know what you are doing, configure :nostrum, :suppress_youtubedl_version to true to silence this warning
-      """)
-    end
-  end
-
-  # Helper to parse 2021 out of "2021.12.17"
-  defp get_youtubedl_version_year(version) do
-    with [year | _rest] <- String.split(version, "."),
-         {year, ""} <- Integer.parse(year) do
-      {:ok, year}
     end
   end
 

--- a/lib/nostrum/struct/voice_state.ex
+++ b/lib/nostrum/struct/voice_state.ex
@@ -27,7 +27,8 @@ defmodule Nostrum.Struct.VoiceState do
     :current_url,
     :player_pid,
     :persist_source,
-    :persist_playback
+    :persist_playback,
+    :type
   ]
 
   def new, do: %__MODULE__{}


### PR DESCRIPTION
Recent updates to YouTube break old versions of youtube-dl, including
the last released version from 2021.

We add a startup check to attempt to fetch the version using the
youtube-dl command line if the configured youtube-dl path contains
`youtube-dl` (to avoid running this check for `yt-dlp`).

The warning advises the user to switch to a maintained fork and outputs
the located youtube-dl binary and the path it is at.

To give the user flexibility, this warning can be disabled using another
configuration key which will suppress the check from running.