### PR TITLE
fix: function clause error in ratelimiter

### DIFF
--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -883,7 +883,7 @@ defmodule Nostrum.Api.Ratelimiter do
 
   def connected(:info, {:gun_down, conn, _, reason, killed_streams}, %{
         running: running,
-        options: options
+        config: config
       }) do
     # Even with `retry: 0`, gun seems to try and reconnect, potentially because
     # of WebSocket. Force the connection to die.
@@ -905,7 +905,7 @@ defmodule Nostrum.Api.Ratelimiter do
         {:reply, client, {:error, {:connection_died, reason}}}
       end)
 
-    {:next_state, :disconnected, empty_state(options), replies}
+    {:next_state, :disconnected, empty_state(config), replies}
   end
 
   def global_limit(:state_timeout, next, data) do


### PR DESCRIPTION
While testing #660 I found a function clause error in the ratelmiter for when we get a `:gun_down` message. A map key probably got renamed but was missed in a spot.