### PR TITLE
Change format_error to format in consumer.ex

### DIFF
--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -20,7 +20,7 @@ defmodule Nostrum.Consumer do
           __MODULE__.handle_event(event)
         rescue
           e ->
-            Logger.error("Error in event handler: \#{Exception.format_error(e, __STACKTRACE__)}")
+            Logger.error("Error in event handler: \#{Exception.format(:error, e, __STACKTRACE__)}")
         end
       end)
 
@@ -449,7 +449,7 @@ defmodule Nostrum.Consumer do
             rescue
               e ->
                 Logger.error(
-                  "Error in event handler: #{Exception.format_error(e, __STACKTRACE__)}"
+                  "Error in event handler: #{Exception.format(:error, e, __STACKTRACE__)}"
                 )
             end
           end)


### PR DESCRIPTION
I was getting weird errors with elixir 1.18 because format_error returns a map