### PR TITLE
Handle case of non matching gun conn pids when receiving a gun_down message

### DIFF
--- a/lib/nostrum/shard/session.ex
+++ b/lib/nostrum/shard/session.ex
@@ -388,6 +388,18 @@ defmodule Nostrum.Shard.Session do
     {:keep_state_and_data, {:next_event, :internal, :reconnect}}
   end
 
+  def connected(
+        :info,
+        {:gun_down, old_conn, _proto, _reason, _killed_streams},
+        %{conn: new_conn}
+        # technically the guard is not needed because of the above clause,
+        # but it makes the intent a bit clearer
+      )
+      when old_conn != new_conn do
+    Logger.debug("Received gun_down message for a previous shard connection. Ignoring message.")
+    :keep_state_and_data
+  end
+
   def connected(:cast, {request, payload}, %{conn: conn, stream: stream})
       when request in [:status_update, :update_voice_state, :request_guild_members] do
     :ok = :gun.ws_send(conn, stream, {:binary, payload})


### PR DESCRIPTION
Occasionally when my bot has to reconnect I would see 2 ready events in quick succession. I noticed from the below stacktrace that the PIDs for the gun connections didn't match and that caused the Shard to blow up.

<details>
  <summary>
   Stacktrace
  </summary>

```erlang
2024-06-23 14:07:30.419 pid=<0.2610.0> [error] ** State machine <0.2610.0> terminating
** Last event = {info,{gun_down,<0.563597.0>,ws,normal,
                                [#Ref<0.1002467860.1931214849.138526>]}}
** When server state  = {connected,#{stream =>
                                         #Ref<0.1002467860.1931214849.143966>,
                                     seq => 30,
                                     '__struct__' =>
                                         'Elixir.Nostrum.Struct.WSState',
                                     session =>
                                         <<"e7c5b7a3c54504b725b76c1ffa68496a">>,
                                     conn => <0.564181.0>,
                                     gateway =>
                                         <<"gateway-us-east1-d.discord.gg">>,
                                     resume_gateway =>
                                         <<"wss://gateway-us-east1-d.discord.gg">>,
                                     shard_num => 0,total_shards => 1,
                                     heartbeat_ack => true,
                                     heartbeat_interval => 41250,
                                     last_heartbeat_ack =>
                                         #{microsecond => {108488,6},
                                           second => 21,
                                           calendar => 'Elixir.Calendar.ISO',
                                           month => 6,
                                           '__struct__' => 'Elixir.DateTime',
                                           utc_offset => 0,std_offset => 0,
                                           year => 2024,hour => 14,day => 23,
                                           zone_abbr => <<"UTC">>,minute => 7,
                                           time_zone => <<"Etc/UTC">>},
                                     conn_pid => <0.2610.0>,
                                     last_heartbeat_send =>
                                         #{microsecond => {164837,6},
                                           second => 34,
                                           calendar => 'Elixir.Calendar.ISO',
                                           month => 6,
                                           '__struct__' => 'Elixir.DateTime',
                                           utc_offset => 0,std_offset => 0,
                                           year => 2024,hour => 14,day => 23,
                                           zone_abbr => <<"UTC">>,minute => 6,
                                           time_zone => <<"Etc/UTC">>},
                                     compress_ctx =>
                                         #Ref<0.1002467860.1927938051.205417>}}
** Reason for termination = error:function_clause
** Callback modules = ['Elixir.Nostrum.Shard.Session']
** Callback mode = [state_functions,state_enter]
** Stacktrace =
**  [{'Elixir.Nostrum.Shard.Session',connected,
         [info,
          {gun_down,<0.563597.0>,ws,normal,
              [#Ref<0.1002467860.1931214849.138526>]},
          #{stream => #Ref<0.1002467860.1931214849.143966>,seq => 30,
            '__struct__' => 'Elixir.Nostrum.Struct.WSState',
            session => <<"e7c5b7a3c54504b725b76c1ffa68496a">>,
            conn => <0.564181.0>,
            gateway => <<"gateway-us-east1-d.discord.gg">>,
            resume_gateway => <<"wss://gateway-us-east1-d.discord.gg">>,
            shard_num => 0,total_shards => 1,heartbeat_ack => true,
            heartbeat_interval => 41250,
            last_heartbeat_ack =>
                #{microsecond => {108488,6},
                  second => 21,calendar => 'Elixir.Calendar.ISO',month => 6,
                  '__struct__' => 'Elixir.DateTime',utc_offset => 0,
                  std_offset => 0,year => 2024,hour => 14,day => 23,
                  zone_abbr => <<"UTC">>,minute => 7,
                  time_zone => <<"Etc/UTC">>},
            conn_pid => <0.2610.0>,
            last_heartbeat_send =>
                #{microsecond => {164837,6},
                  second => 34,calendar => 'Elixir.Calendar.ISO',month => 6,
                  '__struct__' => 'Elixir.DateTime',utc_offset => 0,
                  std_offset => 0,year => 2024,hour => 14,day => 23,
                  zone_abbr => <<"UTC">>,minute => 6,
                  time_zone => <<"Etc/UTC">>},
            compress_ctx => #Ref<0.1002467860.1927938051.205417>}],
         [{file,"lib/nostrum/shard/session.ex"},{line,324}]},
     {gen_statem,loop_state_callback,11,[{file,"gen_statem.erl"},{line,1395}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]
** Time-outs: {1,[{state_timeout,send_heartbeat}]}
```

</details>