### PR TITLE
Fix issue with emojis in `Component.Option`

### DIFF
--- a/lib/nostrum/struct/component/option.ex
+++ b/lib/nostrum/struct/component/option.ex
@@ -3,7 +3,7 @@ defmodule Nostrum.Struct.Component.Option do
   Component Options
   """
   @moduledoc since: "0.5.0"
-  alias Nostrum.Struct.Component
+  alias Nostrum.Struct.{Component, Emoji}
   alias Nostrum.Util
 
   @derive Jason.Encoder

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -39,6 +39,7 @@ defmodule Nostrum.Struct.Emoji do
   alias Nostrum.Struct.Guild.Role
   alias Nostrum.Struct.User
 
+  @derive Jason.Encoder
   defstruct [
     :id,
     :name,


### PR DESCRIPTION
Adding emoji to `Nostrum.Struct.Component.Option` would result in an error:
> ** (UndefinedFunctionError) function Emoji.to_struct/1 is undefined (module Emoji is not available).