### PR TITLE
feat(shard): manually shard connect and reconnect

### DIFF
--- a/guides/intro/intro.md
+++ b/guides/intro/intro.md
@@ -46,7 +46,7 @@ Apart from the `token` field mentioned above, the following fields are also supp
     Useful for splitting a single bot across multiple servers, but see also [the
     multi-node documentation](../advanced/multi_node.md).
   - `:manual`: nostrum does not automatically spawn shards. You should use
-    `Nostrum.Shard.Supervisor.connect/1` to spawn shards instead.
+    `Nostrum.Shard.Supervisor.connect/2` to spawn shards instead.
 - `gateway_intents` - a list of atoms representing gateway intents for Nostrum
   to subscribe to from the Discord API. More information can be found in the
   [gateway intents](./gateway_intents.md) documentation page.

--- a/guides/intro/intro.md
+++ b/guides/intro/intro.md
@@ -45,6 +45,9 @@ Apart from the `token` field mentioned above, the following fields are also supp
     should contain the total amount of shards that your bot is expected to have.
     Useful for splitting a single bot across multiple servers, but see also [the
     multi-node documentation](../advanced/multi_node.md).
+  - `:unstable_manual`: This is not a stable feature. nostrum does not 
+    automatically spawn shards. You should use `Nostrum.Shard.Supervisor.connect/1`
+    to spawn shards instead.
 - `gateway_intents` - a list of atoms representing gateway intents for Nostrum
   to subscribe to from the Discord API. More information can be found in the
   [gateway intents](./gateway_intents.md) documentation page.

--- a/guides/intro/intro.md
+++ b/guides/intro/intro.md
@@ -45,9 +45,8 @@ Apart from the `token` field mentioned above, the following fields are also supp
     should contain the total amount of shards that your bot is expected to have.
     Useful for splitting a single bot across multiple servers, but see also [the
     multi-node documentation](../advanced/multi_node.md).
-  - `:unstable_manual`: This is not a stable feature. nostrum does not 
-    automatically spawn shards. You should use `Nostrum.Shard.Supervisor.connect/1`
-    to spawn shards instead.
+  - `:manual`: nostrum does not automatically spawn shards. You should use
+    `Nostrum.Shard.Supervisor.connect/1` to spawn shards instead.
 - `gateway_intents` - a list of atoms representing gateway intents for Nostrum
   to subscribe to from the Discord API. More information can be found in the
   [gateway intents](./gateway_intents.md) documentation page.

--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -5,8 +5,20 @@ defmodule Nostrum.Shard do
 
   alias Nostrum.Shard.Session
 
-  def start_link([_, shard_num, _total] = opts) do
+  def start_link({:connect, [_, shard_num, _total]} = opts) do
     Supervisor.start_link(__MODULE__, opts, name: :"Nostrum.Shard-#{shard_num}")
+  end
+
+  def start_link(
+        {:reconnect,
+         %{shard: [_gateway, shard_num, _total], resume_gateway: _resume_gateway, seq: _seq}} =
+          opts
+      ) do
+    Supervisor.start_link(__MODULE__, opts, name: :"Nostrum.Shard-#{shard_num}")
+  end
+
+  def start_link([_, _shard_num, _total] = opts) do
+    start_link({:connect, opts})
   end
 
   def init(opts) do

--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -1,7 +1,7 @@
 defmodule Nostrum.Shard do
   @moduledoc false
 
-  use Supervisor
+  use Supervisor, restart: :transient
 
   alias Nostrum.Shard.Session
 
@@ -28,6 +28,11 @@ defmodule Nostrum.Shard do
       # TODO: Add per shard cache
     ]
 
-    Supervisor.init(children, strategy: :one_for_all, max_restarts: 3, max_seconds: 60)
+    Supervisor.init(children,
+      strategy: :one_for_all,
+      max_restarts: 3,
+      max_seconds: 60,
+      auto_shutdown: :any_significant
+    )
   end
 end

--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -16,7 +16,8 @@ defmodule Nostrum.Shard do
            total_shards: _total_shards,
            gateway: _gateway,
            resume_gateway: _resume_gateway,
-           seq: _seq
+           seq: _seq,
+           session: _session
          }} =
           opts
       ) do

--- a/lib/nostrum/shard.ex
+++ b/lib/nostrum/shard.ex
@@ -11,7 +11,13 @@ defmodule Nostrum.Shard do
 
   def start_link(
         {:reconnect,
-         %{shard: [_gateway, shard_num, _total], resume_gateway: _resume_gateway, seq: _seq}} =
+         %{
+           shard_num: shard_num,
+           total_shards: _total_shards,
+           gateway: _gateway,
+           resume_gateway: _resume_gateway,
+           seq: _seq
+         }} =
           opts
       ) do
     Supervisor.start_link(__MODULE__, opts, name: :"Nostrum.Shard-#{shard_num}")

--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -168,6 +168,7 @@ defmodule Nostrum.Shard.Session do
       start: {__MODULE__, :start_link, [opts, []]},
       type: :worker,
       restart: :transient,
+      significant: true,
       shutdown: 500
     }
   end

--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -167,7 +167,7 @@ defmodule Nostrum.Shard.Session do
       id: __MODULE__,
       start: {__MODULE__, :start_link, [opts, []]},
       type: :worker,
-      restart: :permanent,
+      restart: :transient,
       shutdown: 500
     }
   end
@@ -364,7 +364,7 @@ defmodule Nostrum.Shard.Session do
     :ok = :gun.close(conn)
     :ok = :gun.flush(conn)
 
-    {:stop_and_reply, :disconnect,
+    {:stop_and_reply, :normal,
      {:reply, from,
       %{
         shard: [gateway, shard_num, total],

--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -106,7 +106,14 @@ defmodule Nostrum.Shard.Session do
 
   def start_link(
         {:reconnect,
-         %{shard: [_gateway, _shard_num, _total], resume_gateway: _resume_gateway, seq: _seq}} =
+         %{
+           shard_num: _shard_num,
+           total_shards: _total_shards,
+           gateway: _gateway,
+           resume_gateway: _resume_gateway,
+           seq: _seq,
+           session: _session
+         }} =
           opts,
         statem_opts
       ) do
@@ -134,7 +141,9 @@ defmodule Nostrum.Shard.Session do
   def init(
         {:reconnect,
          %{
-           shard: [gateway, shard_num, total],
+           shard_num: shard_num,
+           total_shards: total_shards,
+           gateway: gateway,
            resume_gateway: resume_gateway,
            seq: seq,
            session: session
@@ -145,7 +154,7 @@ defmodule Nostrum.Shard.Session do
     state = %WSState{
       conn_pid: self(),
       shard_num: shard_num,
-      total_shards: total,
+      total_shards: total_shards,
       gateway: gateway,
       resume_gateway: resume_gateway,
       session: session,
@@ -368,7 +377,9 @@ defmodule Nostrum.Shard.Session do
     {:stop_and_reply, :normal,
      {:reply, from,
       %{
-        shard: [gateway, shard_num, total],
+        shard_num: shard_num,
+        total_shards: total,
+        gateway: gateway,
         resume_gateway: resume_gateway,
         session: session,
         seq: seq

--- a/lib/nostrum/shard/supervisor.ex
+++ b/lib/nostrum/shard/supervisor.ex
@@ -124,22 +124,11 @@ defmodule Nostrum.Shard.Supervisor do
   end
 
   def disconnect(shard_num) do
-    name = :"Nostrum.Shard-#{shard_num}"
-
-    children =
-      name
-      |> Supervisor.which_children()
-
-    resume_info =
-      children
-      |> Enum.find(fn {id, _pid, _type, _modules} -> id == Nostrum.Shard.Session end)
-      |> elem(1)
-      |> Session.disconnect()
-
-    shard = Process.whereis(name)
-    DynamicSupervisor.terminate_child(__MODULE__, shard)
-
-    resume_info
+    :"Nostrum.Shard-#{shard_num}"
+    |> Supervisor.which_children()
+    |> Enum.find(fn {id, _pid, _type, _modules} -> id == Nostrum.Shard.Session end)
+    |> elem(1)
+    |> Session.disconnect()
   end
 
   def connect([url, num, total]) do

--- a/lib/nostrum/shard/supervisor.ex
+++ b/lib/nostrum/shard/supervisor.ex
@@ -144,7 +144,7 @@ defmodule Nostrum.Shard.Supervisor do
 
   @doc """
   Disconnects the shard with the given shard number from the Gateway.
-  This function returns resume_information given to `Nostrum.Shard.Supervisor.reconnect/1`.
+  This function returns `resume_information` given to `Nostrum.Shard.Supervisor.reconnect/1`.
   """
   @spec disconnect(shard_num()) :: resume_information()
   def disconnect(shard_num) do
@@ -164,7 +164,7 @@ defmodule Nostrum.Shard.Supervisor do
   end
 
   @doc """
-  Reconnect to the gateway using the given resume information.
+  Reconnect to the gateway using the given `resume_information`.
   In the unlikely event that a shard or session crashes, the connection will resume after a restart, potentially causing events to be delivered more than once.
   For more information about resume, please visit [the Discord Developer Portal](https://discord.com/developers/docs/topics/gateway#resuming).
   """

--- a/lib/nostrum/shard/supervisor.ex
+++ b/lib/nostrum/shard/supervisor.ex
@@ -82,7 +82,7 @@ defmodule Nostrum.Shard.Supervisor do
 
         shard_range = lowest..highest
 
-        for num <- shard_range, do: connect(url, num - 1, total)
+        for num <- shard_range, do: connect([url, num - 1, total])
     end
 
     on_start
@@ -142,7 +142,7 @@ defmodule Nostrum.Shard.Supervisor do
     resume_info
   end
 
-  def connect(url, num, total) do
+  def connect([url, num, total]) do
     DynamicSupervisor.start_child(__MODULE__, create_worker(url, num, total))
   end
 

--- a/lib/nostrum/shard/supervisor.ex
+++ b/lib/nostrum/shard/supervisor.ex
@@ -166,7 +166,6 @@ defmodule Nostrum.Shard.Supervisor do
 
   @doc """
   Reconnect to the gateway using the given `resume_information`.
-  In the unlikely event that a shard or session crashes, the connection will resume after a restart, potentially causing events to be delivered more than once.
   For more information about resume, please visit [the Discord Developer Portal](https://discord.com/developers/docs/topics/gateway#resuming).
   """
   @spec reconnect(resume_information()) :: DynamicSupervisor.on_start_child()

--- a/lib/nostrum/shard/supervisor.ex
+++ b/lib/nostrum/shard/supervisor.ex
@@ -93,7 +93,7 @@ defmodule Nostrum.Shard.Supervisor do
       )
 
     case Application.get_env(:nostrum, :num_shards, :auto) do
-      :unstable_manual ->
+      :manual ->
         on_start
 
       value ->

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -83,6 +83,7 @@ defmodule Nostrum.Util do
 
     case num do
       {_lowest, _highest, total} -> total
+      :unstable_manual -> 0
       nil -> 1
     end
   end

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -83,7 +83,7 @@ defmodule Nostrum.Util do
 
     case num do
       {_lowest, _highest, total} -> total
-      :unstable_manual -> 0
+      :manual -> 0
       nil -> 1
     end
   end


### PR DESCRIPTION
This PR provides the user with functions to connect/reconnect/disconnect to the gateway.
In our use case, this allows for zero downtime updates.
This would also advance Issue #542.

```elixir
# node 1
Nostrum.Shard.Supervisor.connect(0,1) 
info = Nostrum.Shard.Supervisor.disconnect(0)

# node2
Nostrum.Shard.Supervisor.reconnect(info)
```