### PR TITLE
Rename `RoleSelect` and `UserSelect` Functions to Match Module Name

### DIFF
--- a/lib/nostrum/struct/component/role_select.ex
+++ b/lib/nostrum/struct/component/role_select.ex
@@ -27,7 +27,7 @@ defmodule Nostrum.Struct.Component.RoleSelect do
 
   @type opts :: [opt]
 
-  def mentionable_select(custom_id, opts \\ []) when is_binary(custom_id) do
+  def role_select(custom_id, opts \\ []) when is_binary(custom_id) do
     [
       custom_id: custom_id,
       disabled: opts[:disabled],

--- a/lib/nostrum/struct/component/user_select.ex
+++ b/lib/nostrum/struct/component/user_select.ex
@@ -27,7 +27,7 @@ defmodule Nostrum.Struct.Component.UserSelect do
 
   @type opts :: [opt]
 
-  def mentionable_select(custom_id, opts \\ []) when is_binary(custom_id) do
+  def user_select(custom_id, opts \\ []) when is_binary(custom_id) do
     [
       custom_id: custom_id,
       disable: opts[:disabled],


### PR DESCRIPTION
It looks like this was just overlooked when copy/pasting the `MentionableSelect` module.