### PR TITLE
Optimize fetching individual records on each cache type

### DIFF
--- a/lib/nostrum/cache/user_cache.ex
+++ b/lib/nostrum/cache/user_cache.ex
@@ -23,37 +23,9 @@ defmodule Nostrum.Cache.UserCache do
   ## Behaviour specification
 
   @doc ~s"""
-  Retrieves a user from the cache by id.
-
-  This function can be called with the cache to use as an optional argument. By
-  default, the cache configured at compile time is used.
-
-  ## Example
-
-  ```elixir
-  case Nostrum.Cache.UserCache.get(1111222233334444) do
-    {:ok, user} ->
-      "We found " <> user.username
-    {:error, _reason} ->
-      "No es bueno"
-  end
-  ```
+  Retrieve a user from the cache by id.
   """
-  @spec get(User.id()) :: {:ok, User.t()} | {:error, atom}
-  @spec get(User.id(), module()) :: {:ok, User.t()} | {:error, atom}
-  def get(user_id, cache \\ @configured_cache) do
-    handle = :nostrum_user_cache_qlc.get(user_id, cache)
-
-    wrap_qlc(cache, fn ->
-      case :qlc.eval(handle) do
-        [{_user_id, user}] ->
-          {:ok, user}
-
-        [] ->
-          {:error, :not_found}
-      end
-    end)
-  end
+  @callback get(User.id()) :: {:ok, User.t()} | {:error, atom()}
 
   @doc ~S"""
   Add a new user to the cache based on the Discord Gateway payload.
@@ -122,10 +94,25 @@ defmodule Nostrum.Cache.UserCache do
   @callback child_spec(term()) :: Supervisor.child_spec()
 
   @doc """
+  ## Example
+
+  ```elixir
+  case Nostrum.Cache.UserCache.get(1111222233334444) do
+    {:ok, user} ->
+      "We found " <> user.username
+    {:error, _reason} ->
+      "No es bueno"
+  end
+  ```
+  """
+  @spec get(User.id()) :: {:ok, User.t()} | {:error, atom()}
+  defdelegate get(id), to: @configured_cache
+
+  @doc """
   Same as `get/1`, but raises `Nostrum.Error.CacheError` in case of a failure.
   """
   @spec get!(User.id()) :: no_return | User.t()
-  def get!(id) when is_snowflake(id), do: id |> get |> Util.bangify_find(id, __MODULE__)
+  def get!(id) when is_snowflake(id), do: id |> get() |> Util.bangify_find(id, __MODULE__)
 
   @doc "Call `c:query_handle/0` on the configured cache."
   @doc since: "0.8.0"

--- a/lib/nostrum/cache/user_cache/ets.ex
+++ b/lib/nostrum/cache/user_cache/ets.ex
@@ -32,6 +32,11 @@ defmodule Nostrum.Cache.UserCache.ETS do
   @spec table :: :ets.table()
   def table, do: @table_name
 
+  @doc "Retrieve a user from the cache."
+  @impl Nostrum.Cache.UserCache
+  @spec get(User.id()) :: {:ok, User.t()} | {:error, :user_not_found}
+  def get(id), do: lookup(id)
+
   @doc "Bulk create a list of users from upstream data."
   @impl Nostrum.Cache.UserCache
   @spec bulk_create(Enum.t()) :: :ok

--- a/lib/nostrum/cache/user_cache/mnesia.ex
+++ b/lib/nostrum/cache/user_cache/mnesia.ex
@@ -53,6 +53,21 @@ if Code.ensure_loaded?(:mnesia) do
       :ok
     end
 
+    @doc "Retrieve a user from the cache."
+    @impl UserCache
+    @spec get(User.id()) :: {:ok, User.t()} | {:error, :user_not_found}
+    def get(user_id) do
+      :mnesia.activity(:sync_transaction, fn ->
+        case :mnesia.read(@table_name, user_id) do
+          [{_tag, _id, user}] ->
+            {:ok, user}
+
+          _ ->
+            {:error, :user_not_found}
+        end
+      end)
+    end
+
     # Used by dispatch
 
     @impl UserCache

--- a/lib/nostrum/cache/user_cache/noop.ex
+++ b/lib/nostrum/cache/user_cache/noop.ex
@@ -24,6 +24,9 @@ defmodule Nostrum.Cache.UserCache.NoOp do
   def bulk_create(_users), do: :ok
 
   @impl Nostrum.Cache.UserCache
+  def get(_id), do: {:error, :user_not_found}
+
+  @impl Nostrum.Cache.UserCache
   def create(payload), do: User.to_struct(payload)
 
   @impl Nostrum.Cache.UserCache

--- a/test/nostrum/cache/user_cache_meta_test.exs
+++ b/test/nostrum/cache/user_cache_meta_test.exs
@@ -77,13 +77,13 @@ defmodule Nostrum.Cache.UserCacheMetaTest do
 
       describe "get/1" do
         test "returns error tuple on unknown user" do
-          assert {:error, _reason} = UserCache.get(120_815_092_581_902_580, @cache)
+          assert {:error, _reason} = @cache.get(120_815_092_581_902_580, @cache)
         end
 
         test "returns cached user on known user" do
           expected = User.to_struct(@test_user)
           @cache.create(@test_user)
-          assert {:ok, ^expected} = UserCache.get(@test_user.id, @cache)
+          assert {:ok, ^expected} = @cache.get(@test_user.id)
         end
       end
 


### PR DESCRIPTION
It was reported that for bots in a large number of servers it takes sometimes half a second to fetch a user from the cache under the current `:qlc` based method as it will do a full table scan.

As a workaround, functions which only return a single record by its primary key will be optimized to avoid `:qlc`