### PR TITLE
Stop sending port stderr to stdout

### DIFF
--- a/lib/nostrum/voice/payload.ex
+++ b/lib/nostrum/voice/payload.ex
@@ -5,7 +5,6 @@ defmodule Nostrum.Voice.Payload do
   alias Nostrum.Constants
   alias Nostrum.Struct.VoiceState
   alias Nostrum.Struct.VoiceWSState
-  alias Nostrum.Voice.Crypto
 
   require Logger
 

--- a/lib/nostrum/voice/ports.ex
+++ b/lib/nostrum/voice/ports.ex
@@ -37,8 +37,7 @@ defmodule Nostrum.Voice.Ports do
         :binary,
         :exit_status,
         :use_stdio,
-        :stream,
-        :stderr_to_stdout
+        :stream
       ])
 
     # Spawn process to asynchronously send input to port


### PR DESCRIPTION
Newest versions of `yt-dlp` print out a deprecation warning for Python versions less than 3.9 regardless of the `-q --no-warnings` options. This causes the first output to be non-audio and ffmpeg won't transcode anything from yt-dlp. 
Removing `:stderr_to_stdout` from erlang ports. This means any stderr will be printed to the console but will fix issues encountered when using newer yt-dlp versions with old python.