### PR TITLE
Add flag to disable HTTP

### DIFF
--- a/guides/intro/intro.md
+++ b/guides/intro/intro.md
@@ -98,6 +98,9 @@ Apart from the `token` field mentioned above, the following fields are also supp
   variables or by [setting the system flag
   yourself](http://erlang.org/doc/man/erlang.html#system_flag-2). Defaults to
   whatever your system recommends, which is probably `65535`.
+- `force_http1` - Set to `true` if you wish to disable automatic use of HTTP 2
+  or newer HTTP versions for API requests to Discord. Useful to diagnose issues
+  with ratelimiter connections during abnormal network conditions.
 
 
 ### Internal options


### PR DESCRIPTION
Adds a new config flag `force_http1` that explicitly sets the protocols in the
Gun open options to use HTTP1. By default, if a TLS connection is set in the
`transport` (which defaults to TLS if port 443 is used), then the protocols
defaults to `[:http2, :http]`, preferring HTTP2.

We are currently trying to diagnose an issue with stagnation of connections in
the ratelimiter due to missed responses and this flag would allow us to rule out
HTTP2 as having influence in the problems.

I have tested this locally, as you can see here the first map is an inspected
debug log of the generated options and the response is received as normal:

``` elixir
iex(1)> Nostrum.Api.get_user 165023948638126080
%{
  ...
  protocol: :http,
  transport: :tls,
  ...
  origin_host: ~c"discord.com",
  origin_port: 443,
  origin_scheme: "https",
  ...
}
{:ok,
 %Nostrum.Struct.User{
   id: 165023948638126080,
   username: "joe.banks",
   discriminator: "0",
   global_name: "joe",
   avatar: "a_bbe3b1029f3ab24d8034bebd9772ed2c",
   bot: nil,
   public_flags: 4457216
 }}
```