### PR TITLE
FIXUP - missing content-type header in some Api request calls

### DIFF
--- a/lib/nostrum/api/helpers.ex
+++ b/lib/nostrum/api/helpers.ex
@@ -24,7 +24,7 @@ defmodule Nostrum.Api.Helpers do
   end
 
   @spec maybe_add_reason(String.t() | nil, list()) :: list()
-  def maybe_add_reason(reason, headers \\ [])
+  def maybe_add_reason(reason, headers \\ [{"content-type", "application/json"}])
   def maybe_add_reason(nil, headers), do: headers
 
   def maybe_add_reason(reason, headers) do


### PR DESCRIPTION
Some calls to `Api.request(...)` were missing the required `content-type` header, causing requests to fail with `400` responses.