### PR TITLE
Ensure user struct is casted properly before updating ets cache

### DIFF
--- a/lib/nostrum/cache/user_cache/ets.ex
+++ b/lib/nostrum/cache/user_cache/ets.ex
@@ -54,7 +54,7 @@ defmodule Nostrum.Cache.UserCache.ETS do
     converted = User.to_struct(info)
 
     with {:ok, old_user} <- lookup(info.id),
-         new_user = Map.merge(old_user, info),
+         new_user = Map.merge(old_user, converted),
          false <- old_user == new_user do
       :ets.insert(@table_name, {new_user.id, new_user})
       {old_user, new_user}
@@ -62,8 +62,8 @@ defmodule Nostrum.Cache.UserCache.ETS do
       {:error, _} ->
         # User just came online, make sure to cache if possible
         # TODO: check for `:global_name` once fully rolled out?
-        if Enum.all?([:username, :discriminator], &Map.has_key?(info, &1)),
-          do: :ets.insert(@table_name, {info.id, info})
+        if Enum.all?([:username, :discriminator], & is_map_key(info, &1)),
+          do: :ets.insert(@table_name, {converted.id, converted})
 
         {nil, converted}
 

--- a/lib/nostrum/cache/user_cache/ets.ex
+++ b/lib/nostrum/cache/user_cache/ets.ex
@@ -11,6 +11,7 @@ defmodule Nostrum.Cache.UserCache.ETS do
 
   @table_name :nostrum_users
 
+  alias Nostrum.Snowflake
   alias Nostrum.Struct.User
   use Supervisor
 
@@ -54,7 +55,7 @@ defmodule Nostrum.Cache.UserCache.ETS do
     # We don't know if the user_id is an atom or a string here.
     user_id =
       (Map.get(info, :id) || Map.get(info, "id"))
-      |> Nostrum.Snowflake.cast!()
+      |> Snowflake.cast!()
 
     with {:ok, old_user} <- lookup(user_id),
          new_user = User.to_struct(info, old_user),

--- a/lib/nostrum/cache/user_cache/mnesia.ex
+++ b/lib/nostrum/cache/user_cache/mnesia.ex
@@ -13,6 +13,7 @@ if Code.ensure_loaded?(:mnesia) do
     @behaviour Nostrum.Cache.UserCache
 
     alias Nostrum.Cache.UserCache
+    alias Nostrum.Snowflake
     alias Nostrum.Struct.User
     use Supervisor
 
@@ -86,7 +87,7 @@ if Code.ensure_loaded?(:mnesia) do
       # We don't know if the user_id is an atom or a string here.
       user_id =
         (Map.get(payload, :id) || Map.get(payload, "id"))
-        |> Nostrum.Snowflake.cast!()
+        |> Snowflake.cast!()
 
       :mnesia.activity(:sync_transaction, fn ->
         case :mnesia.read(@table_name, user_id, :write) do

--- a/lib/nostrum/struct/guild/member.ex
+++ b/lib/nostrum/struct/guild/member.ex
@@ -308,4 +308,21 @@ defmodule Nostrum.Struct.Guild.Member do
 
     struct(__MODULE__, new)
   end
+
+  @doc false
+  @spec to_struct(map(), nil | __MODULE__.t()) :: __MODULE__.t()
+  def to_struct(map, nil), do: to_struct(map)
+
+  def to_struct(map, old_user) do
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Util.map_update_if_present(:roles, &Util.cast(&1, {:list, Snowflake}))
+      |> Util.map_update_if_present(:communication_disabled_until, &Util.maybe_to_datetime/1)
+      |> Util.map_update_if_present(:premium_since, &Util.maybe_to_datetime/1)
+      |> Util.map_update_if_present(:joined_at, &Util.maybe_to_unixtime/1)
+      |> Map.put(:user_id, Util.cast(map[:user][:id], Snowflake))
+
+    struct(old_user, new)
+  end
 end

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -179,7 +179,7 @@ defmodule Nostrum.Struct.User do
   end
 
   @doc false
-  @spec to_struct(map(), nil) :: __MODULE__.t()
+  @spec to_struct(map(), nil | __MODULE__.t()) :: __MODULE__.t()
   def to_struct(map, nil), do: to_struct(map)
 
   def to_struct(map, old_user) do

--- a/lib/nostrum/struct/user.ex
+++ b/lib/nostrum/struct/user.ex
@@ -177,4 +177,17 @@ defmodule Nostrum.Struct.User do
 
     struct(__MODULE__, new)
   end
+
+  @doc false
+  @spec to_struct(map(), nil) :: __MODULE__.t()
+  def to_struct(map, nil), do: to_struct(map)
+
+  def to_struct(map, old_user) do
+    new =
+      map
+      |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
+      |> Map.update(:id, nil, &Util.cast(&1, Snowflake))
+
+    struct(old_user, new)
+  end
 end

--- a/test/nostrum/cache/user_cache_meta_test.exs
+++ b/test/nostrum/cache/user_cache_meta_test.exs
@@ -89,7 +89,7 @@ defmodule Nostrum.Cache.UserCacheMetaTest do
 
       describe "update/1" do
         test "returns `{nil, after}` on uncached user" do
-          payload = %{id: 8_284_967_893_178_597_859_421}
+          payload = %{id: 8_284_967_893_178_597}
           expected = {nil, User.to_struct(payload)}
           assert ^expected = @cache.update(payload)
         end


### PR DESCRIPTION
Discovered that the user cache did not always have a properly casted user struct after an update, this fixes that as well as makes it so that updated maps are merged in a way where missing values don't replace existing ones with `nil`