### PR TITLE
update/1 on a missing guild should not crash

### DIFF
--- a/lib/nostrum/cache/guild_cache/ets.ex
+++ b/lib/nostrum/cache/guild_cache/ets.ex
@@ -68,13 +68,19 @@ defmodule Nostrum.Cache.GuildCache.ETS do
 
   @doc "Update the given guild in the cache."
   @impl GuildCache
-  @spec update(map()) :: {Guild.t(), Guild.t()}
+  @spec update(map()) :: {Guild.t() | nil, Guild.t()}
   def update(payload) do
-    [{_id, old_guild}] = :ets.lookup(@table_name, payload.id)
     casted = Util.cast(payload, {:struct, Guild})
-    new_guild = Guild.merge(old_guild, casted)
-    true = :ets.update_element(@table_name, payload.id, {2, new_guild})
-    {old_guild, new_guild}
+
+    case :ets.lookup(@table_name, payload.id) do
+      [{_id, old_guild}] ->
+        new_guild = Guild.merge(old_guild, casted)
+        true = :ets.update_element(@table_name, payload.id, {2, new_guild})
+        {old_guild, new_guild}
+
+      [] ->
+        {nil, casted}
+    end
   end
 
   @doc "Delete the given guild from the cache."

--- a/test/nostrum/cache/guild_cache_meta_test.exs
+++ b/test/nostrum/cache/guild_cache_meta_test.exs
@@ -70,6 +70,15 @@ defmodule Nostrum.Cache.GuildCacheMetaTest do
           expected = Guild.to_struct(@test_guild)
           assert ^expected = @cache.create(@test_guild)
         end
+
+        test "update/1 returns {nil, guild}" do
+          expected = Guild.to_struct(@test_guild)
+          assert {nil, ^expected} = @cache.update(@test_guild)
+        end
+
+        test "delete/1 returns nil" do
+          assert nil == @cache.delete(@test_guild.id)
+        end
       end
 
       describe "with cached guild" do


### PR DESCRIPTION
There was an inconsistency between the `ETS` and `Mnesia` implementations where the `ETS` one would crash on an `update/1` if the guild did not currently exist in the cache while the `Mnesia` one would return normally.