### PR TITLE
replace all instances of `{:ok}` with `:ok` (rebase)

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -258,7 +258,7 @@ defmodule Nostrum.Api do
   Same as `delete_message/2`, but takes a `Nostrum.Struct.Message` instead of a
   `channel_id` and `message_id`.
   """
-  @spec delete_message(Message.t()) :: error | {:ok}
+  @spec delete_message(Message.t()) :: error | :ok
   def delete_message(%Message{id: id, channel_id: c_id}) do
     delete_message(c_id, id)
   end
@@ -276,7 +276,7 @@ defmodule Nostrum.Api do
   Same as `delete_message/1`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_message!(Message.t()) :: error | {:ok}
+  @spec delete_message!(Message.t()) :: error | :ok
   def delete_message!(%Message{id: id, channel_id: c_id}) do
     delete_message(c_id, id)
     |> bangify
@@ -286,7 +286,7 @@ defmodule Nostrum.Api do
   Same as `delete_message/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_message!(Channel.id(), Message.id()) :: no_return | {:ok}
+  @spec delete_message!(Channel.id(), Message.id()) :: no_return | :ok
   def delete_message!(channel_id, message_id) do
     delete_message(channel_id, message_id)
     |> bangify
@@ -305,7 +305,7 @@ defmodule Nostrum.Api do
   Same as `create_reaction/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec create_reaction!(Channel.id(), Message.id(), emoji) :: no_return | {:ok}
+  @spec create_reaction!(Channel.id(), Message.id(), emoji) :: no_return | :ok
   def create_reaction!(channel_id, message_id, emoji) do
     create_reaction(channel_id, message_id, emoji)
     |> bangify
@@ -324,7 +324,7 @@ defmodule Nostrum.Api do
   Same as `delete_own_reaction/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_own_reaction!(Channel.id(), Message.id(), emoji) :: no_return | {:ok}
+  @spec delete_own_reaction!(Channel.id(), Message.id(), emoji) :: no_return | :ok
   def delete_own_reaction!(channel_id, message_id, emoji) do
     delete_own_reaction(channel_id, message_id, emoji)
     |> bangify
@@ -342,7 +342,7 @@ defmodule Nostrum.Api do
   Same as `delete_user_reaction/4`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_user_reaction!(Channel.id(), Message.id(), emoji, User.id()) :: no_return | {:ok}
+  @spec delete_user_reaction!(Channel.id(), Message.id(), emoji, User.id()) :: no_return | :ok
   def delete_user_reaction!(channel_id, message_id, emoji, user_id) do
     delete_user_reaction(channel_id, message_id, emoji, user_id)
     |> bangify
@@ -361,7 +361,7 @@ defmodule Nostrum.Api do
   Same as `delete_reaction/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_reaction!(Channel.id(), Message.id(), emoji) :: no_return | {:ok}
+  @spec delete_reaction!(Channel.id(), Message.id(), emoji) :: no_return | :ok
   def delete_reaction!(channel_id, message_id, emoji) do
     delete_reaction(channel_id, message_id, emoji)
     |> bangify
@@ -399,7 +399,7 @@ defmodule Nostrum.Api do
   Same as `delete_all_reactions/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_all_reactions!(Channel.id(), Message.id()) :: no_return | {:ok}
+  @spec delete_all_reactions!(Channel.id(), Message.id()) :: no_return | :ok
   def delete_all_reactions!(channel_id, message_id) do
     delete_all_reactions(channel_id, message_id)
     |> bangify
@@ -551,7 +551,7 @@ defmodule Nostrum.Api do
   """
   @deprecated "Bang functions will be removed in v1.0"
   @spec bulk_delete_messages!(integer, [Nostrum.Struct.Message.id()], boolean) ::
-          no_return | {:ok}
+          no_return | :ok
   def bulk_delete_messages!(channel_id, messages, filter \\ true) do
     bulk_delete_messages(channel_id, messages, filter)
     |> bangify
@@ -579,7 +579,7 @@ defmodule Nostrum.Api do
             optional(:deny) => integer
           },
           AuditLogEntry.reason()
-        ) :: no_return | {:ok}
+        ) :: no_return | :ok
   def edit_channel_permissions!(channel_id, overwrite_id, permission_info, reason \\ nil) do
     edit_channel_permissions(channel_id, overwrite_id, permission_info, reason)
     |> bangify
@@ -645,7 +645,7 @@ defmodule Nostrum.Api do
   Same as `start_typing/1`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec start_typing!(integer) :: no_return | {:ok}
+  @spec start_typing!(integer) :: no_return | :ok
   def start_typing!(channel_id) do
     start_typing(channel_id)
     |> bangify
@@ -683,7 +683,7 @@ defmodule Nostrum.Api do
   Same as `add_pinned_channel_message/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec add_pinned_channel_message!(Channel.id(), Message.id()) :: no_return | {:ok}
+  @spec add_pinned_channel_message!(Channel.id(), Message.id()) :: no_return | :ok
   def add_pinned_channel_message!(channel_id, message_id) do
     add_pinned_channel_message(channel_id, message_id)
     |> bangify
@@ -702,7 +702,7 @@ defmodule Nostrum.Api do
   Same as `delete_pinned_channel_message/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_pinned_channel_message!(Channel.id(), Message.id()) :: no_return | {:ok}
+  @spec delete_pinned_channel_message!(Channel.id(), Message.id()) :: no_return | :ok
   def delete_pinned_channel_message!(channel_id, message_id) do
     delete_pinned_channel_message(channel_id, message_id)
     |> bangify
@@ -798,7 +798,7 @@ defmodule Nostrum.Api do
   Same as `delete_guild_emoji/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_guild_emoji!(Guild.id(), Emoji.id(), AuditLogEntry.reason()) :: no_return | {:ok}
+  @spec delete_guild_emoji!(Guild.id(), Emoji.id(), AuditLogEntry.reason()) :: no_return | :ok
   def delete_guild_emoji!(guild_id, emoji_id, reason \\ nil) do
     delete_guild_emoji(guild_id, emoji_id, reason)
     |> bangify
@@ -927,7 +927,7 @@ defmodule Nostrum.Api do
   Same as `delete_guild/1`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_guild!(Guild.id()) :: no_return | {:ok}
+  @spec delete_guild!(Guild.id()) :: no_return | :ok
   def delete_guild!(guild_id) do
     delete_guild(guild_id)
     |> bangify
@@ -985,7 +985,7 @@ defmodule Nostrum.Api do
   """
   @deprecated "Bang functions will be removed in v1.0"
   @spec modify_guild_channel_positions!(Guild.id(), [%{id: integer, position: integer}]) ::
-          no_return | {:ok}
+          no_return | :ok
   def modify_guild_channel_positions!(guild_id, positions) do
     modify_guild_channel_positions(guild_id, positions)
     |> bangify
@@ -1042,7 +1042,7 @@ defmodule Nostrum.Api do
   Same as `add_guild_member/3`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec add_guild_member!(Guild.id(), User.id(), options) :: no_return | Member.t() | {:ok}
+  @spec add_guild_member!(Guild.id(), User.id(), options) :: no_return | Member.t() | :ok
   def add_guild_member!(guild_id, user_id, options) do
     add_guild_member(guild_id, user_id, options)
     |> bangify
@@ -1062,7 +1062,7 @@ defmodule Nostrum.Api do
   """
   @deprecated "Bang functions will be removed in v1.0"
   @spec modify_guild_member!(Guild.id(), User.id(), options, AuditLogEntry.reason()) ::
-          error | {:ok}
+          error | :ok
   def modify_guild_member!(guild_id, user_id, options \\ %{}, reason \\ nil) do
     modify_guild_member(guild_id, user_id, options, reason)
     |> bangify
@@ -1118,7 +1118,7 @@ defmodule Nostrum.Api do
   Same as `remove_guild_member/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec remove_guild_member!(Guild.id(), User.id(), AuditLogEntry.reason()) :: no_return | {:ok}
+  @spec remove_guild_member!(Guild.id(), User.id(), AuditLogEntry.reason()) :: no_return | :ok
   def remove_guild_member!(guild_id, user_id, reason \\ nil) do
     remove_guild_member(guild_id, user_id, reason)
     |> bangify
@@ -1254,7 +1254,7 @@ defmodule Nostrum.Api do
   Same as `delete_guild_role/2`, but raises `Nostrum.Error.ApiError` in case of failure.
   """
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_guild_role!(Guild.id(), Role.id(), AuditLogEntry.reason()) :: no_return | {:ok}
+  @spec delete_guild_role!(Guild.id(), Role.id(), AuditLogEntry.reason()) :: no_return | :ok
   def delete_guild_role!(guild_id, role_id, reason \\ nil) do
     delete_guild_role(guild_id, role_id, reason)
     |> bangify
@@ -1880,7 +1880,7 @@ defmodule Nostrum.Api do
   Same as `create_interaction_response/3`, but directly takes the
   `t:Nostrum.Struct.Interaction.t/0` received from the gateway.
   """
-  @spec create_interaction_response(Interaction.t(), map()) :: {:ok} | error
+  @spec create_interaction_response(Interaction.t(), map()) :: :ok | error
   def create_interaction_response(interaction, response) do
     create_interaction_response(interaction.id, interaction.token, response)
   end
@@ -1890,7 +1890,7 @@ defmodule Nostrum.Api do
   """
   @doc since: "0.5.0"
   @deprecated "Bang functions will be removed in v1.0"
-  @spec create_interaction_response!(Interaction.t(), map()) :: no_return() | {:ok}
+  @spec create_interaction_response!(Interaction.t(), map()) :: no_return() | :ok
   def create_interaction_response!(interaction, response) do
     create_interaction_response!(interaction.id, interaction.token, response)
   end
@@ -1965,14 +1965,14 @@ defmodule Nostrum.Api do
   `t:Nostrum.Struct.Interaction.t/0` received from the gateway.
   """
   @doc since: "0.5.0"
-  @spec delete_interaction_response(Interaction.t()) :: {:ok} | error
+  @spec delete_interaction_response(Interaction.t()) :: :ok | error
   def delete_interaction_response(%Interaction{} = interaction) do
     delete_interaction_response(interaction.application_id, interaction.token)
   end
 
   @doc since: "0.5.0"
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_interaction_response!(Interaction.t()) :: no_return() | {:ok}
+  @spec delete_interaction_response!(Interaction.t()) :: no_return() | :ok
   def delete_interaction_response!(%Interaction{} = interaction) do
     delete_interaction_response(interaction.application_id, interaction.token)
     |> bangify
@@ -1992,7 +1992,7 @@ defmodule Nostrum.Api do
   """
   @doc since: "0.5.0"
   @deprecated "Bang functions will be removed in v1.0"
-  @spec delete_interaction_response!(User.id(), Interaction.token()) :: no_return() | {:ok}
+  @spec delete_interaction_response!(User.id(), Interaction.token()) :: no_return() | :ok
   def delete_interaction_response!(id \\ Me.get().id, token) do
     delete_interaction_response(id, token)
     |> bangify
@@ -2038,7 +2038,7 @@ defmodule Nostrum.Api do
   @doc since: "0.5.0"
   @deprecated "Bang functions will be removed in v1.0"
   @spec delete_interaction_followup_message!(User.id(), Interaction.token(), Message.id()) ::
-          no_return() | {:ok}
+          no_return() | :ok
   def delete_interaction_followup_message!(
         application_id \\ Me.get().id,
         token,
@@ -2250,14 +2250,14 @@ defmodule Nostrum.Api do
     to: Nostrum.Api.AutoModeration,
     as: :delete_rule
 
-  @spec request(map()) :: {:ok} | {:ok, String.t()} | error
+  @spec request(map()) :: :ok | {:ok, String.t()} | error
   def request(request) do
     TelemetryShim.span(
       ~w[nostrum api request]a,
       %{method: request.method, route: request.route},
       fn ->
         case Ratelimiter.queue(request) do
-          {:ok} = result ->
+          :ok = result ->
             {result, %{status: :ok}}
 
           {:ok, _response} = result ->
@@ -2271,7 +2271,7 @@ defmodule Nostrum.Api do
   end
 
   @spec request(atom(), String.t(), any, keyword() | map()) ::
-          {:ok} | {:ok, String.t()} | error
+          :ok | {:ok, String.t()} | error
   def request(method, route, body \\ "", params \\ [])
 
   def request(method, route, %{} = body, params) when has_files(body),
@@ -2292,7 +2292,7 @@ defmodule Nostrum.Api do
   end
 
   @spec request_multipart(atom(), String.t(), any, keyword() | map()) ::
-          {:ok} | {:ok, String.t()} | error
+          :ok | {:ok, String.t()} | error
   def request_multipart(method, route, body, params \\ []) do
     boundary = Helpers.generate_boundary()
 
@@ -2318,7 +2318,7 @@ defmodule Nostrum.Api do
   @doc false
   def bangify({:error, error}), do: raise(error)
   def bangify({:ok, body}), do: body
-  def bangify({:ok}), do: {:ok}
+  def bangify(:ok), do: :ok
 
   def create_multipart(files, json, boundary) do
     json_mime = MIME.type("json")

--- a/lib/nostrum/api/application_command.ex
+++ b/lib/nostrum/api/application_command.ex
@@ -199,8 +199,8 @@ defmodule Nostrum.Api.ApplicationCommand do
     If not given, this will be fetched from `Me`.
   - `command_id`: The current snowflake of the command.
   """
-  @spec delete_global_command(Snowflake.t()) :: {:ok} | Api.error()
-  @spec delete_global_command(User.id(), Snowflake.t()) :: {:ok} | Api.error()
+  @spec delete_global_command(Snowflake.t()) :: :ok | Api.error()
+  @spec delete_global_command(User.id(), Snowflake.t()) :: :ok | Api.error()
   def delete_global_command(application_id \\ Me.get().id, command_id) do
     Api.request(:delete, Constants.global_application_command(application_id, command_id))
   end
@@ -214,9 +214,9 @@ defmodule Nostrum.Api.ApplicationCommand do
   - `guild_id`: The guild on which the command exists.
   - `command_id`: The current snowflake of the command.
   """
-  @spec delete_guild_command(Guild.id(), Snowflake.t()) :: {:ok} | Api.error()
+  @spec delete_guild_command(Guild.id(), Snowflake.t()) :: :ok | Api.error()
   @spec delete_guild_command(User.id(), Guild.id(), Snowflake.t()) ::
-          {:ok} | Api.error()
+          :ok | Api.error()
   def delete_guild_command(
         application_id \\ Me.get().id,
         guild_id,

--- a/lib/nostrum/api/auto_moderation.ex
+++ b/lib/nostrum/api/auto_moderation.ex
@@ -44,7 +44,7 @@ defmodule Nostrum.Api.AutoModeration do
   """
   @doc since: "1.x.x"
   @spec delete_rule(Guild.id(), AutoModerationRule.id()) ::
-          {:ok} | Api.error()
+          :ok | Api.error()
   def delete_rule(guild_id, rule_id) do
     Api.request(:delete, Constants.guild_auto_moderation_rule(guild_id, rule_id))
   end

--- a/lib/nostrum/api/channel.ex
+++ b/lib/nostrum/api/channel.ex
@@ -25,7 +25,7 @@ defmodule Nostrum.Api.Channel do
   `t:Nostrum.Consumer.message_update/0` and
   `t:Nostrum.Consumer.channel_pins_update/0` events.
 
-  If successful, returns `{:ok}`. Otherwise, returns a `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns a `t:Nostrum.Api.error/0`.
 
   ## Examples
 
@@ -33,7 +33,7 @@ defmodule Nostrum.Api.Channel do
   Nostrum.Api.Channel.pin_message(43189401384091, 18743893102394)
   ```
   """
-  @spec pin_message(Channel.id(), Message.id()) :: Api.error() | {:ok}
+  @spec pin_message(Channel.id(), Message.id()) :: Api.error() | :ok
   def pin_message(channel_id, message_id)
       when is_snowflake(channel_id) and is_snowflake(message_id) do
     Api.request(:put, Constants.channel_pin(channel_id, message_id))
@@ -53,7 +53,7 @@ defmodule Nostrum.Api.Channel do
   `Filter` is an optional parameter that specifies whether messages sent over
   two weeks ago should be filtered out; defaults to `true`.
   """
-  @spec bulk_delete_messages(Channel.id(), [Message.id()], boolean) :: Api.error() | {:ok}
+  @spec bulk_delete_messages(Channel.id(), [Message.id()], boolean) :: Api.error() | :ok
   def bulk_delete_messages(channel_id, messages, filter \\ true)
 
   def bulk_delete_messages(channel_id, messages, false),
@@ -76,7 +76,7 @@ defmodule Nostrum.Api.Channel do
   @spec send_chunked_delete(
           [Message.id()] | Enum.t(),
           Snowflake.t()
-        ) :: Api.error() | {:ok}
+        ) :: Api.error() | :ok
   defp send_chunked_delete(messages, channel_id) do
     messages
     |> Stream.chunk_every(100)
@@ -87,7 +87,7 @@ defmodule Nostrum.Api.Channel do
         %{messages: message_chunk}
       )
     end)
-    |> Enum.find({:ok}, &match?({:error, _}, &1))
+    |> Enum.find(:ok, &match?({:error, _}, &1))
   end
 
   @doc """
@@ -169,7 +169,7 @@ defmodule Nostrum.Api.Channel do
   Role or user overwrite to delete is specified by `channel_id` and `overwrite_id`.
   An optional `reason` can be given for the audit log.
   """
-  @spec delete_permissions(Channel.id(), integer, AuditLogEntry.reason()) :: Api.error() | {:ok}
+  @spec delete_permissions(Channel.id(), integer, AuditLogEntry.reason()) :: Api.error() | :ok
   def delete_permissions(channel_id, overwrite_id, reason \\ nil) do
     Api.request(%{
       method: :delete,
@@ -188,9 +188,9 @@ defmodule Nostrum.Api.Channel do
   `t:Nostrum.Consumer.message_update/0` and
   `t:Nostrum.Consumer.channel_pins_update/0` events.
 
-  Returns `{:ok}` if successful. `error` otherwise.
+  Returns `:ok` if successful. `error` otherwise.
   """
-  @spec unpin_message(Channel.id(), Message.id()) :: Api.error() | {:ok}
+  @spec unpin_message(Channel.id(), Message.id()) :: Api.error() | :ok
   def unpin_message(channel_id, message_id)
       when is_snowflake(channel_id) and is_snowflake(message_id) do
     Api.request(:delete, Constants.channel_pin(channel_id, message_id))
@@ -222,7 +222,7 @@ defmodule Nostrum.Api.Channel do
             optional(:deny) => integer
           },
           AuditLogEntry.reason()
-        ) :: Api.error() | {:ok}
+        ) :: Api.error() | :ok
   def edit_permissions(channel_id, overwrite_id, permission_info, reason \\ nil) do
     Api.request(%{
       method: :put,
@@ -409,9 +409,9 @@ defmodule Nostrum.Api.Channel do
   Triggers the typing indicator in the channel specified by `channel_id`.
   The typing indicator lasts for about 8 seconds and then automatically stops.
 
-  Returns `{:ok}` if successful. `error` otherwise.
+  Returns `:ok` if successful. `error` otherwise.
   """
-  @spec start_typing(integer) :: Api.error() | {:ok}
+  @spec start_typing(integer) :: Api.error() | :ok
   def start_typing(channel_id) do
     Api.request(:post, Constants.channel_typing(channel_id))
   end

--- a/lib/nostrum/api/guild.ex
+++ b/lib/nostrum/api/guild.ex
@@ -32,7 +32,7 @@ defmodule Nostrum.Api.Guild do
   situationally requires the `MANAGE_NICKNAMES`, `MANAGE_ROLES`,
   `MUTE_MEMBERS`, and `DEAFEN_MEMBERS` permissions.
 
-  If successful, returns `{:ok, member}` or `{:ok}` if the user was already a member of the
+  If successful, returns `{:ok, member}` or `:ok` if the user was already a member of the
   guild. Otherwise, returns a `t:Nostrum.Api.error/0`.
 
   ## Options
@@ -58,7 +58,7 @@ defmodule Nostrum.Api.Guild do
   ```
   """
   @spec add_member(Guild.id(), User.id(), Api.options()) ::
-          Api.error() | {:ok, Member.t()} | {:ok}
+          Api.error() | {:ok, Member.t()} | :ok
   def add_member(guild_id, user_id, options)
 
   def add_member(guild_id, user_id, options) when is_list(options),
@@ -78,7 +78,7 @@ defmodule Nostrum.Api.Guild do
   An optional `reason` can be given for the audit log.
   """
   @spec add_member_role(Guild.id(), User.id(), Role.id(), AuditLogEntry.reason()) ::
-          Api.error() | {:ok}
+          Api.error() | :ok
   def add_member_role(guild_id, user_id, role_id, reason \\ nil) do
     Api.request(%{
       method: :put,
@@ -128,7 +128,7 @@ defmodule Nostrum.Api.Guild do
   An optional `reason` can be specified for the audit log.
   """
   @spec ban_member(Guild.id(), User.id(), integer, AuditLogEntry.reason()) ::
-          Api.error() | {:ok}
+          Api.error() | :ok
   def ban_member(guild_id, user_id, days_to_delete, reason \\ nil) do
     Api.request(%{
       method: :put,
@@ -197,7 +197,7 @@ defmodule Nostrum.Api.Guild do
   @spec create_integration(integer, %{
           type: String.t(),
           id: integer
-        }) :: Api.error() | {:ok}
+        }) :: Api.error() | :ok
   def create_integration(guild_id, options) do
     Api.request(:post, Constants.guild_integrations(guild_id), options)
   end
@@ -253,16 +253,16 @@ defmodule Nostrum.Api.Guild do
   This endpoint requires that the current user is the owner of the guild.
   It fires the `t:Nostrum.Consumer.guild_delete/0` event.
 
-  If successful, returns `{:ok}`. Otherwise, returns a `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns a `t:Nostrum.Api.error/0`.
 
   ## Examples
 
   ```elixir
   Nostrum.Api.Guild.delete(81384788765712384)
-  {:ok}
+  :ok
   ```
   """
-  @spec delete(Guild.id()) :: Api.error() | {:ok}
+  @spec delete(Guild.id()) :: Api.error() | :ok
   def delete(guild_id) when is_snowflake(guild_id) do
     Api.request(:delete, Constants.guild(guild_id))
   end
@@ -275,10 +275,10 @@ defmodule Nostrum.Api.Guild do
   This endpoint requires the `MANAGE_EMOJIS` permission. It fires a
   `t:Nostrum.Consumer.guild_emojis_update/0` event.
 
-  If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns `t:Nostrum.Api.error/0`.
   """
   @spec delete_emoji(Guild.id(), Emoji.id(), AuditLogEntry.reason()) ::
-          Api.error() | {:ok}
+          Api.error() | :ok
   def delete_emoji(guild_id, emoji_id, reason \\ nil) do
     Api.request(%{
       method: :delete,
@@ -294,7 +294,7 @@ defmodule Nostrum.Api.Guild do
 
   Integration to delete is specified by `guild_id` and `integeration_id`.
   """
-  @spec delete_integration(Guild.id(), integer) :: Api.error() | {:ok}
+  @spec delete_integration(Guild.id(), integer) :: Api.error() | :ok
   def delete_integration(guild_id, integration_id) do
     Api.request(:delete, Constants.guild_integration(guild_id, integration_id))
   end
@@ -307,7 +307,7 @@ defmodule Nostrum.Api.Guild do
   This endpoint requires the `MANAGE_ROLES` permission. It fires a
   `t:Nostrum.Consumer.guild_role_delete/0` event.
 
-  If successful, returns `{:ok}`. Otherwise, returns a `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns a `t:Nostrum.Api.error/0`.
 
   ## Examples
 
@@ -315,7 +315,7 @@ defmodule Nostrum.Api.Guild do
   Nostrum.Api.Guild.delete_role(41771983423143937, 392817238471936)
   ```
   """
-  @spec delete_role(Guild.id(), Role.id(), AuditLogEntry.reason()) :: Api.error() | {:ok}
+  @spec delete_role(Guild.id(), Role.id(), AuditLogEntry.reason()) :: Api.error() | :ok
   def delete_role(guild_id, role_id, reason \\ nil)
       when is_snowflake(guild_id) and is_snowflake(role_id) do
     Api.request(%{
@@ -514,7 +514,7 @@ defmodule Nostrum.Api.Guild do
   An optional `reason` can be given for the audit log.
   """
   @spec remove_member_role(Guild.id(), User.id(), Role.id(), AuditLogEntry.reason()) ::
-          Api.error() | {:ok}
+          Api.error() | :ok
   def remove_member_role(guild_id, user_id, role_id, reason \\ nil) do
     Api.request(%{
       method: :delete,
@@ -589,7 +589,7 @@ defmodule Nostrum.Api.Guild do
 
   Guild to leave is specified by `guild_id`.
   """
-  @spec leave(Guild.id()) :: Api.error() | {:ok}
+  @spec leave(Guild.id()) :: Api.error() | :ok
   def leave(guild_id) do
     Api.request(%{
       method: :delete,
@@ -743,11 +743,11 @@ defmodule Nostrum.Api.Guild do
 
   ```elixir
   Nostrum.Api.Guild.modify_channel_positions(279093381723062272, [%{id: 351500354581692420, position: 2}])
-  {:ok}
+  :ok
   ```
   """
   @spec modify_channel_positions(Guild.id(), [%{id: Channel.id(), position: integer}]) ::
-          Api.error() | {:ok}
+          Api.error() | :ok
   def modify_channel_positions(guild_id, positions)
       when is_snowflake(guild_id) and is_list(positions) do
     Api.request(:patch, Constants.guild_channels(guild_id), positions)
@@ -807,7 +807,7 @@ defmodule Nostrum.Api.Guild do
           expire_behaviour: integer,
           expire_grace_period: integer,
           enable_emoticons: boolean
-        }) :: Api.error() | {:ok}
+        }) :: Api.error() | :ok
   def modify_integration(guild_id, integration_id, options) do
     Api.request(:patch, Constants.guild_integration(guild_id, integration_id), options)
   end
@@ -911,7 +911,7 @@ defmodule Nostrum.Api.Guild do
   User to unban is specified by `guild_id` and `user_id`.
   An optional `reason` can be specified for the audit log.
   """
-  @spec unban_member(Guild.id(), User.id(), AuditLogEntry.reason()) :: Api.error() | {:ok}
+  @spec unban_member(Guild.id(), User.id(), AuditLogEntry.reason()) :: Api.error() | :ok
   def unban_member(guild_id, user_id, reason \\ nil) do
     Api.request(%{
       method: :delete,
@@ -930,16 +930,16 @@ defmodule Nostrum.Api.Guild do
 
   An optional reason can be provided for the audit log with `reason`.
 
-  If successful, returns `{:ok}`. Otherwise, returns a `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns a `t:Nostrum.Api.error/0`.
 
   ## Examples
 
   ```elixir
   iex> Nostrum.Api.Guild.kick_member(1453827904102291, 18739485766253)
-  {:ok}
+  :ok
   ```
   """
-  @spec kick_member(Guild.id(), User.id(), AuditLogEntry.reason()) :: Api.error() | {:ok}
+  @spec kick_member(Guild.id(), User.id(), AuditLogEntry.reason()) :: Api.error() | :ok
   def kick_member(guild_id, user_id, reason \\ nil)
       when is_snowflake(guild_id) and is_snowflake(user_id) do
     Api.request(%{
@@ -956,7 +956,7 @@ defmodule Nostrum.Api.Guild do
 
   Integration to sync is specified by `guild_id` and `integeration_id`.
   """
-  @spec sync_integration(Guild.id(), Integration.id()) :: Api.error() | {:ok}
+  @spec sync_integration(Guild.id(), Integration.id()) :: Api.error() | :ok
   def sync_integration(guild_id, integration_id) do
     Api.request(:post, Constants.guild_integration_sync(guild_id, integration_id))
   end

--- a/lib/nostrum/api/helpers.ex
+++ b/lib/nostrum/api/helpers.ex
@@ -11,7 +11,7 @@ defmodule Nostrum.Api.Helpers do
 
   def handle_request_with_decode(response, type)
   # add_guild_member/3 can return both a 201 and a 204
-  def handle_request_with_decode({:ok}, _type), do: {:ok}
+  def handle_request_with_decode(:ok, _type), do: :ok
   def handle_request_with_decode({:error, _} = error, _type), do: error
 
   def handle_request_with_decode({:ok, body}, type) do

--- a/lib/nostrum/api/interaction.ex
+++ b/lib/nostrum/api/interaction.ex
@@ -29,7 +29,7 @@ defmodule Nostrum.Api.Interaction do
   Same as `create_response/3`, but directly takes the
   `t:Nostrum.Struct.Interaction.t/0` received from the gateway.
   """
-  @spec create_response(Interaction.t(), map()) :: {:ok} | Api.error()
+  @spec create_response(Interaction.t(), map()) :: :ok | Api.error()
   def create_response(interaction, response) do
     create_response(interaction.id, interaction.token, response)
   end
@@ -68,7 +68,7 @@ defmodule Nostrum.Api.Interaction do
   original `t:Nostrum.Struct.Interaction.t/0` can also be passed
   directly. See `create_response/2`.
   """
-  @spec create_response(Interaction.id(), Interaction.token(), map()) :: {:ok} | Api.error()
+  @spec create_response(Interaction.id(), Interaction.token(), map()) :: :ok | Api.error()
   def create_response(id, token, response) do
     Api.request(
       :post,
@@ -88,7 +88,7 @@ defmodule Nostrum.Api.Interaction do
   - `message_id`: Followup message ID.
   """
   @spec delete_followup_message(User.id(), Interaction.token(), Message.id()) ::
-          {:ok} | Api.error()
+          :ok | Api.error()
   def delete_followup_message(
         application_id \\ Me.get().id,
         token,
@@ -105,7 +105,7 @@ defmodule Nostrum.Api.Interaction do
   `t:Nostrum.Struct.Interaction.t/0` received from the gateway.
   """
   @doc since: "1.x.x"
-  @spec delete_response(Interaction.t()) :: {:ok} | Api.error()
+  @spec delete_response(Interaction.t()) :: :ok | Api.error()
   def delete_response(%Interaction{application_id: application_id, token: token}) do
     delete_response(application_id, token)
   end
@@ -114,7 +114,7 @@ defmodule Nostrum.Api.Interaction do
   Deletes the original interaction response.
   """
   @doc since: "1.x.x"
-  @spec delete_response(User.id(), Interaction.token()) :: {:ok} | Api.error()
+  @spec delete_response(User.id(), Interaction.token()) :: :ok | Api.error()
   def delete_response(id \\ Me.get().id, token) do
     Api.request(:delete, Constants.interaction_callback_original(id, token))
   end

--- a/lib/nostrum/api/message.ex
+++ b/lib/nostrum/api/message.ex
@@ -119,7 +119,7 @@ defmodule Nostrum.Api.Message do
   the `emoji`, this endpoint requires the `ADD_REACTIONS` permission. It
   fires a `t:Nostrum.Consumer.message_reaction_add/0` event.
 
-  If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
   ## Examples
 
@@ -135,7 +135,7 @@ defmodule Nostrum.Api.Message do
 
   For other emoji string examples, see `t:Nostrum.Struct.Emoji.api_name/0`.
   """
-  @spec react(Channel.id(), Message.id(), Api.emoji()) :: Api.error() | {:ok}
+  @spec react(Channel.id(), Message.id(), Api.emoji()) :: Api.error() | :ok
   def react(channel_id, message_id, emoji)
 
   def react(channel_id, message_id, %Emoji{} = emoji),
@@ -151,9 +151,9 @@ defmodule Nostrum.Api.Message do
   This endpoint requires the `VIEW_CHANNEL`, `READ_MESSAGE_HISTORY`, and
   `MANAGE_MESSAGES` permissions. It fires a `t:Nostrum.Consumer.message_reaction_remove_all/0` event.
 
-  If successful, returns `{:ok}`. Otherwise, return `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, return `t:Nostrum.Api.error/0`.
   """
-  @spec clear_reactions(Channel.id(), Message.id()) :: Api.error() | {:ok}
+  @spec clear_reactions(Channel.id(), Message.id()) :: Api.error() | :ok
   def clear_reactions(channel_id, message_id) do
     Api.request(:delete, Constants.channel_reactions_delete(channel_id, message_id))
   end
@@ -162,7 +162,7 @@ defmodule Nostrum.Api.Message do
   Same as `delete/2`, but takes a `Nostrum.Struct.Message` instead of a
   `channel_id` and `message_id`.
   """
-  @spec delete(Message.t()) :: Api.error() | {:ok}
+  @spec delete(Message.t()) :: Api.error() | :ok
   def delete(%Message{id: id, channel_id: c_id}) do
     delete(c_id, id)
   end
@@ -173,7 +173,7 @@ defmodule Nostrum.Api.Message do
   This endpoint requires the 'VIEW_CHANNEL' and 'MANAGE_MESSAGES' permission. It
   fires the `MESSAGE_DELETE` event.
 
-  If successful, returns `{:ok}`. Otherwise, returns a `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns a `t:Nostrum.Api.error/0`.
 
   ## Examples
 
@@ -181,7 +181,7 @@ defmodule Nostrum.Api.Message do
   Nostrum.Api.Message.delete(43189401384091, 43189401384091)
   ```
   """
-  @spec delete(Channel.id(), Message.id()) :: Api.error() | {:ok}
+  @spec delete(Channel.id(), Message.id()) :: Api.error() | :ok
   def delete(channel_id, message_id)
       when is_snowflake(channel_id) and is_snowflake(message_id) do
     Api.request(:delete, Constants.channel_message(channel_id, message_id))
@@ -193,11 +193,11 @@ defmodule Nostrum.Api.Message do
   This endpoint requires the `VIEW_CHANNEL` and `READ_MESSAGE_HISTORY`
   permissions. It fires a `t:Nostrum.Consumer.message_reaction_remove/0` event.
 
-  If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
   See `react/3` for similar examples.
   """
-  @spec unreact(Channel.id(), Message.id(), Api.emoji()) :: Api.error() | {:ok}
+  @spec unreact(Channel.id(), Message.id(), Api.emoji()) :: Api.error() | :ok
   def unreact(channel_id, message_id, emoji)
 
   def unreact(channel_id, message_id, %Emoji{} = emoji),
@@ -212,11 +212,11 @@ defmodule Nostrum.Api.Message do
 
   This endpoint requires the `MANAGE_MESSAGES` permissions. It fires a `t:Nostrum.Consumer.message_reaction_remove_emoji/0` event.
 
-  If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
   See `react/3` for similar examples.
   """
-  @spec delete_emoji_reactions(Channel.id(), Message.id(), Api.emoji()) :: Api.error() | {:ok}
+  @spec delete_emoji_reactions(Channel.id(), Message.id(), Api.emoji()) :: Api.error() | :ok
   def delete_emoji_reactions(channel_id, message_id, emoji)
 
   def delete_emoji_reactions(channel_id, message_id, %Emoji{} = emoji),
@@ -235,12 +235,12 @@ defmodule Nostrum.Api.Message do
   This endpoint requires the `VIEW_CHANNEL`, `READ_MESSAGE_HISTORY`, and
   `MANAGE_MESSAGES` permissions. It fires a `t:Nostrum.Consumer.message_reaction_remove/0` event.
 
-  If successful, returns `{:ok}`. Otherwise, returns `t:Nostrum.Api.error/0`.
+  If successful, returns `:ok`. Otherwise, returns `t:Nostrum.Api.error/0`.
 
   See `react/3` for similar examples.
   """
   @spec delete_user_reaction(Channel.id(), Message.id(), Api.emoji(), User.id()) ::
-          Api.error() | {:ok}
+          Api.error() | :ok
   def delete_user_reaction(channel_id, message_id, emoji, user_id)
 
   def delete_user_reaction(channel_id, message_id, %Emoji{} = emoji, user_id),

--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -1129,7 +1129,7 @@ defmodule Nostrum.Api.Ratelimiter do
         {:ok, body}
 
       {:ok, {204, _, _}} ->
-        {:ok}
+        :ok
 
       {:ok, {status, _, body}} ->
         response =

--- a/lib/nostrum/api/scheduled_event.ex
+++ b/lib/nostrum/api/scheduled_event.ex
@@ -62,7 +62,7 @@ defmodule Nostrum.Api.ScheduledEvent do
   """
   @doc since: "1.x.x"
   @spec delete(Guild.id(), ScheduledEvent.id()) ::
-          Api.error() | {:ok}
+          Api.error() | :ok
   def delete(guild_id, event_id) do
     Api.request(:delete, Constants.guild_scheduled_event(guild_id, event_id))
   end

--- a/lib/nostrum/api/sticker.ex
+++ b/lib/nostrum/api/sticker.ex
@@ -88,7 +88,7 @@ defmodule Nostrum.Api.Sticker do
   Delete a guild sticker with the specified ID.
   """
   @doc since: "1.x.x"
-  @spec delete(Guild.id(), Sticker.id()) :: {:ok} | Api.error()
+  @spec delete(Guild.id(), Sticker.id()) :: :ok | Api.error()
   def delete(guild_id, sticker_id) do
     Api.request(:delete, Constants.guild_sticker(guild_id, sticker_id))
   end

--- a/lib/nostrum/api/thread.ex
+++ b/lib/nostrum/api/thread.ex
@@ -22,7 +22,7 @@ defmodule Nostrum.Api.Thread do
   Add a user to a thread, requires the ability to send messages in the thread.
   """
   @doc since: "1.x.x"
-  @spec add_member(Channel.id(), User.id()) :: {:ok} | Api.error()
+  @spec add_member(Channel.id(), User.id()) :: :ok | Api.error()
   def add_member(thread_id, user_id) do
     Api.request(:put, Constants.thread_member(thread_id, user_id))
   end
@@ -53,7 +53,7 @@ defmodule Nostrum.Api.Thread do
   Join an existing thread, requires that the thread is not archived.
   """
   @doc since: "1.x.x"
-  @spec join(Channel.id()) :: {:ok} | Api.error()
+  @spec join(Channel.id()) :: :ok | Api.error()
   def join(thread_id) do
     Api.request(:put, Constants.thread_member_me(thread_id))
   end
@@ -62,7 +62,7 @@ defmodule Nostrum.Api.Thread do
   Leave a thread, requires that the thread is not archived.
   """
   @doc since: "1.x.x"
-  @spec leave(Channel.id()) :: {:ok} | Api.error()
+  @spec leave(Channel.id()) :: :ok | Api.error()
   def leave(thread_id) do
     Api.request(:delete, Constants.thread_member_me(thread_id))
   end
@@ -199,7 +199,7 @@ defmodule Nostrum.Api.Thread do
   Also requires the `MANAGE_THREADS` permission, or the creator of the thread if the thread is private.
   """
   @doc since: "1.x.x"
-  @spec remove_member(Channel.id(), User.id()) :: {:ok} | Api.error()
+  @spec remove_member(Channel.id(), User.id()) :: :ok | Api.error()
   def remove_member(thread_id, user_id) do
     Api.request(:delete, Constants.thread_member(thread_id, user_id))
   end

--- a/lib/nostrum/api/webhook.ex
+++ b/lib/nostrum/api/webhook.ex
@@ -54,7 +54,7 @@ defmodule Nostrum.Api.Webhook do
     - `webhook_id` - Id of webhook to delete.
     - `reason` - An optional reason for the guild audit log.
   """
-  @spec delete(Webhook.id(), AuditLogEntry.reason()) :: Api.error() | {:ok}
+  @spec delete(Webhook.id(), AuditLogEntry.reason()) :: Api.error() | :ok
   def delete(webhook_id, reason \\ nil) do
     Api.request(%{
       method: :delete,
@@ -95,7 +95,7 @@ defmodule Nostrum.Api.Webhook do
     - `webhook_id` - Id of the webhook to execute.
     - `webhook_token` - Token of the webhook to execute.
   """
-  @spec execute_git(Webhook.id(), Webhook.token(), boolean) :: Api.error() | {:ok}
+  @spec execute_git(Webhook.id(), Webhook.token(), boolean) :: Api.error() | :ok
   def execute_git(webhook_id, webhook_token, wait \\ false) do
     Api.request(:post, Constants.webhook_git(webhook_id, webhook_token), wait: wait)
   end
@@ -107,7 +107,7 @@ defmodule Nostrum.Api.Webhook do
     - `webhook_id` - Id of the webhook to execute.
     - `webhook_token` - Token of the webhook to execute.
   """
-  @spec execute_slack(Webhook.id(), Webhook.token(), boolean) :: Api.error() | {:ok}
+  @spec execute_slack(Webhook.id(), Webhook.token(), boolean) :: Api.error() | :ok
   def execute_slack(webhook_id, webhook_token, wait \\ false) do
     Api.request(:post, Constants.webhook_slack(webhook_id, webhook_token), wait: wait)
   end
@@ -180,7 +180,7 @@ defmodule Nostrum.Api.Webhook do
           matrix,
           boolean
         ) ::
-          Api.error() | {:ok} | {:ok, Message.t()}
+          Api.error() | :ok | {:ok, Message.t()}
   def execute(webhook_id, webhook_token, args, wait \\ false)
 
   def execute(webhook_id, webhook_token, args, wait) do

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -25,11 +25,11 @@ defmodule Nostrum.Struct.Emoji do
   ```elixir
   emoji = %Nostrum.Struct.Emoji{id: 436885297037312001, name: "tealixir"}
   Nostrum.Api.Message.react(381889573426429952, 436247584349356032, Nostrum.Struct.Emoji.api_name(emoji))
-  {:ok}
+  :ok
 
   emoji = %Nostrum.Struct.Emoji{id: 436189601820966923, name: "elixir"}
   Nostrum.Api.Message.react(381889573426429952, 436247584349356032, emoji)
-  {:ok}
+  :ok
   ```
 
   See `t:Nostrum.Struct.Emoji.api_name/0` for more information.

--- a/test/nostrum/api/ratelimit_test.exs
+++ b/test/nostrum/api/ratelimit_test.exs
@@ -115,7 +115,7 @@ defmodule Nostrum.Api.RatelimitTest do
           with {:ok, _} <- Nostrum.Api.Guild.get(@test_guild),
                {:ok, _} <- Nostrum.Api.Message.create(@test_channel, "#{x}"),
                {:ok, _} <- Nostrum.Api.Message.get(@test_channel, @test_message),
-               {:ok} <- Nostrum.Api.Channel.start_typing(@test_channel) do
+               :ok <- Nostrum.Api.Channel.start_typing(@test_channel) do
             :ok
           else
             _ ->

--- a/test/nostrum/api/ratelimiter_test.exs
+++ b/test/nostrum/api/ratelimiter_test.exs
@@ -70,7 +70,7 @@ defmodule Nostrum.Api.RatelimiterTest do
     test "work with 204 responses", %{ratelimiter: ratelimiter} do
       request = build_request("empty_body")
       reply = Ratelimiter.queue(ratelimiter, request, @request_timeout)
-      assert {:ok} = reply
+      assert :ok = reply
     end
   end
 


### PR DESCRIPTION
Rebase of #615 since it was heavily outdated.


Rationale: Virtually all Erlang/Elixir libraries will use `:ok | {:error, reason}` if the happy path does not have a meaningful return value. We should follow that de-facto standard.