### PR TITLE
Suppress the module undefined warning in cache modules

### DIFF
--- a/lib/nostrum/cache/channel_guild_mapping.ex
+++ b/lib/nostrum/cache/channel_guild_mapping.ex
@@ -32,6 +32,11 @@ defmodule Nostrum.Cache.ChannelGuildMapping do
                       @default_implementation
                     )
 
+  # We shouldn't warn about the configured cache module being undefined, as
+  # users can write their own cache modules and those would always generate
+  # this warning since they'd be compiled after Nostrum.
+  @compile {:no_warn_undefined, @configured_cache}
+
   alias Nostrum.Struct.Channel
   alias Nostrum.Struct.Guild
 

--- a/lib/nostrum/cache/guild_cache.ex
+++ b/lib/nostrum/cache/guild_cache.ex
@@ -48,6 +48,11 @@ defmodule Nostrum.Cache.GuildCache do
 
   @configured_cache Nostrum.Cache.Base.get_cache_module(:guilds, @default_cache_implementation)
 
+  # We shouldn't warn about the configured cache module being undefined, as
+  # users can write their own cache modules and those would always generate
+  # this warning since they'd be compiled after Nostrum.
+  @compile {:no_warn_undefined, @configured_cache}
+
   ## Supervisor callbacks
   # These set up the backing cache.
   @doc false

--- a/lib/nostrum/cache/member_cache.ex
+++ b/lib/nostrum/cache/member_cache.ex
@@ -26,6 +26,11 @@ defmodule Nostrum.Cache.MemberCache do
 
   @configured_cache Nostrum.Cache.Base.get_cache_module(:members, @default_cache_implementation)
 
+  # We shouldn't warn about the configured cache module being undefined, as
+  # users can write their own cache modules and those would always generate
+  # this warning since they'd be compiled after Nostrum.
+  @compile {:no_warn_undefined, @configured_cache}
+
   @doc """
   Retrieve a member from the cache by guild and user ID.
   """

--- a/lib/nostrum/cache/message_cache.ex
+++ b/lib/nostrum/cache/message_cache.ex
@@ -34,6 +34,11 @@ defmodule Nostrum.Cache.MessageCache do
 
   @configured_cache Nostrum.Cache.Base.get_cache_module(:messages, @default_cache_implementation)
 
+  # We shouldn't warn about the configured cache module being undefined, as
+  # users can write their own cache modules and those would always generate
+  # this warning since they'd be compiled after Nostrum.
+  @compile {:no_warn_undefined, @configured_cache}
+
   alias Nostrum.Snowflake
   alias Nostrum.Struct.{Channel, Message, User}
 

--- a/lib/nostrum/cache/presence_cache.ex
+++ b/lib/nostrum/cache/presence_cache.ex
@@ -32,6 +32,11 @@ defmodule Nostrum.Cache.PresenceCache do
 
   @configured_cache Nostrum.Cache.Base.get_cache_module(:presences, @default_cache_implementation)
 
+  # We shouldn't warn about the configured cache module being undefined, as
+  # users can write their own cache modules and those would always generate
+  # this warning since they'd be compiled after Nostrum.
+  @compile {:no_warn_undefined, @configured_cache}
+
   alias Nostrum.Struct.{Guild, User}
   alias Nostrum.Util
   import Nostrum.Snowflake, only: [is_snowflake: 1]

--- a/lib/nostrum/cache/user_cache.ex
+++ b/lib/nostrum/cache/user_cache.ex
@@ -20,6 +20,11 @@ defmodule Nostrum.Cache.UserCache do
 
   @configured_cache Nostrum.Cache.Base.get_cache_module(:users, @default_cache_implementation)
 
+  # We shouldn't warn about the configured cache module being undefined, as
+  # users can write their own cache modules and those would always generate
+  # this warning since they'd be compiled after Nostrum.
+  @compile {:no_warn_undefined, @configured_cache}
+
   ## Behaviour specification
 
   @doc ~s"""


### PR DESCRIPTION
Came across this warning while writing my own cache module that was backed by Ecto.

We should probably suppress it since there's nothing users can do about it in that specific case, as Nostrum needs to compile first and would always emit his warning if the configured cache is defined outside of Nostrum.