### PR TITLE
Add Elixir 1.18 to CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '27'
-          elixir-version: '1.17'
+          elixir-version: '1.18'
       - uses: actions/cache@v4
         with:
           path: deps

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        elixir-version: ['1.14', '1.15', '1.16', '1.17']
+        elixir-version: ['1.14', '1.15', '1.16', '1.17', '1.18']
         otp-version: ['25', '26', '27']
         exclude:
           - elixir-version: '1.14'


### PR DESCRIPTION
Adds Elixir 1.18 to the CI matrix and starts building the docs with it instead